### PR TITLE
feat(nwp): land HRRR helpers from feat/hrrr-road-poc-minimal

### DIFF
--- a/brc_tools/download/get_road_forecast.py
+++ b/brc_tools/download/get_road_forecast.py
@@ -1,0 +1,311 @@
+"""Build a minimal hourly HRRR road forecast proof-of-concept."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import math
+import os
+from pathlib import Path
+
+import numpy as np
+
+from brc_tools.download.hrrr_access import (
+    extract_nearest_values,
+    fetch_hourly_datasets,
+    get_latest_hrrr_init,
+)
+from brc_tools.download.hrrr_config import (
+    DEFAULT_HRRR_PRODUCT,
+    DEFAULT_MAX_FXX,
+    DEFAULT_MIN_USABLE_HOURS,
+    ROAD_CORRIDORS,
+    ROAD_FORECAST_QUERY_MAP,
+    ROAD_FORECAST_VARIABLES_META,
+)
+from brc_tools.utils.util_funcs import get_current_datetime
+
+LOG = logging.getLogger(__name__)
+
+
+def derive_road_fields(raw: dict[str, float]) -> dict[str, float | str | None]:
+    """Convert raw HRRR fields into the road forecast schema."""
+    out: dict[str, float | str | None] = {
+        key: None for key in ROAD_FORECAST_VARIABLES_META
+    }
+
+    if _isfinite(raw.get("temp_2m")):
+        out["temp_2m"] = _round(raw["temp_2m"] - 273.15)
+
+    ugrd = raw.get("_ugrd")
+    vgrd = raw.get("_vgrd")
+    if _isfinite(ugrd) and _isfinite(vgrd):
+        out["wind_speed_10m"] = _round(math.hypot(ugrd, vgrd))
+
+    if _isfinite(raw.get("wind_gust")):
+        out["wind_gust"] = _round(raw["wind_gust"])
+
+    if _isfinite(raw.get("visibility")):
+        out["visibility"] = _round(raw["visibility"] / 1000.0)
+
+    if _isfinite(raw.get("precip_1hr")):
+        out["precip_1hr"] = _round(raw["precip_1hr"])
+
+    precip_type = _derive_precip_type(raw)
+    if precip_type is not None:
+        out["precip_type"] = precip_type
+
+    if _isfinite(raw.get("snow_depth")):
+        out["snow_depth"] = _round(raw["snow_depth"] * 1000.0)
+
+    if _isfinite(raw.get("cloud_cover")):
+        out["cloud_cover"] = _round(raw["cloud_cover"])
+
+    if _isfinite(raw.get("rh_2m")):
+        out["rh_2m"] = _round(raw["rh_2m"])
+
+    return out
+
+
+def build_road_payload(
+    *,
+    init_time: dt.datetime,
+    max_fxx: int,
+    forecasts_by_route: dict[str, dict[int, list[dict[str, float | str | None]]]],
+) -> dict[str, object]:
+    """Build a stable JSON payload for the road forecast proof-of-concept."""
+    forecast_hours = list(range(1, max_fxx + 1))
+    valid_times = [
+        (init_time + dt.timedelta(hours=hour)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for hour in forecast_hours
+    ]
+
+    routes_out: dict[str, dict[str, object]] = {}
+    for route_id, corridor in ROAD_CORRIDORS.items():
+        route_forecasts = forecasts_by_route.get(route_id, {})
+        waypoints_out = []
+
+        for waypoint_index, waypoint in enumerate(corridor["waypoints"]):
+            hourly_values = route_forecasts.get(
+                waypoint_index,
+                [derive_road_fields({}) for _ in forecast_hours],
+            )
+            forecast_arrays = {
+                variable: [hour.get(variable) for hour in hourly_values]
+                for variable in ROAD_FORECAST_VARIABLES_META
+            }
+            waypoints_out.append(
+                {
+                    "name": waypoint["name"],
+                    "lat": waypoint["lat"],
+                    "lon": waypoint["lon"],
+                    "elevation_m": waypoint["elevation_m"],
+                    "reference_stid": waypoint["reference_stid"],
+                    "forecasts": forecast_arrays,
+                }
+            )
+
+        routes_out[route_id] = {
+            "name": corridor["name"],
+            "waypoints": waypoints_out,
+        }
+
+    return {
+        "model": "hrrr",
+        "product": DEFAULT_HRRR_PRODUCT,
+        "init_time": init_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": get_current_datetime().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "forecast_hours": forecast_hours,
+        "valid_times": valid_times,
+        "variables": ROAD_FORECAST_VARIABLES_META,
+        "routes": routes_out,
+        "cameras": [],
+    }
+
+
+def build_route_forecasts(
+    *,
+    hour_datasets: dict[int, object],
+    max_fxx: int,
+) -> dict[str, dict[int, list[dict[str, float | str | None]]]]:
+    """Extract derived road forecast fields for each configured waypoint."""
+    query_aliases = list(ROAD_FORECAST_QUERY_MAP)
+    forecasts_by_route: dict[str, dict[int, list[dict[str, float | str | None]]]] = {}
+
+    for route_id, corridor in ROAD_CORRIDORS.items():
+        waypoint_forecasts: dict[int, list[dict[str, float | str | None]]] = {}
+        for waypoint_index, waypoint in enumerate(corridor["waypoints"]):
+            hourly_values = []
+            for hour in range(1, max_fxx + 1):
+                ds = hour_datasets.get(hour)
+                if ds is None:
+                    hourly_values.append(derive_road_fields({}))
+                    continue
+                raw = extract_nearest_values(
+                    ds,
+                    waypoint["lat"],
+                    waypoint["lon"],
+                    aliases=query_aliases,
+                )
+                hourly_values.append(derive_road_fields(raw))
+            waypoint_forecasts[waypoint_index] = hourly_values
+        forecasts_by_route[route_id] = waypoint_forecasts
+
+    return forecasts_by_route
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build an hourly HRRR road forecast proof-of-concept"
+    )
+    parser.add_argument(
+        "--init-time",
+        help="Optional HRRR initialization time in YYYYMMDDHH format",
+    )
+    parser.add_argument(
+        "--product",
+        default=DEFAULT_HRRR_PRODUCT,
+        help=f"HRRR product to use (default: {DEFAULT_HRRR_PRODUCT})",
+    )
+    parser.add_argument(
+        "--max-fxx",
+        type=int,
+        default=DEFAULT_MAX_FXX,
+        help=f"Maximum forecast hour to fetch (default: {DEFAULT_MAX_FXX})",
+    )
+    parser.add_argument(
+        "--min-usable-hours",
+        type=int,
+        default=DEFAULT_MIN_USABLE_HOURS,
+        help=(
+            "Minimum successfully fetched forecast hours required before "
+            "writing output"
+        ),
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=os.path.expanduser("~/gits/brc-tools/data"),
+        help="Directory for output JSON files",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write output locally but never upload it",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload JSON after writing it locally",
+    )
+    parser.add_argument(
+        "--upload-bucket",
+        default="road-forecast",
+        help="Upload bucket name passed to the shared uploader",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    args = parse_args()
+    data_root = Path(args.data_dir).expanduser()
+    data_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        init_time = _parse_or_find_init(args.init_time, product=args.product)
+        hour_datasets = fetch_hourly_datasets(
+            init_time,
+            ROAD_FORECAST_QUERY_MAP,
+            max_fxx=args.max_fxx,
+            product=args.product,
+        )
+        if len(hour_datasets) < args.min_usable_hours:
+            raise RuntimeError(
+                "Only "
+                f"{len(hour_datasets)}/{args.max_fxx} forecast hours available; "
+                f"need at least {args.min_usable_hours}"
+            )
+
+        forecasts_by_route = build_route_forecasts(
+            hour_datasets=hour_datasets,
+            max_fxx=args.max_fxx,
+        )
+        payload = build_road_payload(
+            init_time=init_time,
+            max_fxx=args.max_fxx,
+            forecasts_by_route=forecasts_by_route,
+        )
+    except Exception as exc:
+        LOG.error("Road forecast build failed: %s", exc)
+        return 1
+
+    output_path = _build_output_path(data_root, prefix="road_forecast")
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, allow_nan=False)
+    LOG.info("Wrote road forecast JSON to %s", output_path)
+
+    if args.upload and not args.dry_run:
+        try:
+            from brc_tools.download.push_data import load_config, send_json_to_server
+
+            api_key, server_url = load_config()
+            send_json_to_server(server_url, output_path, args.upload_bucket, api_key)
+        except Exception as exc:
+            LOG.error("Road forecast upload failed: %s", exc)
+            return 1
+    else:
+        LOG.info("Upload skipped")
+
+    return 0
+
+
+def _parse_or_find_init(init_time: str | None, *, product: str) -> dt.datetime:
+    if init_time:
+        return dt.datetime.strptime(init_time, "%Y%m%d%H")
+    return get_latest_hrrr_init(product=product)
+
+
+def _derive_precip_type(raw: dict[str, float]) -> str | None:
+    flag_values = {
+        "snow": raw.get("_csnow"),
+        "rain": raw.get("_crain"),
+        "freezing_rain": raw.get("_cfrzr"),
+        "ice_pellets": raw.get("_cicep"),
+    }
+
+    available = {
+        name: value for name, value in flag_values.items() if _isfinite(value)
+    }
+    if not available:
+        return None
+
+    active = [name for name, value in available.items() if value >= 0.5]
+    if len(active) > 1:
+        return "mixed"
+    if len(active) == 1:
+        return active[0]
+    return "none"
+
+
+def _isfinite(value: float | None) -> bool:
+    return value is not None and bool(np.isfinite(value))
+
+
+def _round(value: float) -> float | None:
+    return round(float(value), 1) if np.isfinite(value) else None
+
+
+def _build_output_path(data_root: Path, *, prefix: str) -> str:
+    timestamp = get_current_datetime().strftime("%Y%m%d_%H%M")
+    return str(data_root / f"{prefix}_{timestamp}Z.json")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brc_tools/download/hrrr_access.py
+++ b/brc_tools/download/hrrr_access.py
@@ -1,0 +1,323 @@
+"""Shared HRRR access helpers for the minimal proof-of-concept."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+import xarray as xr
+from herbie import Herbie
+
+LOG = logging.getLogger(__name__)
+
+_GRIB_MAGIC = b"GRIB"
+_MIN_GRIB_SIZE = 1000
+_DEFAULT_CACHE_DIR = (
+    Path(os.environ.get("BRC_TOOLS_HRRR_CACHE", ""))
+    if os.environ.get("BRC_TOOLS_HRRR_CACHE")
+    else Path(__file__).resolve().parents[2] / "data" / "herbie_cache" / "hrrr"
+)
+
+
+def ensure_cache_dir(cache_dir: str | os.PathLike[str] | None = None) -> Path:
+    """Create and return the Herbie cache directory."""
+    target = Path(cache_dir).expanduser() if cache_dir else _DEFAULT_CACHE_DIR
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def setup_herbie(
+    init_time: dt.datetime,
+    fxx: int,
+    *,
+    product: str = "sfc",
+    cache_dir: str | os.PathLike[str] | None = None,
+) -> Herbie:
+    """Create a Herbie instance for one HRRR cycle and lead time."""
+    return Herbie(
+        init_time,
+        model="hrrr",
+        product=product,
+        fxx=int(fxx),
+        save_dir=str(ensure_cache_dir(cache_dir)),
+        verbose=False,
+    )
+
+
+def get_latest_hrrr_init(
+    *,
+    now: dt.datetime | None = None,
+    product: str = "sfc",
+    availability_fxx: int = 1,
+    start_lag_hours: int = 2,
+    lookback_hours: int = 6,
+    cache_dir: str | os.PathLike[str] | None = None,
+) -> dt.datetime:
+    """Return the most recent HRRR init we can confidently reference."""
+    anchor = now or dt.datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    start_hour = anchor - dt.timedelta(hours=start_lag_hours)
+
+    for hours_back in range(lookback_hours):
+        candidate = start_hour - dt.timedelta(hours=hours_back)
+        try:
+            herbie_obj = setup_herbie(
+                candidate,
+                availability_fxx,
+                product=product,
+                cache_dir=cache_dir,
+            )
+        except Exception as exc:  # pragma: no cover - Herbie setup depends on env
+            LOG.debug("HRRR candidate setup failed for %s: %s", candidate, exc)
+            continue
+
+        if _herbie_candidate_available(herbie_obj):
+            LOG.info("Selected HRRR init %s", candidate.strftime("%Y-%m-%d %HZ"))
+            return candidate
+
+    raise RuntimeError(
+        f"No HRRR {product!r} run found in the last {lookback_hours} hours"
+    )
+
+
+def _herbie_candidate_available(herbie_obj: Herbie) -> bool:
+    """Best-effort availability check without downloading a full dataset."""
+    for attr_name in ("grib", "idx", "remote_grib", "remote_idx"):
+        if getattr(herbie_obj, attr_name, None):
+            return True
+    return False
+
+
+def _validate_cached_grib(grib_path: str | os.PathLike[str] | None) -> bool:
+    """Return True when a cached GRIB looks usable or does not exist."""
+    if grib_path is None:
+        return True
+
+    path = Path(grib_path)
+    if not path.exists():
+        return True
+
+    try:
+        stat = path.stat()
+        if stat.st_size < _MIN_GRIB_SIZE:
+            LOG.warning(
+                "HRRR cache invalid: %s too small (%d bytes)",
+                path.name,
+                stat.st_size,
+            )
+            return False
+        with path.open("rb") as handle:
+            if handle.read(4) != _GRIB_MAGIC:
+                LOG.warning("HRRR cache invalid: %s missing GRIB header", path.name)
+                return False
+    except OSError as exc:
+        LOG.warning("HRRR cache validation failed for %s: %s", path, exc)
+        return False
+    return True
+
+
+def _purge_cached_files(herbie_obj: Herbie) -> None:
+    """Delete any cached index/GRIB files for a Herbie object."""
+    for attr_name in ("idx", "grib"):
+        path = getattr(herbie_obj, attr_name, None)
+        if not isinstance(path, (str, os.PathLike)):
+            continue
+        try:
+            Path(path).unlink(missing_ok=True)
+        except OSError:
+            continue
+
+
+def fetch_hour_dataset(
+    init_time: dt.datetime,
+    fxx: int,
+    query_map: Mapping[str, str],
+    *,
+    product: str = "sfc",
+    cache_dir: str | os.PathLike[str] | None = None,
+    remove_grib: bool = True,
+    retries: int = 2,
+) -> xr.Dataset:
+    """Fetch one HRRR forecast hour and rename data vars to internal aliases."""
+    herbie_obj = setup_herbie(
+        init_time,
+        fxx,
+        product=product,
+        cache_dir=cache_dir,
+    )
+
+    if not _validate_cached_grib(getattr(herbie_obj, "grib", None)):
+        _purge_cached_files(herbie_obj)
+
+    datasets: list[xr.Dataset] = []
+    for alias, search_string in query_map.items():
+        last_exc: Exception | None = None
+        for attempt in range(1, retries + 1):
+            try:
+                raw_ds = herbie_obj.xarray(search_string, remove_grib=remove_grib)
+                renamed = _rename_data_var(raw_ds, alias)
+                normalized = _normalize_hour_dataset(renamed, init_time, fxx)
+                datasets.append(normalized[[alias]])
+                break
+            except Exception as exc:  # pragma: no cover - depends on Herbie/network state
+                last_exc = exc
+                LOG.warning(
+                    "HRRR load failed alias=%s f%03d attempt=%d/%d: %s",
+                    alias,
+                    fxx,
+                    attempt,
+                    retries,
+                    exc,
+                )
+                if attempt < retries:
+                    _purge_cached_files(herbie_obj)
+        else:
+            LOG.warning("Skipping alias=%s f%03d after %d attempts", alias, fxx, retries)
+            if last_exc is not None:
+                LOG.debug("Last HRRR exception for %s f%03d: %r", alias, fxx, last_exc)
+
+    if not datasets:
+        raise RuntimeError(f"No HRRR variables loaded for f{int(fxx):03d}")
+
+    merged = xr.merge(datasets, compat="override", combine_attrs="drop")
+    return _normalize_longitudes(merged)
+
+
+def fetch_hourly_datasets(
+    init_time: dt.datetime,
+    query_map: Mapping[str, str],
+    *,
+    max_fxx: int,
+    product: str = "sfc",
+    cache_dir: str | os.PathLike[str] | None = None,
+    remove_grib: bool = True,
+) -> dict[int, xr.Dataset]:
+    """Fetch multiple HRRR forecast hours, skipping hours that fail."""
+    datasets: dict[int, xr.Dataset] = {}
+    for fxx in range(1, max_fxx + 1):
+        try:
+            datasets[fxx] = fetch_hour_dataset(
+                init_time,
+                fxx,
+                query_map,
+                product=product,
+                cache_dir=cache_dir,
+                remove_grib=remove_grib,
+            )
+            LOG.info("Fetched HRRR hour f%03d with %d fields", fxx, len(datasets[fxx].data_vars))
+        except Exception as exc:  # pragma: no cover - depends on Herbie/network state
+            LOG.warning("Skipping HRRR hour f%03d: %s", fxx, exc)
+    return datasets
+
+
+def nearest_grid_index(ds: xr.Dataset, lat: float, lon: float) -> tuple[int, int]:
+    """Return nearest `(y_idx, x_idx)` on the HRRR grid."""
+    lats = np.asarray(ds.latitude.values)
+    lons = np.asarray(ds.longitude.values)
+    if np.nanmax(lons) > 180.0:
+        lons = ((lons + 180.0) % 360.0) - 180.0
+
+    dist = (lats - lat) ** 2 + (lons - lon) ** 2
+    y_idx, x_idx = np.unravel_index(np.nanargmin(dist), dist.shape)
+    return int(y_idx), int(x_idx)
+
+
+def extract_point_values(
+    ds: xr.Dataset,
+    *,
+    y_idx: int,
+    x_idx: int,
+    aliases: list[str] | None = None,
+) -> dict[str, float]:
+    """Extract scalar values at one grid point for the requested aliases."""
+    values: dict[str, float] = {}
+    wanted = aliases or list(ds.data_vars)
+
+    for alias in wanted:
+        if alias not in ds.data_vars:
+            continue
+        arr = ds[alias]
+        indexers = {}
+        if "time" in arr.dims:
+            indexers["time"] = 0
+        if "y" in arr.dims:
+            indexers["y"] = y_idx
+        if "x" in arr.dims:
+            indexers["x"] = x_idx
+
+        point = arr.isel(**indexers).squeeze(drop=True)
+        if point.size != 1:
+            continue
+
+        value = float(np.asarray(point.values).item())
+        if np.isfinite(value):
+            values[alias] = value
+
+    return values
+
+
+def extract_nearest_values(
+    ds: xr.Dataset,
+    lat: float,
+    lon: float,
+    *,
+    aliases: list[str] | None = None,
+) -> dict[str, float]:
+    """Extract requested values at the nearest HRRR grid point."""
+    y_idx, x_idx = nearest_grid_index(ds, lat, lon)
+    return extract_point_values(ds, y_idx=y_idx, x_idx=x_idx, aliases=aliases)
+
+
+def _rename_data_var(ds: xr.Dataset, alias: str) -> xr.Dataset:
+    """Rename the first data var in a dataset to a stable alias."""
+    if alias in ds.data_vars:
+        return ds
+
+    data_vars = list(ds.data_vars)
+    if not data_vars:
+        raise ValueError(f"No data variables found for alias {alias!r}")
+    return ds.rename({data_vars[0]: alias})
+
+
+def _normalize_hour_dataset(
+    ds: xr.Dataset,
+    init_time: dt.datetime,
+    fxx: int,
+) -> xr.Dataset:
+    """Normalize coordinates so each fetch is a single valid-time slice."""
+    keep_coords = {"time", "latitude", "longitude", "x", "y"}
+    drop_names = [name for name in ds.coords if name not in keep_coords]
+    if drop_names:
+        ds = ds.drop_vars(drop_names, errors="ignore")
+
+    if "time" in ds.dims:
+        ds = ds.isel(time=0, drop=True)
+    ds = ds.expand_dims("time")
+
+    valid_time = np.array(
+        [np.datetime64(init_time + dt.timedelta(hours=int(fxx)))],
+        dtype="datetime64[ns]",
+    )
+    ds = ds.assign_coords(time=("time", valid_time))
+    return _normalize_longitudes(ds)
+
+
+def _normalize_longitudes(ds: xr.Dataset) -> xr.Dataset:
+    """Shift 0-360 longitude coordinates into -180..180 when needed."""
+    if "longitude" not in ds.coords:
+        return ds
+
+    lons = ds.longitude
+    try:
+        lon_max = float(np.nanmax(np.asarray(lons.values)))
+    except (TypeError, ValueError):
+        return ds
+
+    if lon_max <= 180.0:
+        return ds
+
+    shifted = ((lons + 180.0) % 360.0) - 180.0
+    return ds.assign_coords(longitude=shifted)

