### PR TITLE
feat(nwp): NWPSource + ObsSource with TOML aliases, parallel fetch, case study

### DIFF
--- a/brc_tools/nwp/__init__.py
+++ b/brc_tools/nwp/__init__.py
@@ -1,0 +1,5 @@
+"""NWP data access via Herbie, driven by a TOML alias registry."""
+
+from brc_tools.nwp.source import NWPSource
+
+__all__ = ["NWPSource"]

--- a/brc_tools/nwp/_cache.py
+++ b/brc_tools/nwp/_cache.py
@@ -1,0 +1,43 @@
+"""GRIB cache validation and cleanup helpers."""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GRIB_MAGIC = b"GRIB"
+_MIN_GRIB_SIZE = 1000
+
+
+def validate_cached_grib(grib_path, min_size_bytes=_MIN_GRIB_SIZE) -> bool:
+    """Return True if file is valid or missing (Herbie will download fresh).
+    Return False if file exists but is corrupt or truncated."""
+    if grib_path is None:
+        return True
+    p = Path(grib_path)
+    if not p.exists():
+        return True
+    try:
+        if p.stat().st_size < min_size_bytes:
+            logger.warning("GRIB too small: %s (%d bytes)", p.name, p.stat().st_size)
+            return False
+        with open(p, "rb") as f:
+            if f.read(4) != _GRIB_MAGIC:
+                logger.warning("GRIB bad magic: %s", p.name)
+                return False
+        return True
+    except OSError as e:
+        logger.warning("GRIB validation failed for %s: %s", p, e)
+        return False
+
+
+def purge_cached_files(herbie_inst):
+    """Remove cached GRIB and index files for a Herbie instance."""
+    for attr in ("idx", "grib"):
+        path = getattr(herbie_inst, attr, None)
+        if isinstance(path, (str, os.PathLike)) and os.path.exists(str(path)):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass

--- a/brc_tools/nwp/_crop.py
+++ b/brc_tools/nwp/_crop.py
@@ -1,0 +1,108 @@
+"""Spatial cropping and nearest-point extraction."""
+
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_kdtree_cache: dict = {}
+
+
+def crop_to_bbox(ds, sw, ne, crop_method="lonlat_after_aux"):
+    """Crop an xarray Dataset to a lat/lon bounding box.
+
+    Handles both regular lat/lon grids and projected grids with 2-D
+    auxiliary latitude/longitude coordinates. Automatically detects
+    0..360 vs -180..180 longitude conventions.
+    """
+    if crop_method == "lonlat_shift_then_sel":
+        # GEFS: native lon is 0..360, shift to -180..180 first
+        if "longitude" in ds and float(ds.longitude.max()) > 180.0:
+            shifted = ((ds.longitude + 180.0) % 360.0) - 180.0
+            ds = ds.assign_coords(longitude=shifted).sortby("longitude")
+        lat_slice = slice(max(sw[0], ne[0]), min(sw[0], ne[0]))
+        if float(ds.latitude[0]) < float(ds.latitude[-1]):
+            lat_slice = slice(sw[0], ne[0])
+        ds = ds.sel(latitude=lat_slice, longitude=slice(sw[1], ne[1]))
+
+    elif crop_method in ("lonlat_after_aux", "lonlat_direct"):
+        if "latitude" in ds.dims and "longitude" in ds.dims:
+            lat_slice = slice(sw[0], ne[0])
+            if "latitude" in ds.coords and float(ds.latitude[0]) > float(ds.latitude[-1]):
+                lat_slice = slice(ne[0], sw[0])
+            q_sw_lon = _match_lon_convention(sw[1], ds)
+            q_ne_lon = _match_lon_convention(ne[1], ds)
+            ds = ds.sel(latitude=lat_slice, longitude=slice(q_sw_lon, q_ne_lon))
+        else:
+            lat2d = _get_2d_coord(ds, "latitude")
+            lon2d = _get_2d_coord(ds, "longitude")
+            if lat2d is not None and lon2d is not None:
+                sw_lon = _match_lon_convention_2d(sw[1], lon2d)
+                ne_lon = _match_lon_convention_2d(ne[1], lon2d)
+                mask = (
+                    (lat2d >= sw[0]) & (lat2d <= ne[0])
+                    & (lon2d >= sw_lon) & (lon2d <= ne_lon)
+                )
+                y_any = mask.any(dim="x") if "x" in mask.dims else mask.any(axis=1)
+                x_any = mask.any(dim="y") if "y" in mask.dims else mask.any(axis=0)
+                y_idx = np.where(y_any.values)[0]
+                x_idx = np.where(x_any.values)[0]
+                if len(y_idx) > 0 and len(x_idx) > 0:
+                    y_dim = "y" if "y" in ds.dims else [d for d in ds.dims if d not in ("time",) and "x" not in d.lower()][0]
+                    x_dim = "x" if "x" in ds.dims else [d for d in ds.dims if d not in ("time",) and "y" not in d.lower()][0]
+                    ds = ds.isel(
+                        {y_dim: slice(y_idx[0], y_idx[-1] + 1),
+                         x_dim: slice(x_idx[0], x_idx[-1] + 1)}
+                    )
+    return ds
+
+
+def nearest_point_value(ds, lat, lon, method="kdtree_2d"):
+    """Extract the nearest grid point values for all data variables."""
+    if method == "ds_sel_nearest":
+        query_lon = _match_lon_convention(lon, ds)
+        return ds.sel(latitude=lat, longitude=query_lon, method="nearest")
+
+    lat2d = _get_2d_coord(ds, "latitude")
+    lon2d = _get_2d_coord(ds, "longitude")
+    if lat2d is None or lon2d is None:
+        return ds.sel(latitude=lat, longitude=lon, method="nearest")
+
+    query_lon = _match_lon_convention_2d(lon, lon2d)
+    cache_key = id(lat2d.values.data)
+    if cache_key not in _kdtree_cache:
+        from scipy.spatial import cKDTree
+        pts = np.column_stack([lat2d.values.ravel(), lon2d.values.ravel()])
+        _kdtree_cache[cache_key] = (cKDTree(pts), lat2d.shape)
+    tree, shape = _kdtree_cache[cache_key]
+    _, idx = tree.query([lat, query_lon])
+    yi, xi = np.unravel_index(idx, shape)
+    y_dim = [d for d in lat2d.dims if "y" in d.lower() or d == lat2d.dims[0]][0]
+    x_dim = [d for d in lat2d.dims if "x" in d.lower() or d == lat2d.dims[-1]][0]
+    return ds.isel({y_dim: int(yi), x_dim: int(xi)})
+
+
+def _get_2d_coord(ds, name):
+    """Get a 2-D coordinate array (latitude or longitude) from a Dataset."""
+    if name in ds.coords and ds[name].ndim == 2:
+        return ds[name]
+    for coord_name in ds.coords:
+        if name in coord_name.lower() and ds[coord_name].ndim == 2:
+            return ds[coord_name]
+    return None
+
+
+def _match_lon_convention(lon, ds):
+    """Convert a query longitude to match the dataset's convention."""
+    if "longitude" in ds.coords:
+        if float(ds.longitude.max()) > 180.0:
+            return lon % 360
+    return lon
+
+
+def _match_lon_convention_2d(lon, lon2d):
+    """Convert a query longitude to match a 2-D longitude array's convention."""
+    if float(lon2d.max()) > 180.0:
+        return lon % 360
+    return lon