--- a/brc_tools/download/hrrr_config.py
+++ b/brc_tools/download/hrrr_config.py
@@ -1,0 +1,175 @@
+"""Shared configuration for the minimal HRRR proof-of-concept."""
+
+UINTA_BASIN_SW = (39.4, -110.9)
+UINTA_BASIN_NE = (41.1, -108.5)
+
+DEFAULT_HRRR_PRODUCT = "sfc"
+DEFAULT_MAX_FXX = 12
+DEFAULT_MIN_USABLE_HOURS = 6
+
+# Canonical HRRR surface fields for the road proof-of-concept.
+# Keys are internal aliases; values are Herbie search strings.
+ROAD_FORECAST_QUERY_MAP = {
+    "temp_2m": "TMP:2 m",
+    "_ugrd": "UGRD:10 m",
+    "_vgrd": "VGRD:10 m",
+    "wind_gust": "GUST:surface",
+    "visibility": "VIS:surface",
+    "precip_1hr": "APCP:surface",
+    "_crain": "CRAIN:surface",
+    "_csnow": "CSNOW:surface",
+    "_cfrzr": "CFRZR:surface",
+    "_cicep": "CICEP:surface",
+    "snow_depth": "SNOD:surface",
+    "cloud_cover": "TCDC:entire",
+    "rh_2m": "RH:2 m",
+}
+
+ROAD_FORECAST_VARIABLES_META = {
+    "temp_2m": {"units": "Celsius", "display": "Temperature"},
+    "wind_speed_10m": {"units": "m/s", "display": "Wind Speed"},
+    "wind_gust": {"units": "m/s", "display": "Wind Gust"},
+    "visibility": {"units": "km", "display": "Visibility"},
+    "precip_1hr": {"units": "mm", "display": "1-hr Precip"},
+    "precip_type": {"units": "category", "display": "Precip Type"},
+    "snow_depth": {"units": "mm", "display": "Snow Depth"},
+    "cloud_cover": {"units": "%", "display": "Cloud Cover"},
+    "rh_2m": {"units": "%", "display": "Relative Humidity"},
+}
+
+ROAD_CORRIDORS = {
+    "us40": {
+        "name": "US-40 Corridor",
+        "waypoints": [
+            {
+                "name": "Daniels Summit",
+                "lat": 40.30,
+                "lon": -111.26,
+                "elevation_m": 2438,
+                "reference_stid": "UTDAN",
+            },
+            {
+                "name": "Strawberry",
+                "lat": 40.17,
+                "lon": -111.14,
+                "elevation_m": 2316,
+                "reference_stid": None,
+            },
+            {
+                "name": "Fruitland",
+                "lat": 40.21,
+                "lon": -110.85,
+                "elevation_m": 2042,
+                "reference_stid": "UTFRT",
+            },
+            {
+                "name": "Starvation",
+                "lat": 40.19,
+                "lon": -110.45,
+                "elevation_m": 1783,
+                "reference_stid": "UTSTV",
+            },
+            {
+                "name": "Duchesne",
+                "lat": 40.16,
+                "lon": -110.40,
+                "elevation_m": 1752,
+                "reference_stid": "KU69",
+            },
+            {
+                "name": "Myton",
+                "lat": 40.20,
+                "lon": -110.06,
+                "elevation_m": 1585,
+                "reference_stid": "UTMYT",
+            },
+            {
+                "name": "Roosevelt",
+                "lat": 40.30,
+                "lon": -109.99,
+                "elevation_m": 1588,
+                "reference_stid": "K74V",
+            },
+            {
+                "name": "Vernal (Asphalt Ridge)",
+                "lat": 40.48,
+                "lon": -109.56,
+                "elevation_m": 1609,
+                "reference_stid": "UTASH",
+            },
+            {
+                "name": "Dinosaur",
+                "lat": 40.24,
+                "lon": -109.01,
+                "elevation_m": 1829,
+                "reference_stid": "DNOC2",
+            },
+        ],
+    },
+    "us191": {
+        "name": "US-191 North-South",
+        "waypoints": [
+            {
+                "name": "Vernal",
+                "lat": 40.46,
+                "lon": -109.53,
+                "elevation_m": 1609,
+                "reference_stid": "KVEL",
+            },
+            {
+                "name": "Maeser",
+                "lat": 40.50,
+                "lon": -109.58,
+                "elevation_m": 1600,
+                "reference_stid": None,
+            },
+            {
+                "name": "Ouray",
+                "lat": 40.09,
+                "lon": -109.68,
+                "elevation_m": 1463,
+                "reference_stid": "A1622",
+            },
+            {
+                "name": "Indian Canyon Summit",
+                "lat": 39.90,
+                "lon": -110.40,
+                "elevation_m": 2772,
+                "reference_stid": "UTICS",
+            },
+        ],
+    },
+    "basin_roads": {
+        "name": "Local Basin Roads",
+        "waypoints": [
+            {
+                "name": "Roosevelt",
+                "lat": 40.30,
+                "lon": -109.99,
+                "elevation_m": 1588,
+                "reference_stid": "K74V",
+            },
+            {
+                "name": "Altamont",
+                "lat": 40.36,
+                "lon": -110.29,
+                "elevation_m": 1612,
+                "reference_stid": None,
+            },
+            {
+                "name": "Bluebell",
+                "lat": 40.37,
+                "lon": -110.17,
+                "elevation_m": 1612,
+                "reference_stid": "UCC34",
+            },
+            {
+                "name": "Starvation Dam",
+                "lat": 40.19,
+                "lon": -110.45,
+                "elevation_m": 1783,
+                "reference_stid": "UTSTV",
+            },
+        ],
+    },
+}

--- a/docs/nwp/MERGE-PLAN.md
+++ b/docs/nwp/MERGE-PLAN.md
@@ -1,0 +1,548 @@
+# HRRR Plan v2: implementation-ready rewrite
+
+Status: rewritten from current repo state on 2026-03-17 UTC
+
+Purpose: build a reliable HRRR waypoint forecast pipeline for BasinWx in `brc-tools`, using `clyfar` as the example of an operational scheduled system, but not copying its GEFS-specific complexity blindly.
+
+This rewrite is intentionally opinionated. Anything marked "Choice" is open for change. Anything marked "Recommended" is the path I would take if I were implementing this now in Codex CLI.
+
+## Active Scope
+
+Current implementation target:
+- add the smallest safe hourly HRRR road proof-of-concept
+- keep upload off by default
+- keep 15-minute output out of scope for the first working version
+- keep aviation out of scope for the first working version
+- reuse HRRR road branch ideas selectively, not by broad merge
+
+---
+
+## What changed from the old draft
+
+The old draft had the right general direction, but the order was wrong for implementation.
+
+Main changes in this rewrite:
+- Freeze the external contract first: endpoint, payload shape, waypoints, variables, horizon.
+- Build single-run HRRR first.
+- Add 15-minute support only after proving variable/product availability.
+- Add lagged ensemble only after single-run output is stable.
+- Treat `clyfar` as the operations model for retries, smoke runs, caching, and upload ownership.
+- Do **not** assume the referenced PRs or files are present in this checkout.
+
+---
+
+## Repo facts this plan is based on
+
+### In `brc-tools` today
+- The only real production-style pipeline here is observations:
+  - `brc_tools/download/get_map_obs.py`
+  - `brc_tools/download/push_data.py`
+- The model pipeline in `docs/PIPELINE-ARCHITECTURE.md` is still proposed structure, not finished implementation.
+- The current shared uploader posts to:
+  - `/api/upload/{file_data}`
+- Current upload helper is shared across repos:
+  - `clyfar/export/to_basinwx.py` imports `brc_tools.download.push_data.send_json_to_server`
+- The current checkout does **not** contain:
+  - `get_road_forecast.py`
+  - a waypoint module
+  - an HRRR model schema
+  - a `tests/` tree
+
+### In `clyfar` today
+- `run_gefs_clyfar.py` has retryable exit codes and testing mode.
+- `nwp/gefsdata.py` has useful Herbie reliability patterns:
+  - cache dir
+  - cache validation
+  - lock files
+  - fallback handling
+  - nearest-point extraction
+  - Uinta Basin crop
+- `nwp/download_funcs.py` has useful slice-by-slice loading and coordinate normalization.
+- `scripts/submit_clyfar.sh` is the best local example of an operational wrapper:
+  - wrapper owns init-time selection
+  - wrapper owns retry policy
+  - wrapper owns upload policy
+  - wrapper can disable internal export to avoid duplicate uploads
+- `scripts/run_smoke.sh` is the best local example of a minimal smoke wrapper.
+
+### Known contradictions already visible in repo
+- Docs mention `/api/data/upload/model-data`, but code uses `/api/upload/{file_data}`.
+- `push_data.py` expects a 32-character API key, while some docs describe 64 characters.
+- The old plan assumes branch and PR state that is not present in this checkout.
+
+---
+
+## Hard truths we should accept up front
+
+1. The first blocker is not HRRR math.
+It is the external contract: what JSON shape BasinWx expects for this product.
+
+2. The second blocker is not scheduling.
+It is whether HRRR `subh` really provides the variables and horizon we want.
+
+3. The old "merge PRs first" sequence is not safe as a default.
+I cannot see those PR contents here, and some of the files named in the old plan are absent.
+
+4. `clyfar` is useful as an operations reference, not as a model-specific template.
+GEFS ensemble logic and HRRR lagged-run logic are different problems.
+
+---
+
+## Decisions that must be made early
+
+These are the choices that unblock implementation. Recommended defaults are included.
+
+### Choice 1: upload contract
+- Question: what upload route and `file_data` token should HRRR use?
+- Current code reality:
+  - `push_data.py` posts to `/api/upload/{file_data}`
+  - `clyfar` currently uploads forecast JSONs with `file_data="forecasts"`
+  - `ubair-website` can already accept arbitrary `dataType` values and store them in matching subdirectories, even if page-specific retrieval code has not been written yet
+- Recommended:
+  - keep the current uploader unchanged for v1
+  - if road and aviation stay separate products, prefer separate bucket names such as `road-forecast` and `aviation-forecast`
+  - if we want the least website work at first, use `forecasts` with strict filename prefixes and let each page filter its own files
+
+### Choice 2: v1 output scope
+- Question: do we need cropped gridded data, or only waypoint forecast JSON?
+- Recommended:
+  - waypoint JSON only for v1
+- Why:
+  - the old plan says "compact waypoint JSON"
+  - waypoint output is much easier to validate and upload
+  - gridded export can be added later without changing the fetch layer much
+
+### Choice 3: v1 cadence
+- Question: do we require full 15-minute output in the first working version?
+- Recommended:
+  - No.
+  - Build hourly single-run HRRR first from a proven product.
+  - Add 15-minute support only after availability is explicitly probed.
+- Why:
+  - this is the fastest honest path to a working model pipeline
+  - it reduces failure modes while schema and upload contract are still moving
+
+### Choice 4: missing `subh` behavior
+- Question: what should happen when 15-minute slices are missing or partial?
+- Recommended:
+  - never interpolate silently in v1
+  - emit explicit missing values and metadata
+  - keep single-run hourly output available as fallback product during development
+
+### Choice 5: waypoint extraction method
+- Question: nearest point or bilinear interpolation?
+- Recommended:
+  - nearest point first
+- Why:
+  - `clyfar` already uses nearest-point extraction
+  - it is simple, reproducible, and easier to debug
+  - bilinear can be added after baseline verification
+
+### Choice 6: lagged-ensemble alignment
+- Question: when some runs are missing for a valid time, do we fail or renormalize?
+- Recommended:
+  - renormalize weights over available runs at each valid time
+  - record which runs were actually used
+
+### Choice 7: operational path
+- Question: cron on login node or wrapper-driven scheduled run?
+- Recommended:
+  - development: local smoke wrapper
+  - production: submission wrapper, following the `clyfar` pattern
+
+### Decisions confirmed after review
+- Confirmed:
+  - v1 should be hourly first
+  - 15-minute output remains an end goal, but not a day-one requirement
+  - road and aviation should be separate products, not one shared payload
+- Implication:
+  - the repo should not start with one generic "all transport forecasts" JSON
+  - it should likely produce separate road and aviation exporters, even if they share the same HRRR access layer
+
+---
+
+## Recommended development path
+
+### Path A: recommended
+Build in this order:
+1. Freeze contract
+2. Single-run hourly HRRR
+3. Waypoint JSON
+4. 15-minute support
+5. Lagged ensemble
+6. Upload
+7. Smoke run
+8. Production wrapper
+
+Why this is recommended:
+- smallest number of moving parts at each step
+- easiest to test
+- easiest to debug when Herbie or upload behavior changes
+
+### Path B: aggressive
+Try to build 15-minute lagged ensemble from day one.
+
+Why I do **not** recommend it:
+- too many simultaneous unknowns
+- harder to know whether failures are due to schema, Herbie product search, time alignment, or weighting logic
+
+### Path C: PR-first
+Stop and merge PRs `#8`, `#7`, `#9` before any new code.
+
+Why I do **not** recommend it as the default:
+- I cannot verify those branches from this checkout
+- the files named in the old plan are not present here
+- merge order only matters after we know what those PRs actually contain
+
+### PR review result
+- The remote branches now visible in git are useful as reference:
+  - `origin/fix/synopticpy-requirement-name`
+  - `origin/feat/hrrr-road-forecast-core`
+  - `origin/chore/hrrr-road-ops-docs`
+  - `origin/recovery/brc-tools-hrrr-direct-main-2026-03-02`
+- Recommended:
+  - treat the road core branch as a source of extraction logic and route/waypoint ideas
+  - treat the ops/docs branch as a source of road-product assumptions and shell-wrapper ideas
+  - do **not** merge the recovery branch wholesale
+  - do **not** assume the road spec is integrated with `ubair-website` yet
+
+---
+
+## Phase 0: freeze the contract
+
+Goal: decide what the product is before writing loader logic.
+
+### Deliverables
+- one sample JSON file, even if hand-written
+- one short schema note
+- one agreed waypoint list
+- one agreed variable list
+- one agreed horizon
+
+### Microtasks
+- [ ] Decide the upload `file_data` token.
+- [ ] Decide the top-level payload shape.
+- [ ] Decide whether v1 is road-only, aviation-only, or both.
+- [ ] Decide the waypoint list and stable waypoint IDs.
+- [ ] Decide the v1 variables and output units.
+- [ ] Decide the forecast horizon.
+- [ ] Decide whether v1 is hourly-only first, or must expose 15-minute slots immediately.
+- [ ] Decide what "missing subhourly" looks like in JSON.
+
+### Recommended payload style
+- Use a nested forecast payload, not observation-style row records.
+- Reason:
+  - row records will get large quickly for many times x waypoints x variables
+  - `clyfar` already uses nested JSON with metadata plus arrays
+
+### Recommended v1 JSON shape
+- `metadata`
+- `forecast_times`
+- `waypoints`
+- `waypoints[waypoint_id].location`
+- `waypoints[waypoint_id].variables[var_name]`
+
+### Caveat
+- Do not let phase 1 start until this exists as an example file in the repo.
+
+---
+
+## Phase 1: build a reliable HRRR access layer
+
+Goal: create one small loader module that can fetch a single HRRR run reliably.
+
+### What to borrow from `clyfar`
+- cache directory pattern
+- basic cache validation
+- lock file pattern if concurrent downloads are possible
+- slice-by-slice logging
+- coordinate normalization
+- Uinta Basin crop constants
+- nearest-point extraction helper
+
+### What not to borrow blindly
+- GEFS member logic
+- heavy multi-product exporter design
+- large Slurm assumptions
+
+### Proposed files
+- `brc_tools/download/hrrr_access.py`
+- `brc_tools/download/hrrr_config.py`
+
+### Microtasks
+- [ ] Add a small `setup_herbie` helper for HRRR.
+- [ ] Add cache directory handling with an env override.
+- [ ] Add minimal cache validation for bad/truncated GRIBs.
+- [ ] Add one function to fetch a single variable for one `init_dt`, `fxx`, and product.
+- [ ] Add one function to normalize coordinates and valid time.
+- [ ] Add one function to crop to the Uinta Basin box.
+- [ ] Add one function to extract nearest values for waypoint lat/lon pairs.
+- [ ] Log product, query, init time, lead time, and any failures explicitly.
+
+### Explicit probe task
+- [ ] Write a small availability probe for each target variable across:
+  - `sfc`
+  - `subh`
+- [ ] Save probe results to a simple markdown or JSON artifact.
+
+### Caveat
+- We should not hard-code a "strict 15-minute axis" until the probe confirms what is actually available.
+
+### Gotchas
+- HRRR may expose coordinates differently than GEFS.
+- Some searches may work in one product and fail in another.
+- `subh` may exist for some variables and not others.
+
+---
+
+## Phase 2: single-run waypoint MVP
+
+Goal: produce one clean, local-only HRRR forecast file from one run.
+
+This is the first "real" target, not the lagged ensemble.
+
+### Proposed files
+- `brc_tools/download/hrrr_waypoints.py`
+- `brc_tools/download/hrrr_export.py`
+- `brc_tools/download/get_hrrr_waypoints.py`
+
+### Microtasks
+- [ ] Define the canonical waypoint list in code.
+- [ ] Define the canonical variable map in code.
+- [ ] Build one function that creates the valid-time axis.
+- [ ] Build one function that assembles a per-waypoint forecast structure.
+- [ ] Build one serializer for the agreed JSON shape.
+- [ ] Save one local JSON file without uploading.
+- [ ] Compare the file size and readability with expectations.
+
+### Recommended v1 rule
+- Hourly first.
+- Keep 15-minute logic behind a separate feature flag until proven.
+
+### Exit criteria
+- One command produces one JSON file for one HRRR run.
+- The file includes metadata, times, waypoints, variables, and units.
+- Missing values are explicit.
+
+### Caveat
+- If aviation and road products need different waypoint sets or variables, split them early.
+
+---
+
+## Phase 3: add 15-minute support
+
+Goal: extend the single-run pipeline to support subhourly data honestly.
+
+### Microtasks
+- [ ] Decide whether the time axis is:
+  - one global 15-minute axis, or
+  - per-variable cadence
+- [ ] Implement `subh` fetches only for variables proven by the probe.
+- [ ] Align `subh` slices to valid times explicitly.
+- [ ] Mark missing intervals explicitly in output metadata.
+- [ ] Keep hourly `sfc` behavior available for comparison during development.
+
+### Recommended rule
+- If a variable does not have stable `subh` coverage, do not fake it.
+- Keep that variable hourly until we intentionally change the contract.
+
+### Gotchas
+- The frontend may assume all variables share one common time axis.
+- Mixed hourly and 15-minute variables make the payload more complex.
+
+### Point of choice
+- If you want a very simple frontend contract, require all v1 variables to share the same 15-minute axis.
+- If you want faster backend progress, allow mixed cadence and describe it in metadata.
+
+---
+
+## Phase 4: add the 5-run lagged ensemble
+
+Goal: compute lagged-run statistics on top of the working single-run product.
+
+### Recommended v1 math
+- runs: latest 5 available runs
+- raw weight: `exp(-lambda * run_age_index)`
+- default `lambda = ln(2)`
+- normalize weights over available runs at each valid time
+
+### Microtasks
+- [ ] Build a run selector for `R0..R4`.
+- [ ] Build per-run single-run payload generation first.
+- [ ] Align runs by valid time.
+- [ ] Renormalize weights where some runs are missing.
+- [ ] Compute weighted mean.
+- [ ] Compute weighted spread.
+- [ ] Compute min/max envelope.
+- [ ] Record run IDs and actual weights used per valid time.
+
+### Recommended implementation rule
+- Keep single-run output and lagged-ensemble output separable.
+- Do not bury single-run debugging inside ensemble-only code.
+
+### Caveat
+- Lagged-run weighting is easy.
+- Time alignment and missing-run handling are the real risks.
+
+### Gotchas
+- Some valid times may only have 2 or 3 usable runs.
+- `subh` availability may differ by run age.
+- Cycle rollover logic can produce confusing "latest run" bugs if not logged clearly.
+
+---
+
+## Phase 5: export and upload
+
+Goal: push the working HRRR JSON without breaking the shared upload path.
+
+### Recommended rule
+- Keep `send_json_to_server()` unchanged at first.
+- Treat upload hardening as a separate task if needed.
+
+### Proposed files
+- `brc_tools/download/hrrr_push.py` or reuse `hrrr_export.py`
+
+### Microtasks
+- [ ] Save forecast JSON locally first.
+- [ ] Add `--upload` and `--dry-run` flags to the CLI.
+- [ ] Use the agreed `file_data` token.
+- [ ] Confirm BasinWx accepts one smoke payload.
+- [ ] Only then enable upload by default in wrapper scripts.
+
+### Caveats
+- `send_json_to_server()` currently prints status and does not return a strong success/failure contract.
+- Any change to upload endpoint behavior may affect `clyfar`, because `clyfar` imports the same helper.
+
+### Gotcha
+- Do not "fix" the uploader casually in `brc-tools` without checking `clyfar`.
+
+---
+
+## Phase 6: tests and validation
+
+Goal: add the minimum test surface this repo currently lacks.
+
+### Fact
+- There is no `tests/` tree in this checkout.
+
+### Proposed files
+- `tests/test_hrrr_weights.py`
+- `tests/test_hrrr_payload.py`
+- `tests/test_hrrr_time_axis.py`
+
+### Microtasks
+- [ ] Add a weight-normalization test.
+- [ ] Add a missing-run renormalization test.
+- [ ] Add a JSON payload shape test.
+- [ ] Add a time-axis test.
+- [ ] Add a serialization test for `None` / `NaN`.
+- [ ] Add one golden-file smoke payload fixture.
+
+### Recommended rule
+- A smoke run is not a substitute for tests.
+
+---
+
+## Phase 7: smoke script and operational wrapper
+
+Goal: copy the good operational shape from `clyfar` without copying unnecessary complexity.
+
+### What to copy from `clyfar`
+- separate smoke script
+- wrapper-owned upload flag
+- wrapper-owned retry policy
+- explicit UTC/init-time logging
+- non-interactive shell safety: `set -euo pipefail`
+
+### Proposed files
+- `scripts/run_hrrr_smoke.sh`
+- `scripts/submit_hrrr.sh`
+
+### Microtasks
+- [ ] Create a local smoke wrapper that runs one init time with upload disabled.
+- [ ] Add a wrapper-level `HRRR_ENABLE_UPLOAD=0/1`.
+- [ ] Add a wrapper-level `HRRR_SKIP_INTERNAL_EXPORT=0/1` only if we truly need split ownership.
+- [ ] Add explicit init-time logging.
+- [ ] Add clear exit codes for retryable Herbie/network failures if needed.
+- [ ] Only add scheduler integration after local smoke is reliable.
+
+### Recommended rule
+- The shell wrapper should own scheduling and upload mode.
+- The Python module should own data generation.
+
+### Caveat
+- For HRRR waypoint JSON, we may not need the full complexity of `submit_clyfar.sh`.
+- Start simpler, then add retries only if real failures justify them.
+
+---
+
+## Proposed implementation order for Codex
+
+This is the order I would actually code in:
+
+1. Create a sample HRRR JSON file and short schema note.
+2. Create `hrrr_access.py` with one fetch path for one variable.
+3. Create waypoint definitions.
+4. Create single-run hourly export CLI.
+5. Add tests for payload and time axis.
+6. Add `subh` probe and 15-minute extension.
+7. Add lagged-ensemble layer.
+8. Add local smoke script.
+9. Add upload flag and smoke upload.
+10. Add production wrapper only after smoke upload passes.
+
+---
+
+## Non-goals for v1
+
+- Do not refactor the whole `brc-tools` architecture first.
+- Do not switch the shared upload endpoint first.
+- Do not build gridded map products first.
+- Do not depend on unverified PR state first.
+- Do not silently interpolate missing 15-minute data.
+
+---
+
+## Questions that still need answers
+
+These are the highest-value clarification questions.
+
+1. What exact BasinWx upload type should HRRR use: `forecasts`, `model-data`, or something else?
+2. Do you want one shared product for road and aviation waypoints, or two separate products?
+3. What is the v1 waypoint list?
+4. What are the v1 variables?
+5. What forecast horizon do you actually need?
+6. Must v1 be truly 15-minute from the start, or is hourly MVP acceptable first?
+7. When `subh` is missing, should we emit nulls, omit times, or stop the run?
+8. Do you want nearest-point extraction first, or should I spend time on bilinear interpolation up front?
+9. Do you want me to inspect the actual PR branches next, or treat this repo state as the source of truth and start implementing here?
+
+---
+
+## Short critique of the old draft
+
+What the old draft got right:
+- use `clyfar` as the operational reference
+- keep Uinta Basin crop aligned
+- make missing `subh` explicit
+- keep metadata honest
+
+What the old draft got wrong:
+- schema and endpoint were too late in the sequence
+- PR merge order was treated as known fact, but the checkout does not show those contents
+- lagged ensemble came too early relative to single-run validation
+- upload was treated as solved, but repo docs and code disagree
+- "road + aviation waypoints" was too vague to implement
+
+---
+
+## Final recommendation
+
+If we want the fastest path to a robust HRRR product, we should:
+- freeze the JSON contract first
+- build single-run hourly HRRR first
+- add 15-minute support second
+- add lagged ensemble third
+- keep upload and scheduling last
+
+That is the cleanest path from the repo we actually have, not the repo we hope exists in other branches.