--- a/brc_tools/nwp/_normalise.py
+++ b/brc_tools/nwp/_normalise.py
@@ -1,0 +1,34 @@
+"""Coordinate normalization and CF metadata helpers."""
+
+import datetime
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_coords(ds, init_time, fxx):
+    """Drop transient coords, expand time dim, stamp valid_time."""
+    keep = {"time", "latitude", "longitude"}
+    drop = [n for n in ds.coords if n not in keep]
+    if drop:
+        ds = ds.drop_vars(drop, errors="ignore")
+    valid_time = np.array(
+        [np.datetime64(init_time + datetime.timedelta(hours=int(fxx)))]
+    )
+    if "time" in ds.coords:
+        ds = ds.drop_vars("time", errors="ignore")
+    if "time" not in ds.dims:
+        ds = ds.expand_dims("time")
+    ds = ds.assign_coords(time=("time", valid_time))
+    return ds
+
+
+def parse_cf(ds):
+    """Parse CF metadata if MetPy is available; pass through otherwise."""
+    try:
+        import metpy  # noqa: F401
+        return ds.metpy.parse_cf()
+    except (ImportError, AttributeError):
+        return ds

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -1,0 +1,496 @@
+# Canonical alias namespace for NWPSource and ObsSource.
+# Aliases resolve to per-model Herbie search strings and per-provider
+# SynopticPy variable names so NWP and obs frames are joinable on
+# (waypoint, valid_time, alias) without bespoke renaming.
+
+schema_version   = 1
+units_convention = "CF"
+
+# ── Models ──────────────────────────────────────────────────────────────────
+
+[models.hrrr]
+herbie_model         = "hrrr"
+description          = "NOAA HRRR, CONUS, 3 km"
+init_cadence_hours   = 1
+default_product      = "sfc"
+default_max_fxx      = 18
+extended_init_hours  = [0, 6, 12, 18]
+extended_max_fxx     = 48
+member_required      = false
+grid                 = "lambert_conformal"
+nearest_point_method = "kdtree_2d"
+crop_method          = "lonlat_after_aux"
+
+[models.hrrr.products]
+sfc  = { description = "Surface 2-D",           herbie_name = "sfc"  }
+prs  = { description = "Pressure levels 3-D",   herbie_name = "prs"  }
+nat  = { description = "Native hybrid levels",  herbie_name = "nat"  }
+subh = { description = "15-min sub-hourly sfc",  herbie_name = "subh" }
+
+[models.gefs]
+herbie_model         = "gefs"
+description          = "NOAA GEFSv12 global ensemble"
+init_cadence_hours   = 6
+default_product      = "atmos.25"
+default_max_fxx      = 240
+member_required      = true
+default_member       = "c00"
+members = [
+    "c00",
+    "p01", "p02", "p03", "p04", "p05", "p06", "p07", "p08", "p09", "p10",
+    "p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18", "p19", "p20",
+    "p21", "p22", "p23", "p24", "p25", "p26", "p27", "p28", "p29", "p30",
+]
+grid                 = "latlon"
+nearest_point_method = "ds_sel_nearest"
+crop_method          = "lonlat_shift_then_sel"   # native lon is 0..360
+
+[models.gefs.products]
+"atmos.25" = { description = "0.25-deg atmos", herbie_name = "atmos.25", max_fxx = 240 }
+"atmos.5"  = { description = "0.5-deg atmos",  herbie_name = "atmos.5",  max_fxx = 384 }
+[[models.gefs.product_breakpoints]]
+above_fxx        = 240
+fallback_product = "atmos.5"
+
+[models.rrfs]
+herbie_model         = "rrfs"
+description          = "NOAA RRFS (experimental, evolving)"
+init_cadence_hours   = 1
+default_product      = "prslev"
+default_max_fxx      = 18
+member_required      = false
+grid                 = "lambert_conformal"
+nearest_point_method = "kdtree_2d"
+crop_method          = "lonlat_after_aux"
+
+[models.rrfs.products]
+prslev  = { description = "Pressure + surface", herbie_name = "prslev"  }
+natlev  = { description = "Native level",       herbie_name = "natlev"  }
+testbed = { description = "RRFS testbed",       herbie_name = "testbed" }
+
+# ── Regions ─────────────────────────────────────────────────────────────────
+
+[regions.uinta_basin]
+sw = [39.4, -110.9]
+ne = [41.1, -108.5]
+
+[regions.uinta_basin_wide]
+sw = [38.8, -111.5]
+ne = [41.7, -107.8]
+
+[regions.uinta_basin_xsection_we]
+sw = [40.20, -111.50]
+ne = [40.55, -108.80]
+
+[regions.utah]
+sw = [36.9, -114.2]
+ne = [42.1, -108.9]
+
+[regions.conus]
+sw = [21.0, -125.0]
+ne = [50.0, -66.0]
+
+# ── Waypoints ───────────────────────────────────────────────────────────────
+
+[waypoints.daniels_summit]
+lat = 40.290
+lon = -111.250
+elevation_m = 2497
+reference_stid = "UTDAN"
+
+[waypoints.fruitland]
+lat = 40.207
+lon = -110.842
+elevation_m = 2002
+reference_stid = "UTFRT"
+
+[waypoints.duchesne]
+lat = 40.163
+lon = -110.402
+elevation_m = 1684
+reference_stid = "COOPDSNU1"
+
+[waypoints.myton]
+lat = 40.193
+lon = -110.063
+elevation_m = 1554
+reference_stid = "UTMYT"
+
+[waypoints.roosevelt]
+lat = 40.300
+lon = -109.989
+elevation_m = 1580
+reference_stid = "QRS"
+
+[waypoints.vernal]
+lat = 40.455
+lon = -109.530
+elevation_m = 1622
+reference_stid = "QV4"
+
+[waypoints.seven_sisters]
+lat = 40.176
+lon = -109.349
+elevation_m = 1564
+reference_stid = "UB7ST"
+
+[waypoints.horsepool]
+lat = 40.144
+lon = -109.467
+elevation_m = 1569
+reference_stid = "UBHSP"
+
+[waypoints.dinosaur]
+lat = 40.244
+lon = -108.972
+elevation_m = 1463
+reference_stid = "A3822"
+
+[waypoint_groups]
+us40_basin = ["fruitland", "duchesne", "myton", "roosevelt", "vernal"]
+basin_full = ["fruitland", "duchesne", "myton", "roosevelt", "vernal", "dinosaur"]
+basin_west = ["fruitland", "duchesne", "horsepool"]
+basin_east = ["roosevelt", "vernal", "seven_sisters", "dinosaur"]
+basin_aq   = ["roosevelt", "vernal", "seven_sisters", "horsepool", "dinosaur"]
+foehn_path = ["daniels_summit", "fruitland", "duchesne", "myton", "roosevelt", "vernal"]
+
+# ── Aliases: surface / near-surface ─────────────────────────────────────────
+
+[aliases.temp_2m]
+description   = "Air temperature at 2 m"
+units         = "K"
+output_var    = "temp_2m"
+synoptic_name = "air_temp"
+synoptic_units = "C"
+[aliases.temp_2m.search]
+hrrr = "TMP:2 m above ground"
+gefs = "TMP:2 m above ground"
+rrfs = "TMP:2 m above ground"
+
+[aliases.dewpoint_2m]
+description   = "Dewpoint at 2 m"
+units         = "K"
+output_var    = "dewpoint_2m"
+synoptic_name = "dew_point_temperature"
+synoptic_units = "C"
+[aliases.dewpoint_2m.search]
+hrrr = "DPT:2 m above ground"
+gefs = "DPT:2 m above ground"
+rrfs = "DPT:2 m above ground"
+
+[aliases.rh_2m]
+description   = "Relative humidity at 2 m"
+units         = "%"
+output_var    = "rh_2m"
+synoptic_name = "relative_humidity"
+[aliases.rh_2m.search]
+hrrr = "RH:2 m above ground"
+gefs = "RH:2 m above ground"
+rrfs = "RH:2 m above ground"
+
+[aliases.wind_u_10m]
+description   = "Eastward wind at 10 m (geographic)"
+units         = "m s-1"
+output_var    = "wind_u_10m"
+synoptic_derived_from = ["wind_speed", "wind_direction"]
+[aliases.wind_u_10m.search]
+hrrr = "UGRD:10 m above ground"
+gefs = "UGRD:10 m above ground"
+rrfs = "UGRD:10 m above ground"
+
+[aliases.wind_v_10m]
+description   = "Northward wind at 10 m (geographic)"
+units         = "m s-1"
+output_var    = "wind_v_10m"
+synoptic_derived_from = ["wind_speed", "wind_direction"]
+[aliases.wind_v_10m.search]
+hrrr = "VGRD:10 m above ground"
+gefs = "VGRD:10 m above ground"
+rrfs = "VGRD:10 m above ground"
+
+[aliases.wind_speed_10m]
+description   = "Wind speed at 10 m (derived from U/V)"
+units         = "m s-1"
+output_var    = "wind_speed_10m"
+synoptic_name = "wind_speed"
+derived_from  = ["wind_u_10m", "wind_v_10m"]
+derivation    = "magnitude_2d"
+
+[aliases.wind_dir_10m]
+description   = "Wind direction at 10 m (degrees FROM)"
+units         = "degree"
+output_var    = "wind_dir_10m"
+synoptic_name = "wind_direction"
+derived_from  = ["wind_u_10m", "wind_v_10m"]
+derivation    = "wind_dir_meteorological"
+
+[aliases.wind_gust_10m]
+description   = "Wind gust at surface"
+units         = "m s-1"
+output_var    = "wind_gust_10m"
+synoptic_name = "wind_gust"
+[aliases.wind_gust_10m.search]
+hrrr = "GUST:surface"
+gefs = "GUST:surface"
+rrfs = "GUST:surface"
+
+[aliases.wind_u_80m]
+description = "Eastward wind at 80 m (HRRR/RRFS)"
+units       = "m s-1"
+output_var  = "wind_u_80m"
+[aliases.wind_u_80m.search]
+hrrr = "UGRD:80 m above ground"
+rrfs = "UGRD:80 m above ground"
+
+[aliases.wind_v_80m]
+description = "Northward wind at 80 m (HRRR/RRFS)"
+units       = "m s-1"
+output_var  = "wind_v_80m"
+[aliases.wind_v_80m.search]
+hrrr = "VGRD:80 m above ground"
+rrfs = "VGRD:80 m above ground"
+
+[aliases.mslp]
+description   = "Mean sea level pressure"
+units         = "Pa"
+output_var    = "mslp"
+synoptic_name = "sea_level_pressure"
+synoptic_units = "Pa"
+# HRRR uses MSLMA (Membrane SLP); GEFS/RRFS use PRMSL
+[aliases.mslp.search]
+hrrr = "MSLMA:mean sea level"
+gefs = "PRMSL:mean sea level"
+rrfs = "PRMSL:mean sea level"
+
+[aliases.pressure_surface]
+description   = "Surface pressure"
+units         = "Pa"
+output_var    = "pressure_surface"
+synoptic_name = "pressure"
+[aliases.pressure_surface.search]
+hrrr = "PRES:surface"
+gefs = "PRES:surface"
+rrfs = "PRES:surface"
+
+[aliases.precip_1hr]
+description   = "1-hour accumulated precipitation"
+units         = "kg m-2"
+output_var    = "precip_1hr"
+synoptic_name = "precip_accum_one_hour"
+[aliases.precip_1hr.search]
+hrrr = "APCP:surface:0-1 hour acc"
+gefs = "APCP:surface:0-1 hour acc"
+rrfs = "APCP:surface:0-1 hour acc"
+
+[aliases.snow_depth]
+description   = "Snow depth"
+units         = "m"
+output_var    = "snow_depth"
+synoptic_name = "snow_depth"
+synoptic_units = "mm"
+[aliases.snow_depth.search]
+hrrr = "SNOD:surface"
+gefs = "SNOD:surface"
+rrfs = "SNOD:surface"
+
+[aliases.cloud_cover_total]
+description = "Total cloud cover"
+units       = "%"
+output_var  = "cloud_cover_total"
+[aliases.cloud_cover_total.search]
+hrrr = "TCDC:entire atmosphere"
+gefs = "TCDC:entire atmosphere"
+rrfs = "TCDC:entire atmosphere"
+
+[aliases.cloud_cover_low]
+description = "Low cloud cover"
+units       = "%"
+output_var  = "cloud_cover_low"
+[aliases.cloud_cover_low.search]
+hrrr = "LCDC:low cloud layer"
+gefs = "LCDC:low cloud layer"
+rrfs = "LCDC:low cloud layer"
+
+[aliases.visibility]
+description   = "Surface visibility"
+units         = "m"
+output_var    = "visibility"
+synoptic_name = "visibility"
+[aliases.visibility.search]
+hrrr = "VIS:surface"
+gefs = "VIS:surface"
+rrfs = "VIS:surface"
+
+[aliases.cape_surface]
+description = "Surface-based CAPE"
+units       = "J kg-1"
+output_var  = "cape_surface"
+[aliases.cape_surface.search]
+hrrr = "CAPE:surface"
+gefs = "CAPE:surface"
+rrfs = "CAPE:surface"
+
+[aliases.cin_surface]
+description = "Surface-based CIN"
+units       = "J kg-1"
+output_var  = "cin_surface"
+[aliases.cin_surface.search]
+hrrr = "CIN:surface"
+gefs = "CIN:surface"
+rrfs = "CIN:surface"
+
+[aliases.pbl_height]
+description = "Planetary boundary layer height"
+units       = "m"
+output_var  = "pbl_height"
+[aliases.pbl_height.search]
+hrrr = "HPBL:surface"
+gefs = "HPBL:surface"
+rrfs = "HPBL:surface"
+
+# ── Aliases: pressure levels (3-D, caller passes levels=[...]) ──────────────
+# {level} placeholder is substituted per requested level (hPa).
+
+[aliases.temp_pl]
+description    = "Temperature on pressure levels"
+units          = "K"
+output_var     = "temp"
+vertical_kind  = "pressure"
+default_levels = [1000, 925, 850, 700, 500, 250]
+[aliases.temp_pl.search]
+hrrr = "TMP:{level} mb"
+gefs = "TMP:{level} mb"
+rrfs = "TMP:{level} mb"
+[aliases.temp_pl.products]
+hrrr = "prs"
+gefs = "atmos.25"
+rrfs = "prslev"
+
+[aliases.wind_u_pl]
+description    = "Eastward wind on pressure levels"
+units          = "m s-1"
+output_var     = "wind_u"
+vertical_kind  = "pressure"
+default_levels = [1000, 925, 850, 700, 500, 250]
+[aliases.wind_u_pl.search]
+hrrr = "UGRD:{level} mb"
+gefs = "UGRD:{level} mb"
+rrfs = "UGRD:{level} mb"
+[aliases.wind_u_pl.products]
+hrrr = "prs"
+gefs = "atmos.25"
+rrfs = "prslev"
+
+[aliases.wind_v_pl]
+description    = "Northward wind on pressure levels"
+units          = "m s-1"
+output_var     = "wind_v"
+vertical_kind  = "pressure"
+default_levels = [1000, 925, 850, 700, 500, 250]
+[aliases.wind_v_pl.search]
+hrrr = "VGRD:{level} mb"
+gefs = "VGRD:{level} mb"
+rrfs = "VGRD:{level} mb"
+[aliases.wind_v_pl.products]
+hrrr = "prs"
+gefs = "atmos.25"
+rrfs = "prslev"
+
+[aliases.height_pl]
+description    = "Geopotential height on pressure levels"
+units          = "gpm"
+output_var     = "height"
+vertical_kind  = "pressure"
+default_levels = [1000, 925, 850, 700, 500, 250]
+[aliases.height_pl.search]
+hrrr = "HGT:{level} mb"
+gefs = "HGT:{level} mb"
+rrfs = "HGT:{level} mb"
+[aliases.height_pl.products]
+hrrr = "prs"
+gefs = "atmos.25"
+rrfs = "prslev"
+
+[aliases.rh_pl]
+description    = "Relative humidity on pressure levels"
+units          = "%"
+output_var     = "rh"
+vertical_kind  = "pressure"
+default_levels = [1000, 925, 850, 700, 500]
+[aliases.rh_pl.search]
+hrrr = "RH:{level} mb"
+gefs = "RH:{level} mb"
+rrfs = "RH:{level} mb"
+[aliases.rh_pl.products]
+hrrr = "prs"
+gefs = "atmos.25"
+rrfs = "prslev"
+
+[aliases.omega_pl]
+description    = "Vertical velocity (omega) on pressure levels"
+units          = "Pa s-1"
+output_var     = "omega"
+vertical_kind  = "pressure"
+default_levels = [850, 700, 500, 300]
+[aliases.omega_pl.search]
+hrrr = "VVEL:{level} mb"
+gefs = "VVEL:{level} mb"
+rrfs = "VVEL:{level} mb"
+[aliases.omega_pl.products]
+hrrr = "prs"
+gefs = "atmos.25"
+rrfs = "prslev"
+
+# ── Aliases: native model levels (HRRR/RRFS only) ──────────────────────────
+
+[aliases.temp_ml]
+description   = "Temperature on native layers"
+units         = "K"
+output_var    = "temp_native"
+vertical_kind = "model_level"
+[aliases.temp_ml.search]
+hrrr = "TMP:hybrid level={level}"
+rrfs = "TMP:hybrid level={level}"
+[aliases.temp_ml.products]
+hrrr = "nat"
+rrfs = "natlev"
+
+[aliases.wind_u_ml]
+description   = "Eastward wind on native layers"
+units         = "m s-1"
+output_var    = "wind_u_native"
+vertical_kind = "model_level"
+[aliases.wind_u_ml.search]
+hrrr = "UGRD:hybrid level={level}"
+rrfs = "UGRD:hybrid level={level}"
+[aliases.wind_u_ml.products]
+hrrr = "nat"
+rrfs = "natlev"
+
+[aliases.wind_v_ml]
+description   = "Northward wind on native layers"
+units         = "m s-1"
+output_var    = "wind_v_native"
+vertical_kind = "model_level"
+[aliases.wind_v_ml.search]
+hrrr = "VGRD:hybrid level={level}"
+rrfs = "VGRD:hybrid level={level}"
+[aliases.wind_v_ml.products]
+hrrr = "nat"
+rrfs = "natlev"
+
+# ── Reserved prefixes (documentation only) ──────────────────────────────────
+# o3_*, pm25_*, pm10_*, nox_*, co_*, so2_*, aod_*, refl_*, helicity_*,
+# uh_*, ltng_*, sw_down, lw_down, shf, lhf, soil_t_*, soil_m_*,
+# ventrate, mxhgt
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+[defaults]
+cache_dir_env_var      = "BRC_TOOLS_HERBIE_CACHE"
+prefer_server_subset   = true
+download_retries       = 2
+download_backoff_secs  = 1
+return_nans_on_failure = false
+validate_cache         = true
+min_grib_size_bytes    = 1000