--- a/scripts/run_road_forecast_smoke.sh
+++ b/scripts/run_road_forecast_smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INIT_TIME="${1:-}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+DATA_DIR="${DATA_DIR:-./data/road_forecast_smoke}"
+LOG_DIR="${LOG_DIR:-./data/logs}"
+LOG_FILE="${LOG_DIR}/road_forecast_smoke.log"
+
+mkdir -p "${DATA_DIR}" "${LOG_DIR}"
+
+CMD=(
+  "${PYTHON_BIN}"
+  -m
+  brc_tools.download.get_road_forecast
+  --dry-run
+  --data-dir
+  "${DATA_DIR}"
+)
+
+if [[ -n "${INIT_TIME}" ]]; then
+  CMD+=(--init-time "${INIT_TIME}")
+fi
+
+echo "[run_road_forecast_smoke] $(date -u '+%Y-%m-%d %H:%M:%S UTC')" | tee -a "${LOG_FILE}"
+"${CMD[@]}" 2>&1 | tee -a "${LOG_FILE}"

--- a/tests/test_road_forecast_logic.py
+++ b/tests/test_road_forecast_logic.py
@@ -1,0 +1,66 @@
+import datetime as dt
+
+from brc_tools.download.get_road_forecast import build_road_payload, derive_road_fields
+
+
+def test_derive_road_fields_converts_units_and_flags_precip():
+    raw = {
+        "temp_2m": 273.15,
+        "_ugrd": 3.0,
+        "_vgrd": 4.0,
+        "wind_gust": 8.25,
+        "visibility": 5000.0,
+        "precip_1hr": 1.2,
+        "_csnow": 1.0,
+        "_crain": 0.0,
+        "_cfrzr": 0.0,
+        "_cicep": 0.0,
+        "snow_depth": 0.152,
+        "cloud_cover": 87.2,
+        "rh_2m": 94.6,
+    }
+
+    derived = derive_road_fields(raw)
+
+    assert derived["temp_2m"] == 0.0
+    assert derived["wind_speed_10m"] == 5.0
+    assert derived["wind_gust"] == 8.2
+    assert derived["visibility"] == 5.0
+    assert derived["precip_1hr"] == 1.2
+    assert derived["precip_type"] == "snow"
+    assert derived["snow_depth"] == 152.0
+    assert derived["cloud_cover"] == 87.2
+    assert derived["rh_2m"] == 94.6
+
+
+def test_derive_road_fields_stays_explicit_about_missing_values():
+    derived = derive_road_fields({"temp_2m": 280.15})
+
+    assert derived["temp_2m"] == 7.0
+    assert derived["wind_speed_10m"] is None
+    assert derived["precip_type"] is None
+
+
+def test_build_road_payload_preserves_hourly_shape():
+    init_time = dt.datetime(2026, 3, 17, 12, tzinfo=dt.timezone.utc)
+    hourly_template = [{"temp_2m": -1.0, "wind_speed_10m": 3.0}] * 3
+    forecasts_by_route = {
+        "us40": {0: hourly_template},
+        "us191": {},
+        "basin_roads": {},
+    }
+
+    payload = build_road_payload(
+        init_time=init_time,
+        max_fxx=3,
+        forecasts_by_route=forecasts_by_route,
+    )
+
+    assert payload["model"] == "hrrr"
+    assert payload["forecast_hours"] == [1, 2, 3]
+    assert len(payload["valid_times"]) == 3
+    assert payload["routes"]["us40"]["waypoints"][0]["forecasts"]["temp_2m"] == [
+        -1.0,
+        -1.0,
+        -1.0,
+    ]


### PR DESCRIPTION
> Path (a) from the architecture chat on #10: open the existing tested HRRR work as a PR **as-is**, with a follow-up PR doing the refactor into `brc_tools/nwp/` + lookup-driven aliases. This keeps the diff small and reviewable, and means we never lose the tested code while we discuss the right shape.

## What this PR adds

| Path | Lines | Role |
|---|---|---|
| `brc_tools/download/hrrr_access.py` | 323 | Reusable HRRR layer (cache validation, retry, fetch, nearest-point extraction) |
| `brc_tools/download/hrrr_config.py` | 175 | Query map (alias → Herbie search string), variable metadata, basin bbox, US-40 corridor with Duchesne→Vernal waypoints |
| `brc_tools/download/get_road_forecast.py` | 311 | Application layer that wires the access layer into JSON output for the road-forecast endpoint |
| `tests/test_road_forecast_logic.py` | 66 | 3 unit tests covering unit conversion, None propagation, JSON shape — pure logic, no Herbie/network |
| `scripts/run_road_forecast_smoke.sh` | small | Smoke wrapper for ad-hoc local runs |
| `docs/nwp/MERGE-PLAN.md` | 548 | Strategic merge plan that lived at root on the source branch — moved into `docs/nwp/` so it lives next to `ROADMAP.md` and `HRRR-BRANCH-NOTES.md` |