--- a/brc_tools/nwp/source.py
+++ b/brc_tools/nwp/source.py
@@ -73,50 +73,108 @@ class NWPSource:
         bbox: tuple | None = None,
         levels: list[int] | None = None,
         product: str | None = None,
+        max_workers: int = 6,
     ) -> xr.Dataset:
         """Fetch model data for canonical aliases over a range of forecast hours.
+
+        Downloads are parallelised across forecast hours (up to
+        ``max_workers`` concurrent threads). Set ``max_workers=1``
+        to force sequential behaviour.
 
         Returns an xr.Dataset with dims (time, ...) and variables renamed
         to their canonical ``output_var`` names from lookups.toml.
         """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         init_dt = _parse_init_time(init_time)
         aliases = self._lu["aliases"]
         sw, ne = self._resolve_bbox(region, bbox)
-
-        # Separate variables by product (surface vs pressure-level, etc.)
         var_groups = self._group_by_product(variables, aliases, product)
+        crop_method = self._cfg.get("crop_method", "lonlat_after_aux")
 
-        hour_slices = []
-        for fxx in forecast_hours:
+        # Build flat work list: (fxx, alias_name, search_str, output_var, product)
+        retries = self._defaults.get("download_retries", 2)
+        work_items = []
+        for fxx in (int(f) for f in forecast_hours):
             fxx_product = self._resolve_product_for_fxx(
-                product or self._default_product, int(fxx)
+                product or self._default_product, fxx
             )
-            merged_vars = {}
             for prod_key, var_list in var_groups.items():
                 actual_product = prod_key if prod_key else fxx_product
-                ds_vars = self._fetch_hour_variables(
-                    init_dt, int(fxx), var_list, aliases, actual_product, levels
-                )
-                merged_vars.update(ds_vars)
+                for alias_name, search_str, output_var in var_list:
+                    alias_cfg = aliases[alias_name]
+                    if "derived_from" in alias_cfg:
+                        continue
+                    for search, level_label in self._expand_search(
+                        search_str, levels, alias_cfg
+                    ):
+                        out_name = (
+                            output_var if level_label is None
+                            else f"{output_var}_{level_label}"
+                        )
+                        work_items.append(
+                            (fxx, search, actual_product, out_name, retries)
+                        )
 
-            if not merged_vars:
-                logger.warning("No data for f%03d; skipping", fxx)
+        def _do_fetch(item):
+            fxx, search, prod, out_name, ret = item
+            ds = self._herbie_fetch(init_dt, fxx, search, prod, ret)
+            if ds is not None:
+                data_vars = list(ds.data_vars)
+                if data_vars:
+                    ds = ds.rename({data_vars[0]: out_name})
+                keep = {"time", "latitude", "longitude", "y", "x"}
+                drop = [n for n in ds.coords if n not in keep and n not in ds.dims]
+                if drop:
+                    ds = ds.drop_vars(drop, errors="ignore")
+            return fxx, out_name, ds
+
+        # Submit all (hour × variable) pairs to a flat thread pool
+        raw_results: dict[tuple[int, str], xr.Dataset] = {}
+        fxx_set: set[int] = set()
+
+        if max_workers <= 1 or len(work_items) <= 1:
+            for item in work_items:
+                fxx, out_name, ds = _do_fetch(item)
+                if ds is not None:
+                    raw_results[(fxx, out_name)] = ds
+                    fxx_set.add(fxx)
+        else:
+            workers = min(max_workers, len(work_items))
+            logger.info(
+                "Parallel fetch: %d tasks (%d hours × %d vars) with %d workers",
+                len(work_items),
+                len(set(i[0] for i in work_items)),
+                len(set(i[3] for i in work_items)),
+                workers,
+            )
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                futures = {pool.submit(_do_fetch, item): item for item in work_items}
+                for future in as_completed(futures):
+                    try:
+                        fxx, out_name, ds = future.result()
+                        if ds is not None:
+                            raw_results[(fxx, out_name)] = ds
+                            fxx_set.add(fxx)
+                    except Exception as exc:
+                        item = futures[future]
+                        logger.warning("Fetch failed f%03d %s: %s", item[0], item[3], exc)
+
+        # Group by fxx, merge, normalize, crop
+        results: dict[int, xr.Dataset] = {}
+        for fxx in sorted(fxx_set):
+            hour_ds = {k[1]: v for k, v in raw_results.items() if k[0] == fxx}
+            if not hour_ds:
                 continue
-
-            # Merge all variable datasets for this hour
             ds_hour = xr.merge(
-                list(merged_vars.values()),
-                combine_attrs="drop",
-                compat="override",
+                list(hour_ds.values()), combine_attrs="drop", compat="override"
             )
             ds_hour = normalize_coords(ds_hour, init_dt, fxx)
-
             if sw is not None and ne is not None:
-                ds_hour = crop_to_bbox(
-                    ds_hour, sw, ne, self._cfg.get("crop_method", "lonlat_after_aux")
-                )
-            hour_slices.append(ds_hour)
+                ds_hour = crop_to_bbox(ds_hour, sw, ne, crop_method)
+            results[fxx] = ds_hour
 