## Why a cherry-pick instead of a rebase

The source branch (`feat/hrrr-road-poc-minimal`) was created in early March, *before* the docs cleanup landed in #12 and #14. A straight rebase or merge would re-introduce `CLAUDE-INDEX.md`, `CLAUDE-CODE-WORKFLOW.md`, `AGENT-INDEX.md`, `CONTRADICTIONS-REPORT.md`, `AGENTS.md`, root `__init__.py`, the old root location of `CROSS-REPO-SYNC.md`, and conflict on every doc we just consolidated. ~24 files of noise.

Cherry-picking only the HRRR additions onto a new branch off current main produces exactly the diff you want to review: 6 files, all additions, no conflicts.

The original `feat/hrrr-road-poc-minimal` branch is untouched — it stays as the historical artefact and can be deleted later once this PR merges.

## Verification

Local, brc-tools conda env (Python 3.13.12):
```
$ conda run -n brc-tools python -m pytest tests/test_road_forecast_logic.py -v
test_derive_road_fields_converts_units_and_flags_precip   PASSED
test_derive_road_fields_stays_explicit_about_missing_values PASSED
test_build_road_payload_preserves_hourly_shape            PASSED
3 passed in 2.17s
```

## What this PR is NOT trying to do

These are deferred to focused follow-ups so this PR stays small:

- **Refactor into `brc_tools/nwp/` + TOML lookup file.** The architecture conversation on #10 is converging on a shared `NWPSource` / `ObsSource` pattern with a TOML alias namespace. That refactor builds on this PR rather than racing it.
- **Fix `pyproject.toml` synoptic dep name.** That's #8, which has already been extended to cover both `requirements.txt` and `pyproject.toml`. Merging #8 first then this PR is the cleanest order, but they touch disjoint files so order doesn't matter.
- **Open the receiving endpoint on `ubair-website`.** The road-forecast upload contract assumes `POST /api/upload/road-forecast`, which is spec'd in the (still-open) #9 but not yet implemented on the website side. Without that endpoint the cron in #9's `run_road_forecast.sh` would push to a 404. This PR doesn't gate on it because the helpers are useful as a library long before the cron runs in production.
- **Generalise to GEFS / RRFS / AQM.** Same lookup-driven refactor — separate follow-up.

## Related items

- Refs #10
- Supersedes #7 (older variant on `feat/hrrr-road-forecast-core`; once this lands #7 should be closed)
- Compatible with #8 (synoptic dep name fix) and #9 (road-forecast spec + cron) — none of them touch the same files

## Test plan

- [x] Unit tests pass (3/3)
- [ ] CODEOWNERS-driven review (`docs/nwp/MERGE-PLAN.md` is in a code-owned path and should auto-request @johnrobertlawson)
- [ ] Spot-check `hrrr_access.py` retry / cache-validation logic against the planned shared `_cache.py` / `_retry.py` modules in the refactor follow-up
- [ ] Confirm the existing Herbie search strings in `hrrr_config.ROAD_FORECAST_QUERY_MAP` match the current HRRR GRIB inventory (worth a manual `Herbie(...).inventory()` check before trusting in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)