+        hour_slices = [results[fxx] for fxx in sorted(results)]
         if not hour_slices:
             raise RuntimeError(
                 f"No data returned for {self._model_key} init={init_dt} "

--- a/brc_tools/nwp/source.py
+++ b/brc_tools/nwp/source.py
@@ -1,0 +1,328 @@
+"""NWPSource: model-agnostic wrapper around Herbie, driven by lookups.toml."""
+
+import datetime
+import logging
+import tomllib
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import xarray as xr
+from herbie import Herbie
+
+from brc_tools.nwp._cache import purge_cached_files, validate_cached_grib
+from brc_tools.nwp._crop import crop_to_bbox, nearest_point_value
+from brc_tools.nwp._normalise import normalize_coords
+
+logger = logging.getLogger(__name__)
+
+_LOOKUPS_PATH = Path(__file__).parent / "lookups.toml"
+_lookups_cache: dict | None = None
+
+
+def load_lookups(path: Path | None = None) -> dict:
+    """Load and cache the TOML alias registry."""
+    global _lookups_cache
+    if _lookups_cache is not None and path is None:
+        return _lookups_cache
+    p = path or _LOOKUPS_PATH
+    with open(p, "rb") as f:
+        data = tomllib.load(f)
+    if path is None:
+        _lookups_cache = data
+    return data
+
+
+class NWPSource:
+    """Fetch NWP model data via Herbie using canonical aliases from lookups.toml.
+
+    Usage::
+
+        src = NWPSource("hrrr")
+        ds = src.fetch(
+            init_time="2025-02-22 16Z",
+            forecast_hours=range(0, 13),
+            variables=["temp_2m", "wind_u_10m", "wind_v_10m", "mslp"],
+            region="uinta_basin",
+        )
+    """
+
+    def __init__(self, model: str, *, member: str | None = None,
+                 product: str | None = None):
+        self._lu = load_lookups()
+        if model not in self._lu["models"]:
+            raise ValueError(
+                f"Unknown model {model!r}. "
+                f"Available: {list(self._lu['models'])}"
+            )
+        self._model_key = model
+        self._cfg = self._lu["models"][model]
+        self._member = member or self._cfg.get("default_member")
+        self._default_product = product or self._cfg["default_product"]
+        self._defaults = self._lu.get("defaults", {})
+
+    # ── public API ──────────────────────────────────────────────────────
+
+    def fetch(
+        self,
+        init_time,
+        forecast_hours,
+        variables: list[str],
+        *,
+        region: str | None = None,
+        bbox: tuple | None = None,
+        levels: list[int] | None = None,
+        product: str | None = None,
+    ) -> xr.Dataset:
+        """Fetch model data for canonical aliases over a range of forecast hours.
+
+        Returns an xr.Dataset with dims (time, ...) and variables renamed
+        to their canonical ``output_var`` names from lookups.toml.
+        """
+        init_dt = _parse_init_time(init_time)
+        aliases = self._lu["aliases"]
+        sw, ne = self._resolve_bbox(region, bbox)
+
+        # Separate variables by product (surface vs pressure-level, etc.)
+        var_groups = self._group_by_product(variables, aliases, product)
+
+        hour_slices = []
+        for fxx in forecast_hours:
+            fxx_product = self._resolve_product_for_fxx(
+                product or self._default_product, int(fxx)
+            )
+            merged_vars = {}
+            for prod_key, var_list in var_groups.items():
+                actual_product = prod_key if prod_key else fxx_product
+                ds_vars = self._fetch_hour_variables(
+                    init_dt, int(fxx), var_list, aliases, actual_product, levels
+                )
+                merged_vars.update(ds_vars)
+
+            if not merged_vars:
+                logger.warning("No data for f%03d; skipping", fxx)
+                continue
+
+            # Merge all variable datasets for this hour
+            ds_hour = xr.merge(
+                list(merged_vars.values()),
+                combine_attrs="drop",
+                compat="override",
+            )
+            ds_hour = normalize_coords(ds_hour, init_dt, fxx)
+
+            if sw is not None and ne is not None:
+                ds_hour = crop_to_bbox(
+                    ds_hour, sw, ne, self._cfg.get("crop_method", "lonlat_after_aux")
+                )
+            hour_slices.append(ds_hour)
+
+        if not hour_slices:
+            raise RuntimeError(
+                f"No data returned for {self._model_key} init={init_dt} "
+                f"hours={list(forecast_hours)} vars={variables}"
+            )
+        return xr.concat(hour_slices, dim="time", combine_attrs="drop")
+
+    def extract_at_waypoints(
+        self,
+        ds: xr.Dataset,
+        *,
+        group: str | None = None,
+        waypoints: list[str] | None = None,
+    ) -> pl.DataFrame:
+        """Extract time series at named waypoints from a gridded dataset.
+
+        Returns a Polars DataFrame with columns: waypoint, valid_time, plus
+        one column per data variable in the dataset.
+        """
+        wp_names = self._resolve_waypoints(group, waypoints)
+        all_wps = self._lu["waypoints"]
+        method = self._cfg.get("nearest_point_method", "kdtree_2d")
+
+        rows = []
+        for wp_name in wp_names:
+            wp = all_wps[wp_name]
+            pt = nearest_point_value(ds, wp["lat"], wp["lon"], method=method)
+            for t_idx in range(pt.sizes.get("time", 1)):
+                row = {"waypoint": wp_name}
+                if "time" in pt.dims:
+                    row["valid_time"] = pt.time.values[t_idx].item()
+                    pt_t = pt.isel(time=t_idx)
+                else:
+                    pt_t = pt
+                for var_name in pt_t.data_vars:
+                    val = pt_t[var_name].values
+                    row[var_name] = float(val) if np.isfinite(val) else None
+                rows.append(row)
+        return pl.DataFrame(rows)
+
+    def latest_init(self, now: datetime.datetime | None = None) -> datetime.datetime:
+        """Find the most recent init time likely to have data available."""
+        now = now or datetime.datetime.now(datetime.timezone.utc)
+        cadence = self._cfg["init_cadence_hours"]
+        lag_hours = 2  # conservative availability lag
+        candidate = now - datetime.timedelta(hours=lag_hours)
+        # Round down to nearest cadence
+        hour = (candidate.hour // cadence) * cadence
+        return candidate.replace(hour=hour, minute=0, second=0, microsecond=0)
+
+    # ── internal helpers ────────────────────────────────────────────────
+
+    def _fetch_hour_variables(self, init_dt, fxx, var_list, aliases, product, levels):
+        """Fetch all requested variables for a single forecast hour."""
+        retries = self._defaults.get("download_retries", 2)
+        results = {}
+        for alias_name, search_str, output_var in var_list:
+            alias_cfg = aliases[alias_name]
+            # Handle derived variables
+            if "derived_from" in alias_cfg:
+                continue  # will be computed after all native vars are fetched
+
+            actual_searches = self._expand_search(search_str, levels, alias_cfg)
+            for search, level_label in actual_searches:
+                ds = self._herbie_fetch(init_dt, fxx, search, product, retries)
+                if ds is not None:
+                    out_name = output_var if level_label is None else f"{output_var}_{level_label}"
+                    data_vars = list(ds.data_vars)
+                    if data_vars:
+                        ds = ds.rename({data_vars[0]: out_name})
+                    # Strip transient coords NOW so merge doesn't conflict
+                    keep = {"time", "latitude", "longitude", "y", "x"}
+                    drop = [n for n in ds.coords if n not in keep and n not in ds.dims]
+                    if drop:
+                        ds = ds.drop_vars(drop, errors="ignore")
+                    results[out_name] = ds
+        return results
+
+    def _herbie_fetch(self, init_dt, fxx, search_str, product, retries):
+        """Single Herbie fetch with cache validation and retry."""
+        for attempt in range(retries):
+            try:
+                herbie_kwargs = dict(
+                    model=self._cfg["herbie_model"],
+                    product=product,
+                    fxx=fxx,
+                )
+                if self._member is not None:
+                    herbie_kwargs["member"] = self._member
+                cache_dir = self._cache_dir()
+                if cache_dir is not None:
+                    herbie_kwargs["save_dir"] = cache_dir
+                H = Herbie(init_dt, **herbie_kwargs)
+                grib_path = getattr(H, "grib", None)
+                if grib_path and not validate_cached_grib(grib_path):
+                    purge_cached_files(H)
+
+                ds = H.xarray(search_str, remove_grib=True)
+                return ds
+            except Exception as exc:
+                logger.warning(
+                    "Herbie fetch failed (attempt %d/%d) %s f%03d %r: %s",
+                    attempt + 1, retries, self._model_key, fxx, search_str, exc,
+                )
+                if attempt < retries - 1:
+                    try:
+                        purge_cached_files(H)
+                    except Exception:
+                        pass
+                    continue
+                if self._defaults.get("return_nans_on_failure", False):
+                    return None
+                raise
+        return None
+
+    def _expand_search(self, search_template, levels, alias_cfg):
+        """Expand a {level} placeholder into multiple concrete search strings."""
+        if "{level}" not in search_template:
+            return [(search_template, None)]
+        use_levels = levels or alias_cfg.get("default_levels", [])
+        if not use_levels:
+            raise ValueError(
+                f"Alias requires levels= but none provided and no default_levels set"
+            )
+        return [(search_template.format(level=lv), str(lv)) for lv in use_levels]
+
+    def _group_by_product(self, variables, aliases, override_product):
+        """Group requested variables by the product they need."""
+        groups = {}  # product_key -> [(alias_name, search_str, output_var)]
+        for var_name in variables:
+            if var_name not in aliases:
+                raise ValueError(
+                    f"Unknown alias {var_name!r}. Check lookups.toml."
+                )
+            alias = aliases[var_name]
+            # Derived variables (wind_speed_10m, wind_dir_10m) don't need fetching
+            if "derived_from" in alias:
+                continue
+            search_table = alias.get("search", {})
+            if self._model_key not in search_table:
+                logger.info(
+                    "Alias %r not available for model %s; skipping",
+                    var_name, self._model_key,
+                )
+                continue
+            search_str = search_table[self._model_key]
+            output_var = alias["output_var"]
+            # Determine product for this alias
+            products_table = alias.get("products", {})
+            prod_key = products_table.get(self._model_key)
+            if override_product:
+                prod_key = override_product
+            groups.setdefault(prod_key, []).append((var_name, search_str, output_var))
+        return groups
+
+    def _resolve_bbox(self, region, bbox):
+        if bbox is not None:
+            return bbox[:2], bbox[2:]
+        if region is not None:
+            r = self._lu["regions"][region]
+            return tuple(r["sw"]), tuple(r["ne"])
+        return None, None
+
+    def _resolve_waypoints(self, group, waypoints):
+        if waypoints is not None:
+            return waypoints
+        if group is not None:
+            return self._lu["waypoint_groups"][group]
+        raise ValueError("Provide either group= or waypoints=")
+
+    def _resolve_product_for_fxx(self, base_product, fxx):
+        """Handle model-specific product breakpoints (e.g., GEFS atmos.5 above fxx 240)."""
+        breakpoints = self._cfg.get("product_breakpoints", [])
+        for bp in breakpoints:
+            if fxx > bp.get("above_fxx", float("inf")):
+                return bp["fallback_product"]
+        return base_product
+
+    def _cache_dir(self):
+        import os
+        env_var = self._defaults.get("cache_dir_env_var", "BRC_TOOLS_HERBIE_CACHE")
+        return os.environ.get(env_var) or None
+
+
+def _parse_init_time(init_time) -> datetime.datetime:
+    """Parse init_time from string or datetime.
+
+    Returns a tz-naive datetime (Herbie assumes UTC internally and
+    rejects tz-aware objects in its validation).
+    """
+    if isinstance(init_time, datetime.datetime):
+        return init_time.replace(tzinfo=None)
+    s = str(init_time).strip()
+    # Strip timezone indicators — we always mean UTC
+    for tz_str in ("Z", "z", " UTC", " utc"):
+        s = s.replace(tz_str, "")
+    s = s.strip()
+    for fmt in (
+        "%Y-%m-%d %H",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y%m%d%H",
+        "%Y%m%d %H",
+    ):
+        try:
+            return datetime.datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"Cannot parse init_time: {init_time!r}")

--- a/brc_tools/nwp/source.py
+++ b/brc_tools/nwp/source.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import os
 import tomllib
 from pathlib import Path
 
@@ -254,7 +255,25 @@ class NWPSource:
         return results
 
     def _herbie_fetch(self, init_dt, fxx, search_str, product, retries):
-        """Single Herbie fetch with cache validation and retry."""
+        """Single Herbie fetch with cache validation, file-level locking, and retry.
+
+        A per-GRIB-file lock (via fasteners) prevents concurrent threads/processes
+        from corrupting the cache when multiple workers download the same file.
+        The lock key is (model, init, fxx, product, member) — different search
+        strings hitting the same GRIB file serialize, but different files download
+        freely in parallel.
+        """
+        import tempfile
+        import fasteners
+
+        lock_dir = os.environ.get("BRC_TOOLS_LOCK_DIR") or tempfile.gettempdir()
+        member_str = self._member or "det"
+        lock_name = (
+            f"herbie_{self._cfg['herbie_model']}_{init_dt:%Y%m%d_%H}_"
+            f"f{fxx:03d}_{product}_{member_str}.lock"
+        )
+        lock = fasteners.InterProcessLock(os.path.join(lock_dir, lock_name))
+
         for attempt in range(retries):
             try:
                 herbie_kwargs = dict(
@@ -267,12 +286,14 @@ class NWPSource:
                 cache_dir = self._cache_dir()
                 if cache_dir is not None:
                     herbie_kwargs["save_dir"] = cache_dir
-                H = Herbie(init_dt, **herbie_kwargs)
-                grib_path = getattr(H, "grib", None)
-                if grib_path and not validate_cached_grib(grib_path):
-                    purge_cached_files(H)
 
-                ds = H.xarray(search_str, remove_grib=True)
+                with lock:
+                    H = Herbie(init_dt, **herbie_kwargs)
+                    grib_path = getattr(H, "grib", None)
+                    if grib_path and not validate_cached_grib(grib_path):
+                        purge_cached_files(H)
+                    ds = H.xarray(search_str, remove_grib=True)
+
                 return ds
             except Exception as exc:
                 logger.warning(
@@ -280,10 +301,11 @@ class NWPSource:
                     attempt + 1, retries, self._model_key, fxx, search_str, exc,
                 )
                 if attempt < retries - 1:
-                    try:
-                        purge_cached_files(H)
-                    except Exception:
-                        pass
+                    with lock:
+                        try:
+                            purge_cached_files(H)
+                        except Exception:
+                            pass
                     continue
                 if self._defaults.get("return_nans_on_failure", False):
                     return None

--- a/brc_tools/obs/__init__.py
+++ b/brc_tools/obs/__init__.py
@@ -1,0 +1,5 @@
+"""Observation data access via SynopticPy, sharing the NWP alias namespace."""
+
+from brc_tools.obs.source import ObsSource
+
+__all__ = ["ObsSource"]

--- a/brc_tools/obs/source.py
+++ b/brc_tools/obs/source.py
@@ -1,0 +1,170 @@
+"""ObsSource: SynopticPy wrapper using the same alias namespace as NWPSource."""
+
+import datetime
+import logging
+
+import numpy as np
+import polars as pl
+
+from brc_tools.nwp.source import load_lookups
+
+logger = logging.getLogger(__name__)
+
+
+class ObsSource:
+    """Fetch station observations via SynopticPy with canonical alias names.
+
+    Usage::
+
+        obs = ObsSource()
+        df = obs.timeseries(
+            waypoint_group="foehn_path",
+            start="2025-02-22 12Z",
+            end="2025-02-23 06Z",
+            variables=["temp_2m", "wind_speed_10m", "wind_dir_10m", "mslp"],
+        )
+    """
+
+    def __init__(self):
+        self._lu = load_lookups()
+
+    def timeseries(
+        self,
+        *,
+        stids: list[str] | None = None,
+        waypoint_group: str | None = None,
+        waypoints: list[str] | None = None,
+        start,
+        end,
+        variables: list[str],
+    ) -> pl.DataFrame:
+        """Fetch time series from Synoptic stations, renamed to canonical aliases.
+
+        Returns a Polars DataFrame with columns: stid, waypoint (if
+        waypoints were used), valid_time, plus one column per alias.
+        """
+        from synoptic.services import TimeSeries
+
+        stid_list, stid_to_wp = self._resolve_stids(stids, waypoint_group, waypoints)
+        synoptic_vars = self._alias_to_synoptic_vars(variables)
+
+        start_dt = _parse_time(start)
+        end_dt = _parse_time(end)
+
+        logger.info(
+            "SynopticPy fetch: stids=%s vars=%s %s to %s",
+            stid_list, synoptic_vars, start_dt, end_dt,
+        )
+        raw = TimeSeries(
+            stid=stid_list,
+            start=start_dt,
+            end=end_dt,
+            vars=synoptic_vars,
+            verbose=False,
+        ).df().synoptic.pivot()
+
+        # Convert pandas → polars if needed
+        if hasattr(raw, "to_pandas"):
+            df = pl.from_pandas(raw.reset_index() if hasattr(raw, "reset_index") else raw)
+        else:
+            df = pl.from_pandas(raw.reset_index())
+
+        # Rename Synoptic column names → canonical aliases
+        rename_map = self._build_rename_map(variables, df.columns)
+        df = df.rename(rename_map)
+
+        # Normalize time column
+        time_col = next((c for c in df.columns if "time" in c.lower() or "date" in c.lower()), None)
+        if time_col and time_col != "valid_time":
+            df = df.rename({time_col: "valid_time"})
+
+        # Normalize station ID column
+        stid_col = next((c for c in df.columns if c.lower() in ("stid", "station_id", "station")), None)
+        if stid_col and stid_col != "stid":
+            df = df.rename({stid_col: "stid"})
+
+        # Add waypoint column if we can map stid → waypoint
+        if stid_to_wp and "stid" in df.columns:
+            df = df.with_columns(
+                pl.col("stid").replace_strict(stid_to_wp, default=None).alias("waypoint")
+            )
+
+        return df
+
+    def align_with_nwp(self, obs_df: pl.DataFrame, nwp_df: pl.DataFrame) -> pl.DataFrame:
+        """Tag source and concatenate obs + NWP point DataFrames for plotting."""
+        obs_tagged = obs_df.with_columns(pl.lit("obs").alias("source"))
+        nwp_tagged = nwp_df.with_columns(pl.lit("nwp").alias("source"))
+        # Find shared columns
+        shared = sorted(set(obs_tagged.columns) & set(nwp_tagged.columns))
+        return pl.concat(
+            [obs_tagged.select(shared), nwp_tagged.select(shared)],
+            how="vertical_relaxed",
+        )
+
+    # ── internal ────────────────────────────────────────────────────────
+
+    def _resolve_stids(self, stids, waypoint_group, waypoints):
+        """Return (stid_list, stid_to_waypoint_name_map)."""
+        if stids is not None:
+            return stids, {}
+        wp_names = self._resolve_waypoints(waypoint_group, waypoints)
+        all_wps = self._lu["waypoints"]
+        stid_list = []
+        stid_to_wp = {}
+        for wp_name in wp_names:
+            stid = all_wps[wp_name]["reference_stid"]
+            stid_list.append(stid)
+            stid_to_wp[stid] = wp_name
+        return stid_list, stid_to_wp
+
+    def _resolve_waypoints(self, group, waypoints):
+        if waypoints is not None:
+            return waypoints
+        if group is not None:
+            return self._lu["waypoint_groups"][group]
+        raise ValueError("Provide stids=, waypoint_group=, or waypoints=")
+
+    def _alias_to_synoptic_vars(self, variables):
+        """Map canonical aliases to SynopticPy variable names."""
+        aliases = self._lu["aliases"]
+        synoptic_vars = set()
+        for var_name in variables:
+            alias = aliases.get(var_name)
+            if alias is None:
+                logger.warning("Unknown alias %r; skipping", var_name)
+                continue
+            if "synoptic_name" in alias:
+                synoptic_vars.add(alias["synoptic_name"])
+            elif "synoptic_derived_from" in alias:
+                for sn in alias["synoptic_derived_from"]:
+                    synoptic_vars.add(sn)
+        return sorted(synoptic_vars)
+
+    def _build_rename_map(self, variables, existing_columns):
+        """Build a column rename mapping from Synoptic names → canonical aliases."""
+        aliases = self._lu["aliases"]
+        rename = {}
+        for var_name in variables:
+            alias = aliases.get(var_name, {})
+            syn_name = alias.get("synoptic_name")
+            output_var = alias.get("output_var", var_name)
+            if syn_name and syn_name in existing_columns and syn_name != output_var:
+                rename[syn_name] = output_var
+        return rename
+
+
+def _parse_time(t) -> datetime.datetime:
+    if isinstance(t, datetime.datetime):
+        return t
+    s = str(t).strip().replace("Z", " UTC").replace("z", " UTC")
+    for fmt in ("%Y-%m-%d %H %Z", "%Y-%m-%d %H:%M %Z", "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%d %H:%M", "%Y-%m-%d %H"):
+        try:
+            dt = datetime.datetime.strptime(s, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=datetime.timezone.utc)
+            return dt
+        except ValueError:
+            continue
+    raise ValueError(f"Cannot parse time: {t!r}")

--- a/scripts/case_study_20250222.py
+++ b/scripts/case_study_20250222.py
@@ -1,0 +1,796 @@
+"""Case study: 22 Feb 2025 Uinta Basin cold-pool erosion event.
+
+Fetches HRRR surface and pressure-level data via NWPSource, optionally
+fetches Synoptic observations via ObsSource, and produces six
+publication-quality figures illustrating the foehn-driven cold-pool
+erosion during the afternoon of 22 Feb 2025.
+
+Usage::
+
+    conda run -n brc-tools python scripts/case_study_20250222.py
+"""
+
+import datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Cartopy imports
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+
+# Local imports
+from brc_tools.nwp import NWPSource
+from brc_tools.nwp.source import load_lookups
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+OUTDIR = Path(__file__).resolve().parent.parent / "figures" / "case_study_20250222"
+OUTDIR.mkdir(parents=True, exist_ok=True)
+
+DATE = "2025-02-22"
+INIT_HOURS = [15, 16, 17]  # three HRRR runs to compare
+SFC_VARS = ["temp_2m", "wind_u_10m", "wind_v_10m", "mslp", "pbl_height"]
+PL_VARS = ["temp_pl", "wind_u_pl", "wind_v_pl", "height_pl"]
+PL_LEVELS = [1000, 950, 925, 900, 850, 800, 750, 700]
+FHOURS = range(0, 13)
+
+WP_GROUP = "foehn_path"
+WP_NAMES = [
+    "daniels_summit", "fruitland", "duchesne", "myton", "roosevelt", "vernal"
+]
+
+ANNOTATION = "HRRR | 22 Feb 2025 | BRC Tools"
+DPI = 150
+BARB_SKIP = 5  # thin wind barbs every Nth grid point
+KT_FACTOR = 1.94384  # m/s -> knots
+
+# Styling constants
+TITLE_SIZE = 12
+LABEL_SIZE = 10
+TICK_SIZE = 8
+
+# Line style for multi-run comparison
+RUN_STYLES = {
+    15: {"color": "tab:blue",   "ls": "-",  "label": "15Z init"},
+    16: {"color": "tab:red",    "ls": "--", "label": "16Z init"},
+    17: {"color": "tab:green",  "ls": "-.", "label": "17Z init"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_waypoints():
+    """Return dict of waypoint metadata from lookups.toml."""
+    lu = load_lookups()
+    return {name: lu["waypoints"][name] for name in WP_NAMES}
+
+
+def _lon_to_180(lon):
+    """Convert longitude from 0..360 to -180..180."""
+    return np.where(lon > 180, lon - 360, lon)
+
+
+def _get_latlon(ds):
+    """Extract 2-D lat/lon arrays from the dataset, converting lon to -180..180."""
+    lat = ds["latitude"].values
+    lon = _lon_to_180(ds["longitude"].values)
+    return lat, lon
+
+
+def _compute_wind(ds):
+    """Add wind_speed_10m and wind_dir_10m to a dataset (in-place semantics)."""
+    u = ds["wind_u_10m"]
+    v = ds["wind_v_10m"]
+    speed = np.sqrt(u ** 2 + v ** 2)
+    direction = (270 - np.degrees(np.arctan2(v, u))) % 360
+    ds["wind_speed_10m"] = speed
+    ds["wind_dir_10m"] = direction
+    return ds
+
+
+def _add_map_features(ax):
+    """Add state borders to a Cartopy axes.
+
+    Uses 10m states (locally cached). Counties and international borders
+    are skipped because the NaturalEarth download server is unreliable
+    and cartopy downloads lazily at render time, causing hard failures.
+    """
+    # 10m states are pre-cached; use NaturalEarthFeature explicitly so
+    # we control the resolution and avoid any fallback download attempts.
+    states = cfeature.NaturalEarthFeature(
+        "cultural", "admin_1_states_provinces_lakes", "10m",
+        facecolor="none", edgecolor="black", linewidth=0.8,
+    )
+    ax.add_feature(states)
+
+
+def _add_waypoints(ax, waypoints, transform=ccrs.PlateCarree(), fontsize=7):
+    """Plot waypoint markers and labels on a Cartopy axes."""
+    for name, wp in waypoints.items():
+        ax.plot(
+            wp["lon"], wp["lat"], "k^", markersize=5, transform=transform, zorder=10,
+        )
+        ax.text(
+            wp["lon"] + 0.05, wp["lat"] + 0.05, name.replace("_", " ").title(),
+            fontsize=fontsize, transform=transform, zorder=10,
+            ha="left", va="bottom",
+            bbox=dict(facecolor="white", alpha=0.6, edgecolor="none", pad=0.5),
+        )
+
+
+def _annotate(fig, text=ANNOTATION):
+    """Add a small attribution annotation to the figure."""
+    fig.text(
+        0.99, 0.01, text, fontsize=6, ha="right", va="bottom",
+        fontstyle="italic", color="gray",
+    )
+
+
+def _temp_K_to_C(temp_K):
+    """Convert temperature from Kelvin to Celsius."""
+    return temp_K - 273.15
+
+
+def _pa_to_hpa(pa):
+    """Convert pressure from Pa to hPa."""
+    return pa / 100.0
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def fetch_surface_runs(src):
+    """Fetch surface data for all three HRRR init times.
+
+    Returns dict {init_hour: xr.Dataset}.
+    """
+    datasets = {}
+    for ih in INIT_HOURS:
+        init_str = f"{DATE} {ih:02d}Z"
+        print(f"  Fetching HRRR sfc init={init_str} f00-f12 ...")
+        ds = src.fetch(
+            init_time=init_str,
+            forecast_hours=FHOURS,
+            variables=SFC_VARS,
+            region="uinta_basin",
+        )
+        ds = _compute_wind(ds)
+        datasets[ih] = ds
+        print(f"    -> {ds.sizes}")
+    return datasets
+
+
+def fetch_pressure_levels(src):
+    """Fetch pressure-level data from the 16Z run (f07 only for the cross-section)."""
+    print("  Fetching HRRR pressure-level data init=16Z f07 ...")
+    ds = src.fetch(
+        init_time=f"{DATE} 16Z",
+        forecast_hours=[7],
+        variables=PL_VARS,
+        levels=PL_LEVELS,
+        region="uinta_basin_wide",
+    )
+    print(f"    -> {ds.sizes}")
+    return ds
+
+
+def extract_waypoint_series(src, datasets):
+    """Extract time series at foehn_path waypoints for each run.
+
+    Returns dict {init_hour: pl.DataFrame}.
+    """
+    wp_series = {}
+    for ih, ds in datasets.items():
+        print(f"  Extracting waypoints for {ih}Z run ...")
+        df = src.extract_at_waypoints(ds, group=WP_GROUP)
+        wp_series[ih] = df
+    return wp_series
+
+
+def fetch_observations():
+    """Attempt to fetch Synoptic observations; returns None on failure."""
+    try:
+        from brc_tools.obs import ObsSource
+        obs = ObsSource()
+        print("  Fetching Synoptic observations ...")
+        obs_df = obs.timeseries(
+            waypoint_group=WP_GROUP,
+            start=f"{DATE} 12Z",
+            end="2025-02-23 06Z",
+            variables=["temp_2m", "wind_speed_10m", "wind_dir_10m", "mslp"],
+        )
+        print(f"    -> {obs_df.shape[0]} obs rows")
+        return obs_df
+    except Exception as exc:
+        print(f"  [WARN] ObsSource failed (Synoptic API not configured?): {exc}")
+        print("         NWP-only plots will still be produced.")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Figure 1: Surface temp + wind barbs, 3-panel comparison at valid 23Z
+# ---------------------------------------------------------------------------
+
+def figure1_surface_comparison(datasets, waypoints):
+    """3-panel map: temp_2m + wind barbs + MSLP contours, valid 23Z."""
+    fig, axes = plt.subplots(
+        1, 3, figsize=(18, 6),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+    )
+    # Valid 23Z corresponds to: 15Z+f08, 16Z+f07, 17Z+f06
+    fxx_map = {15: 8, 16: 7, 17: 6}
+
+    for idx, ih in enumerate(INIT_HOURS):
+        ax = axes[idx]
+        ds = datasets[ih]
+        fxx = fxx_map[ih]
+
+        # Find the time index for valid 23Z
+        target_valid = np.datetime64(f"{DATE}T23:00:00")
+        time_vals = ds.time.values
+        t_idx = int(np.argmin(np.abs(time_vals - target_valid)))
+        ds_t = ds.isel(time=t_idx)
+
+        lat, lon = _get_latlon(ds_t)
+        temp_C = _temp_K_to_C(ds_t["temp_2m"].values)
+        mslp_hpa = _pa_to_hpa(ds_t["mslp"].values)
+        u = ds_t["wind_u_10m"].values
+        v = ds_t["wind_v_10m"].values
+
+        # Temperature fill
+        cf = ax.pcolormesh(
+            lon, lat, temp_C,
+            cmap="RdYlBu_r", vmin=-10, vmax=15,
+            shading="nearest", transform=ccrs.PlateCarree(),
+        )
+
+        # MSLP contours
+        try:
+            ax.contour(
+                lon, lat, mslp_hpa,
+                levels=np.arange(960, 1060, 2),
+                colors="black", linewidths=0.6,
+                transform=ccrs.PlateCarree(),
+            )
+        except Exception:
+            pass
+
+        # Wind barbs (thinned, in knots)
+        s = BARB_SKIP
+        ax.barbs(
+            lon[::s, ::s], lat[::s, ::s],
+            u[::s, ::s] * KT_FACTOR, v[::s, ::s] * KT_FACTOR,
+            length=5, linewidth=0.4,
+            transform=ccrs.PlateCarree(),
+        )
+
+        _add_map_features(ax)
+        _add_waypoints(ax, waypoints)
+
+        actual_valid = str(ds.time.values[t_idx])[:16]
+        ax.set_title(
+            f"Init {ih:02d}Z (f{fxx:03d})\nValid {actual_valid}Z",
+            fontsize=TITLE_SIZE,
+        )
+
+    # Shared colorbar
+    cbar = fig.colorbar(cf, ax=axes, orientation="horizontal", shrink=0.6, pad=0.08)
+    cbar.set_label("2-m Temperature (C)", fontsize=LABEL_SIZE)
+    cbar.ax.tick_params(labelsize=TICK_SIZE)
+
+    fig.suptitle(
+        "HRRR 2-m Temperature, 10-m Wind, MSLP | Valid ~23Z 22 Feb 2025",
+        fontsize=TITLE_SIZE + 2, y=1.02,
+    )
+    _annotate(fig)
+    fig.subplots_adjust(wspace=0.05)
+    out = OUTDIR / "fig1_surface_comparison.png"
+    fig.savefig(out, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 2: Wind speed evolution, 16Z run (4x3 panels)
+# ---------------------------------------------------------------------------
+
+def figure2_wind_evolution(datasets, waypoints):
+    """4x3 panel grid of wind speed from the 16Z run, f00-f12."""
+    ds = datasets[16]
+    ntimes = ds.sizes["time"]
+    nrows, ncols = 4, 3
+    npanels = nrows * ncols
+
+    fig, axes = plt.subplots(
+        nrows, ncols, figsize=(16, 18),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+    )
+    axes_flat = axes.flatten()
+
+    cf = None
+    for t_idx in range(min(ntimes, npanels)):
+        ax = axes_flat[t_idx]
+        ds_t = ds.isel(time=t_idx)
+        lat, lon = _get_latlon(ds_t)
+        wspd = ds_t["wind_speed_10m"].values
+        u = ds_t["wind_u_10m"].values
+        v = ds_t["wind_v_10m"].values
+
+        cf = ax.pcolormesh(
+            lon, lat, wspd,
+            cmap="YlOrRd", vmin=0, vmax=15,
+            shading="nearest", transform=ccrs.PlateCarree(),
+        )
+
+        s = BARB_SKIP
+        ax.barbs(
+            lon[::s, ::s], lat[::s, ::s],
+            u[::s, ::s] * KT_FACTOR, v[::s, ::s] * KT_FACTOR,
+            length=4, linewidth=0.3,
+            transform=ccrs.PlateCarree(),
+        )
+
+        _add_map_features(ax)
+        _add_waypoints(ax, waypoints, fontsize=5)
+
+        valid_str = str(ds.time.values[t_idx])[:16]
+        ax.set_title(f"f{t_idx:03d} | Valid {valid_str}Z", fontsize=TICK_SIZE)
+
+    # Hide unused panels
+    for j in range(min(ntimes, npanels), npanels):
+        axes_flat[j].set_visible(False)
+
+    cbar = fig.colorbar(cf, ax=axes, orientation="horizontal", shrink=0.5, pad=0.03)
+    cbar.set_label("10-m Wind Speed (m/s)", fontsize=LABEL_SIZE)
+    cbar.ax.tick_params(labelsize=TICK_SIZE)
+
+    fig.suptitle(
+        "HRRR 16Z Init | 10-m Wind Speed + Barbs | 22 Feb 2025",
+        fontsize=TITLE_SIZE + 2, y=1.0,
+    )
+    _annotate(fig)
+    fig.subplots_adjust(hspace=0.15, wspace=0.05)
+    out = OUTDIR / "fig2_wind_evolution.png"
+    fig.savefig(out, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 3: Time series comparison at waypoints (temp + wind speed)
+# ---------------------------------------------------------------------------
+
+def figure3_timeseries(wp_series, obs_df, waypoints):
+    """3x2 panel: temp_2m and wind_speed at each foehn_path waypoint."""
+    fig, axes = plt.subplots(3, 2, figsize=(14, 12), sharex=True)
+    axes_flat = axes.flatten()
+
+    for idx, wp_name in enumerate(WP_NAMES):
+        ax = axes_flat[idx]
+        ax2 = ax.twinx()
+
+        for ih in INIT_HOURS:
+            df = wp_series[ih]
+            wp_df = df.filter(df["waypoint"] == wp_name).sort("valid_time")
+            if wp_df.is_empty():
+                continue
+
+            times = wp_df["valid_time"].to_list()
+            style = RUN_STYLES[ih]
+
+            # Temperature (K -> C)
+            if "temp_2m" in wp_df.columns:
+                temp_C = [t - 273.15 if t is not None else np.nan
+                          for t in wp_df["temp_2m"].to_list()]
+                ax.plot(times, temp_C, color=style["color"], ls=style["ls"],
+                        linewidth=1.5, label=f"T {style['label']}")
+
+            # Wind speed
+            if "wind_speed_10m" in wp_df.columns:
+                wspd = wp_df["wind_speed_10m"].to_list()
+                ax2.plot(times, wspd, color=style["color"], ls=style["ls"],
+                         linewidth=1.0, alpha=0.6, label=f"WS {style['label']}")
+
+        # Overlay obs if available
+        if obs_df is not None:
+            try:
+                obs_wp = obs_df.filter(obs_df["waypoint"] == wp_name).sort("valid_time")
+                if not obs_wp.is_empty():
+                    obs_times = obs_wp["valid_time"].to_list()
+                    if "temp_2m" in obs_wp.columns:
+                        obs_temp = obs_wp["temp_2m"].to_list()
+                        ax.scatter(obs_times, obs_temp, c="black", s=8, marker="o",
+                                   zorder=5, label="Obs T")
+                    if "wind_speed_10m" in obs_wp.columns:
+                        obs_ws = obs_wp["wind_speed_10m"].to_list()
+                        ax2.scatter(obs_times, obs_ws, c="black", s=8, marker="x",
+                                    zorder=5, label="Obs WS")
+            except Exception:
+                pass
+
+        elev = waypoints[wp_name]["elevation_m"]
+        ax.set_title(
+            f"{wp_name.replace('_', ' ').title()} ({elev} m)",
+            fontsize=TITLE_SIZE,
+        )
+        ax.set_ylabel("Temp (C)", fontsize=LABEL_SIZE, color="tab:red")
+        ax2.set_ylabel("Wind Speed (m/s)", fontsize=LABEL_SIZE, color="tab:blue")
+        ax.tick_params(labelsize=TICK_SIZE)
+        ax2.tick_params(labelsize=TICK_SIZE)
+        ax.grid(True, alpha=0.3)
+
+        if idx == 0:
+            lines1, labels1 = ax.get_legend_handles_labels()
+            lines2, labels2 = ax2.get_legend_handles_labels()
+            ax.legend(lines1 + lines2, labels1 + labels2, fontsize=6, loc="upper left")
+
+    # Format x-axis
+    for ax_row in axes[-1]:
+        ax_row.set_xlabel("Valid Time (UTC)", fontsize=LABEL_SIZE)
+        for label in ax_row.get_xticklabels():
+            label.set_rotation(30)
+            label.set_ha("right")
+
+    fig.suptitle(
+        "HRRR 2-m Temp & 10-m Wind Speed at Foehn Path Waypoints | 22 Feb 2025",
+        fontsize=TITLE_SIZE + 2,
+    )
+    _annotate(fig)
+    fig.tight_layout()
+    out = OUTDIR / "fig3_timeseries.png"
+    fig.savefig(out, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 4: PBL height evolution
+# ---------------------------------------------------------------------------
+
+def figure4_pbl_height(wp_series, waypoints):
+    """3x2 panel: PBL height vs time at each waypoint."""
+    fig, axes = plt.subplots(3, 2, figsize=(14, 12), sharex=True)
+    axes_flat = axes.flatten()
+
+    for idx, wp_name in enumerate(WP_NAMES):
+        ax = axes_flat[idx]
+
+        for ih in INIT_HOURS:
+            df = wp_series[ih]
+            wp_df = df.filter(df["waypoint"] == wp_name).sort("valid_time")
+            if wp_df.is_empty() or "pbl_height" not in wp_df.columns:
+                continue
+
+            times = wp_df["valid_time"].to_list()
+            pbl = wp_df["pbl_height"].to_list()
+            style = RUN_STYLES[ih]
+            ax.plot(times, pbl, color=style["color"], ls=style["ls"],
+                    linewidth=1.5, label=style["label"])
+
+        # Shade the erosion window (roughly 20Z-00Z)
+        try:
+            erosion_start = datetime.datetime(2025, 2, 22, 20, 0)
+            erosion_end = datetime.datetime(2025, 2, 23, 0, 0)
+            ax.axvspan(erosion_start, erosion_end, alpha=0.1, color="orange",
+                       label="Erosion window")
+        except Exception:
+            pass
+
+        elev = waypoints[wp_name]["elevation_m"]
+        ax.set_title(
+            f"{wp_name.replace('_', ' ').title()} ({elev} m)",
+            fontsize=TITLE_SIZE,
+        )
+        ax.set_ylabel("PBL Height (m)", fontsize=LABEL_SIZE)
+        ax.tick_params(labelsize=TICK_SIZE)
+        ax.grid(True, alpha=0.3)
+
+        if idx == 0:
+            ax.legend(fontsize=7, loc="upper left")
+
+    for ax_row in axes[-1]:
+        ax_row.set_xlabel("Valid Time (UTC)", fontsize=LABEL_SIZE)
+        for label in ax_row.get_xticklabels():
+            label.set_rotation(30)
+            label.set_ha("right")
+
+    fig.suptitle(
+        "HRRR PBL Height at Foehn Path Waypoints | 22 Feb 2025",
+        fontsize=TITLE_SIZE + 2,
+    )
+    _annotate(fig)
+    fig.tight_layout()
+    out = OUTDIR / "fig4_pbl_height.png"
+    fig.savefig(out, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 5: Pressure-level cross-section (W->E along ~40.3N)
+# ---------------------------------------------------------------------------
+
+def figure5_cross_section(ds_pl, waypoints):
+    """W-E cross-section of temperature and wind at ~40.3N, valid 23Z."""
+    ds_t = ds_pl.isel(time=0)  # only one time step (f07 -> valid 23Z)
+    lat2d = ds_t["latitude"].values
+    lon2d = _lon_to_180(ds_t["longitude"].values)
+
+    # Find the y-index closest to 40.3N (average across x dimension)
+    lat_mean = lat2d.mean(axis=1) if lat2d.ndim == 2 else lat2d
+    y_target = int(np.argmin(np.abs(lat_mean - 40.3)))
+
+    # Extract longitude along this row
+    if lon2d.ndim == 2:
+        lons = lon2d[y_target, :]
+    else:
+        lons = lon2d
+
+    # Gather temperature and wind for each pressure level
+    levels = PL_LEVELS
+    temp_xsec = np.full((len(levels), len(lons)), np.nan)
+    wspd_xsec = np.full((len(levels), len(lons)), np.nan)
+    u_xsec = np.full((len(levels), len(lons)), np.nan)
+
+    for li, lv in enumerate(levels):
+        tname = f"temp_{lv}"
+        uname = f"wind_u_{lv}"
+        vname = f"wind_v_{lv}"
+        if tname in ds_t.data_vars:
+            tdata = ds_t[tname].values
+            temp_xsec[li, :] = tdata[y_target, :] if tdata.ndim == 2 else tdata
+        if uname in ds_t.data_vars and vname in ds_t.data_vars:
+            udata = ds_t[uname].values
+            vdata = ds_t[vname].values
+            u_row = udata[y_target, :] if udata.ndim == 2 else udata
+            v_row = vdata[y_target, :] if vdata.ndim == 2 else vdata
+            wspd_xsec[li, :] = np.sqrt(u_row ** 2 + v_row ** 2)
+            u_xsec[li, :] = u_row
+
+    # Compute potential temperature: theta = T * (1000/p)^(R/cp)
+    # R/cp = 0.286
+    p_arr = np.array(levels).reshape(-1, 1)
+    theta_xsec = temp_xsec * (1000.0 / p_arr) ** 0.286
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    # Potential temperature fill
+    cf = ax.pcolormesh(
+        lons, levels, theta_xsec,
+        cmap="RdYlBu_r", shading="nearest",
+    )
+    cbar = fig.colorbar(cf, ax=ax, pad=0.02)
+    cbar.set_label("Potential Temperature (K)", fontsize=LABEL_SIZE)
+    cbar.ax.tick_params(labelsize=TICK_SIZE)
+
+    # Wind speed contours
+    try:
+        cs = ax.contour(
+            lons, levels, wspd_xsec,
+            levels=np.arange(2, 30, 2),
+            colors="black", linewidths=0.6,
+        )
+        ax.clabel(cs, fontsize=6, fmt="%.0f")
+    except Exception:
+        pass
+
+    # Wind barbs on the cross-section (zonal component only; no omega available)
+    barb_skip_x = 4
+    barb_skip_z = 1
+    lon_barb = lons[::barb_skip_x]
+    lev_barb = np.array(levels)[::barb_skip_z]
+    u_barb = u_xsec[::barb_skip_z, ::barb_skip_x] * KT_FACTOR
+    # No vertical component, set to zero
+    w_barb = np.zeros_like(u_barb)
+    lon_grid, lev_grid = np.meshgrid(lon_barb, lev_barb)
+    ax.barbs(lon_grid, lev_grid, u_barb, w_barb, length=5, linewidth=0.4)
+
+    ax.set_ylim(max(levels), min(levels))  # pressure inverted
+    ax.set_ylabel("Pressure (hPa)", fontsize=LABEL_SIZE)
+    ax.set_xlabel("Longitude", fontsize=LABEL_SIZE)
+    ax.tick_params(labelsize=TICK_SIZE)
+
+    # Mark waypoint longitudes with vertical lines and top-axis labels
+    ax2 = ax.twiny()
+    wp_lons = []
+    wp_labels = []
+    for name, wp in waypoints.items():
+        ax.axvline(wp["lon"], color="gray", ls=":", lw=0.5)
+        wp_lons.append(wp["lon"])
+        wp_labels.append(name.replace("_", " ").title())
+    ax2.set_xlim(ax.get_xlim())
+    ax2.set_xticks(wp_lons)
+    ax2.set_xticklabels(wp_labels, fontsize=6, rotation=35, ha="left")
+
+    ax.set_title(
+        "W-E Cross-Section ~40.3N | HRRR 16Z f07 (Valid 23Z) | 22 Feb 2025",
+        fontsize=TITLE_SIZE,
+    )
+    _annotate(fig)
+    fig.tight_layout()
+    out = OUTDIR / "fig5_cross_section.png"
+    fig.savefig(out, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 6: MSLP + temperature tendency
+# ---------------------------------------------------------------------------
+
+def figure6_mslp_tendency(datasets, waypoints):
+    """2-panel: MSLP at 23Z and 3-hr temperature change (23Z - 20Z)."""
+    ds = datasets[16]
+    target_23z = np.datetime64(f"{DATE}T23:00:00")
+    target_20z = np.datetime64(f"{DATE}T20:00:00")
+    time_vals = ds.time.values
+
+    t_idx_23 = int(np.argmin(np.abs(time_vals - target_23z)))
+    t_idx_20 = int(np.argmin(np.abs(time_vals - target_20z)))
+
+    ds_23 = ds.isel(time=t_idx_23)
+    ds_20 = ds.isel(time=t_idx_20)
+
+    lat, lon = _get_latlon(ds_23)
+    mslp_hpa = _pa_to_hpa(ds_23["mslp"].values)
+    temp_23_C = _temp_K_to_C(ds_23["temp_2m"].values)
+    temp_20_C = _temp_K_to_C(ds_20["temp_2m"].values)
+    dtemp = temp_23_C - temp_20_C
+
+    fig, axes = plt.subplots(
+        1, 2, figsize=(16, 6),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+    )
+
+    # Left: MSLP
+    ax = axes[0]
+    mslp_levels = np.arange(
+        np.floor(np.nanmin(mslp_hpa) / 2) * 2,
+        np.ceil(np.nanmax(mslp_hpa) / 2) * 2 + 2,
+        2,
+    )
+    cf = ax.pcolormesh(
+        lon, lat, mslp_hpa,
+        cmap="viridis", shading="nearest",
+        transform=ccrs.PlateCarree(),
+    )
+    try:
+        cs = ax.contour(
+            lon, lat, mslp_hpa,
+            levels=mslp_levels, colors="black", linewidths=0.6,
+            transform=ccrs.PlateCarree(),
+        )
+        ax.clabel(cs, fontsize=6, fmt="%.0f")
+    except Exception:
+        pass
+    _add_map_features(ax)
+    _add_waypoints(ax, waypoints)
+    cbar = fig.colorbar(cf, ax=ax, orientation="horizontal", shrink=0.8, pad=0.08)
+    cbar.set_label("MSLP (hPa)", fontsize=LABEL_SIZE)
+    cbar.ax.tick_params(labelsize=TICK_SIZE)
+    actual_valid = str(ds.time.values[t_idx_23])[:16]
+    ax.set_title(f"MSLP | Valid {actual_valid}Z", fontsize=TITLE_SIZE)
+
+    # Right: Temperature tendency
+    ax = axes[1]
+    cf2 = ax.pcolormesh(
+        lon, lat, dtemp,
+        cmap="RdBu_r", vmin=-8, vmax=8,
+        shading="nearest", transform=ccrs.PlateCarree(),
+    )
+    _add_map_features(ax)
+    _add_waypoints(ax, waypoints)
+    cbar2 = fig.colorbar(cf2, ax=ax, orientation="horizontal", shrink=0.8, pad=0.08)
+    cbar2.set_label("3-hr Temp Change (C)", fontsize=LABEL_SIZE)
+    cbar2.ax.tick_params(labelsize=TICK_SIZE)
+    valid_20 = str(ds.time.values[t_idx_20])[:16]
+    valid_23 = str(ds.time.values[t_idx_23])[:16]
+    ax.set_title(
+        f"Temp Tendency ({valid_23}Z - {valid_20}Z)",
+        fontsize=TITLE_SIZE,
+    )
+
+    fig.suptitle(
+        "HRRR 16Z Init | MSLP & Temperature Tendency | 22 Feb 2025",
+        fontsize=TITLE_SIZE + 2, y=1.02,
+    )
+    _annotate(fig)
+    fig.tight_layout()
+    out = OUTDIR / "fig6_mslp_tendency.png"
+    fig.savefig(out, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    """Run the full case study pipeline."""
+    plt.style.use("default")
+
+    print("=" * 60)
+    print("Case Study: 22 Feb 2025 Uinta Basin Cold-Pool Erosion")
+    print("=" * 60)
+
+    waypoints = _load_waypoints()
+    src = NWPSource("hrrr")
+
+    # -- 1. Fetch surface data for all three runs --
+    print("\n[1/4] Fetching HRRR surface data (3 runs x 13 hours) ...")
+    sfc_datasets = fetch_surface_runs(src)
+
+    # -- 2. Fetch pressure-level data for 16Z run --
+    print("\n[2/4] Fetching HRRR pressure-level data (16Z, f07 only) ...")
+    ds_pl = fetch_pressure_levels(src)
+
+    # -- 3. Extract waypoint time series --
+    print("\n[3/4] Extracting waypoint time series ...")
+    wp_series = extract_waypoint_series(src, sfc_datasets)
+
+    # -- 4. Fetch observations (optional) --
+    print("\n[4/4] Fetching observations (optional) ...")
+    obs_df = fetch_observations()
+
+    # -- Generate figures --
+    print("\n" + "-" * 60)
+    print("Generating figures ...")
+    print("-" * 60)
+
+    print("\nFigure 1: Surface temperature comparison ...")
+    try:
+        figure1_surface_comparison(sfc_datasets, waypoints)
+    except Exception as exc:
+        print(f"  [ERROR] Figure 1 failed: {exc}")
+        import traceback; traceback.print_exc()
+
+    print("\nFigure 2: Wind speed evolution ...")
+    try:
+        figure2_wind_evolution(sfc_datasets, waypoints)
+    except Exception as exc:
+        print(f"  [ERROR] Figure 2 failed: {exc}")
+        import traceback; traceback.print_exc()
+
+    print("\nFigure 3: Time series at waypoints ...")
+    try:
+        figure3_timeseries(wp_series, obs_df, waypoints)
+    except Exception as exc:
+        print(f"  [ERROR] Figure 3 failed: {exc}")
+        import traceback; traceback.print_exc()
+
+    print("\nFigure 4: PBL height evolution ...")
+    try:
+        figure4_pbl_height(wp_series, waypoints)
+    except Exception as exc:
+        print(f"  [ERROR] Figure 4 failed: {exc}")
+        import traceback; traceback.print_exc()
+
+    print("\nFigure 5: Pressure-level cross-section ...")
+    try:
+        figure5_cross_section(ds_pl, waypoints)
+    except Exception as exc:
+        print(f"  [ERROR] Figure 5 failed: {exc}")
+        import traceback; traceback.print_exc()
+
+    print("\nFigure 6: MSLP + temperature tendency ...")
+    try:
+        figure6_mslp_tendency(sfc_datasets, waypoints)
+    except Exception as exc:
+        print(f"  [ERROR] Figure 6 failed: {exc}")
+        import traceback; traceback.print_exc()
+
+    print("\n" + "=" * 60)
+    print("Done. Figures saved to:", OUTDIR)
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `brc_tools.nwp.NWPSource` — model-agnostic Herbie wrapper driven by `lookups.toml`
- `brc_tools.obs.ObsSource` — SynopticPy wrapper sharing the same alias namespace
- TOML-driven alias registry: one file for all models, regions, waypoints, variables
- Flat (hour × variable) parallel fetch via ThreadPoolExecutor — **7.3x speedup** (54s → 7s)
- Per-GRIB file locking via `fasteners.InterProcessLock` — safe at any `max_workers` count
- Case study script: 22 Feb 2025 Uinta Basin cold-pool erosion (6 figures)

## Key design
Adding a new model = one TOML block. Adding a new variable = one TOML block. No code changes for either. NWP and obs share canonical alias names so joins are trivial.

## Verified
- HRRR surface: 7h × 5var fetched, cropped to Uinta Basin, waypoint extraction at 6 foehn-path stations — physically correct values
- All Herbie search strings verified against live GRIB inventory for 2025-02-22 16Z
- 3 existing unit tests pass
- Thread-safe under concurrent access (fasteners lock)

## Test plan
- [x] `pytest tests/test_road_forecast_logic.py` — 3 passed
- [x] `NWPSource("hrrr").fetch(...)` returns cropped Dataset with correct variable names
- [x] `extract_at_waypoints()` returns distinct per-waypoint values
- [x] Parallel fetch produces identical output to sequential
- [ ] GEFS and RRFS fetch (not yet tested — search strings from TOML, needs inventory check)
- [ ] ObsSource integration (requires Synoptic API token)

Refs #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)