### PR TITLE
feat(push): BASINWX_API_URLS fan-out for dual-site uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ This package is deployed on CHPC to push weather data to BasinWX.
 
 **Cross-repo data contract:** see [`docs/CROSS-REPO-SYNC.md`](docs/CROSS-REPO-SYNC.md).
 
+### Upload destinations (fan-out)
+
+Uploads can target one or more servers (e.g. production + dev). Resolution
+order used by `load_config_urls()` in `brc_tools/download/push_data.py`:
+
+1. `BASINWX_API_URLS` env var — comma-separated list. First URL is primary
+   (failure raises), remaining URLs are best-effort mirrors (failure logged
+   as WARN but non-fatal).
+2. `~/.config/ubair-website/website_urls` — same format, file fallback.
+3. `~/.config/ubair-website/website_url` — legacy single-URL file, preserved
+   for back-compat.
+
+Example:
+
+```bash
+export BASINWX_API_URLS="https://basinwx.com,https://basinwx.dev"
+```
+
+Use this for dual-site pushes from CHPC. For one-shot dev uploads, the
+HRRR export CLI also accepts `--server-url` as a single-URL override.
+
+### Why `send_json_to_server` is preserved
+
+`brc_tools.download.push_data.send_json_to_server(server, fpath, bucket, key)`
+retains its original single-URL signature because **the `clyfar` repo imports
+it directly**. New brc-tools code should use `send_json_to_all(urls, ...)`
+instead; the legacy function stays intact until `clyfar` migrates (tracked as
+a follow-up, needs a cross-repo PR per
+[`docs/CROSS-REPO-SYNC.md`](docs/CROSS-REPO-SYNC.md)).
+
 ## Authors
 
 John Lawson and Michael Davies, Bingham Research Center, 2025

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -41,3 +41,35 @@ Important before onboarding new contributors.
 - [ ] GitHub Actions CI/CD (run pytest + ruff on PRs).
 - [ ] Pre-commit hooks for code quality.
 - [ ] `CONTRIBUTING.md` with git workflow (document for range of experience levels).
+
+## Priority 5: Documentation and agent onboarding
+
+Deferred from Phase 2 of the dual-site fan-out work (2026-04-23); parked
+here so the next cold-start agent knows to tackle it.
+
+- [ ] **CLAUDE.md overhaul** — current file is accurate but grew ad-hoc.
+  Goal: reorganise around "what an AI agent needs to know on a cold start"
+  with clear sections for (a) active pipelines + cadences, (b) load-bearing
+  data-flow anchors, (c) quick-start for case-study construction, (d) what
+  *not* to change without a cross-repo PR. Keep it under 200 lines.
+- [ ] **Roadmap brainstorm** — prepare a small doc (`docs/ROADMAP.md` or
+  similar) that captures the next 6–12 months of work in outcome terms, not
+  task lists. Input to the CLAUDE.md overhaul.
+- [ ] **Prune root + file contents** for AI-and-human readability: remove
+  stale `docs/` entries (PIPELINE-ARCHITECTURE aspirational, `nwp/MERGE-PLAN`
+  historical), consolidate `docs/nwp/` archive, and make sure every top-level
+  file earns its place.
+- [ ] **Update "Key data-flow anchor" in CLAUDE.md** post-fan-out to mention
+  `send_json_to_all` + `BASINWX_API_URLS` (small; bundle with the overhaul
+  above unless a cold-start agent wants a quick win first).
+
+## Priority 6: Seasonal ops (pause/resume)
+
+- [ ] **Clyfar/FFION/GEFS-plot pipelines paused end-March 2026** for the
+  season; resume ~October 2026. When resuming, verify they still use the new
+  fan-out path (`send_json_to_all`) — check clyfar's import site first since
+  it still uses the legacy `send_json_to_server`.
+- [ ] **HRRR surface-layer cron** needs installing on the CHPC cron host
+  once fan-out is shipped. Template in `CLAUDE.md` under "HRRR surface layer
+  export" (adjust cadence and `--server-url` as needed once `BASINWX_API_URLS`
+  is set).

--- a/brc_tools/download/get_map_obs.py
+++ b/brc_tools/download/get_map_obs.py
@@ -16,7 +16,7 @@ from synoptic.services import Metadata, Latest, TimeSeries
 from brc_tools.utils.lookups import obs_map_vrbls, obs_map_stids
 from brc_tools.download.download_funcs import generate_json_fpath
 from brc_tools.download.push_data import (clean_dataframe_for_json, save_json,
-                                          send_json_to_server, load_config)
+                                          send_json_to_all, load_config_urls)
 from brc_tools.utils.util_funcs import get_current_datetime
 
 
@@ -81,14 +81,13 @@ if __name__ == "__main__":
     clean_df = clean_dataframe_for_json(latest_obs)
     save_json(clean_df, map_fpath)
 
-    # This is where I want to send json to the website server
     send_json = True
     if send_json:
-        # tempdir = os.environ.get('TMP_DIR')
-        API_KEY, server_url = load_config()
-        print(f"Using API key {API_KEY[:5]}... and server URL starting"
-              f" {server_url[:10]}")
+        API_KEY, server_urls = load_config_urls()
+        print(f"Using API key {API_KEY[:5]}... and {len(server_urls)} URL(s): "
+              f"primary={server_urls[0]}"
+              + (f", mirrors={server_urls[1:]}" if len(server_urls) > 1 else ""))
 
         for f, data_type in (
                 (meta_fpath, "metadata"), (map_fpath, "observations")):
-            send_json_to_server(server_url, f, data_type, API_KEY)
+            send_json_to_all(server_urls, f, data_type, API_KEY)

--- a/brc_tools/download/get_road_forecast.py
+++ b/brc_tools/download/get_road_forecast.py
@@ -253,10 +253,10 @@ def main() -> int:
 
     if args.upload and not args.dry_run:
         try:
-            from brc_tools.download.push_data import load_config, send_json_to_server
+            from brc_tools.download.push_data import load_config_urls, send_json_to_all
 
-            api_key, server_url = load_config()
-            send_json_to_server(server_url, output_path, args.upload_bucket, api_key)
+            api_key, server_urls = load_config_urls()
+            send_json_to_all(server_urls, output_path, args.upload_bucket, api_key)
         except Exception as exc:
             LOG.error("Road forecast upload failed: %s", exc)
             return 1

--- a/brc_tools/download/push_data.py
+++ b/brc_tools/download/push_data.py
@@ -33,67 +33,113 @@ def save_json(df, fpath, orient='records'):
     return
 
 
-def send_json_to_server(server_address, fpath, file_data, API_KEY):
+def _post_json_to_url(server_address, fpath, file_data, api_key, *, role="PRIMARY"):
+    """Upload one JSON file to one server. Return True on HTTP 200."""
     endpoint = f"{server_address}/api/upload/{file_data}"
     hostname = socket.getfqdn()
+    headers = {'x-api-key': api_key, 'x-client-hostname': hostname}
+    prefix = f"[{role} {server_address}]"
 
-    headers = {
-        'x-api-key': API_KEY,
-        'x-client-hostname': hostname
-    }
-
-    # Test basic connectivity first
     try:
         health_response = requests.get(f"{server_address}/api/health", timeout=10)
-        print(f"Health check: {health_response.status_code}")
+        print(f"{prefix} health {health_response.status_code}")
     except requests.exceptions.RequestException as e:
-        print(f"Health check failed: {e}")
-        return
+        print(f"{prefix} health check failed: {e}")
+        return False
 
-    # Prepare upload file
-    print(f"Uploading {os.path.basename(fpath)} to {endpoint}...")
+    print(f"{prefix} uploading {os.path.basename(fpath)} to {endpoint}")
     try:
         with open(fpath, 'rb') as f:
             files = {'file': (os.path.basename(fpath), f, 'application/json')}
-
-            # Send the file
-            response = requests.post(
-                endpoint,
-                files=files,
-                headers=headers,
-                timeout=30,
-            )
-
+            response = requests.post(endpoint, files=files, headers=headers, timeout=30)
         if response.status_code == 200:
-            print(f"✅ Successfully uploaded {os.path.basename(fpath)}")
-        else:
-            print(f"❌ Upload failed ({response.status_code}): {response.text}")
+            print(f"{prefix} ✅ uploaded {os.path.basename(fpath)}")
+            return True
+        print(f"{prefix} ❌ upload failed ({response.status_code}): {response.text}")
+        return False
     except requests.exceptions.Timeout:
-        print(f"❌ Upload timed out after 30 seconds")
+        print(f"{prefix} ❌ upload timed out after 30s")
+        return False
     except requests.exceptions.RequestException as e:
-        print(f"❌ Upload error: {e}")
+        print(f"{prefix} ❌ upload error: {e}")
+        return False
+
+
+def send_json_to_server(server_address, fpath, file_data, API_KEY):
+    """Upload JSON to a single server. Preserved for the clyfar import contract."""
+    _post_json_to_url(server_address, fpath, file_data, API_KEY, role="PRIMARY")
+
+
+def send_json_to_all(server_addresses, fpath, file_data, api_key):
+    """Fan-out upload. First URL is primary (failure raises), rest are mirrors
+    (failure logged, non-fatal). Returns a {url: ok} mapping.
+    """
+    if not server_addresses:
+        raise ValueError("server_addresses is empty")
+
+    results = {}
+    for idx, url in enumerate(server_addresses):
+        role = "PRIMARY" if idx == 0 else "MIRROR"
+        results[url] = _post_json_to_url(url, fpath, file_data, api_key, role=role)
+
+    primary = server_addresses[0]
+    mirror_failures = [u for u in server_addresses[1:] if not results[u]]
+    if mirror_failures:
+        print(f"WARNING mirror uploads failed: {', '.join(mirror_failures)}")
+    if not results[primary]:
+        raise RuntimeError(f"Primary upload to {primary} failed for {fpath}")
+    return results
+
+
+def _read_url_file(path):
+    with open(path, 'r') as f:
+        raw = f.read()
+    return [u.strip().rstrip('/') for u in raw.replace('\n', ',').split(',') if u.strip()]
+
 
 def load_config():
-    """Load API key and website URL from file.
-
-    TODO: explain how this works!
+    """Single-URL config loader. Preserved for the clyfar import contract.
+    Returns (api_key, primary_url). New brc-tools code should use load_config_urls().
     """
+    api_key, urls = load_config_urls()
+    return api_key, urls[0]
 
+
+def load_config_urls():
+    """Load API key and the full list of upload destinations.
+
+    Resolution order for URLs:
+      1. BASINWX_API_URLS env var (comma-separated; first = primary, rest = mirrors).
+      2. ~/.config/ubair-website/website_urls (comma- or newline-separated).
+      3. ~/.config/ubair-website/website_url (legacy single URL → one-element list).
+    API key is always read from DATA_UPLOAD_API_KEY.
+    """
     api_key = os.environ.get('DATA_UPLOAD_API_KEY')
-    config_dir = os.path.join(os.path.expanduser('~'), '.config',
-                              'ubair-website')
     if not api_key:
         raise ValueError("DATA_UPLOAD_API_KEY environment variable not set")
     if len(api_key) != 32:
         raise ValueError(f"API key should be 32 characters (hex), got {len(api_key)}")
 
+    env_urls = os.environ.get('BASINWX_API_URLS', '').strip()
+    if env_urls:
+        urls = [u.strip().rstrip('/') for u in env_urls.split(',') if u.strip()]
+        if urls:
+            return api_key, urls
 
-    # Read website URL
-    url_file = os.path.join(config_dir, 'website_url')
-    if not os.path.exists(url_file):
-        raise FileNotFoundError("Website URL file not found. Check docs for setup.")
+    config_dir = os.path.join(os.path.expanduser('~'), '.config', 'ubair-website')
+    plural = os.path.join(config_dir, 'website_urls')
+    if os.path.exists(plural):
+        urls = _read_url_file(plural)
+        if urls:
+            return api_key, urls
 
-    with open(url_file, 'r') as f:
-        website_url = f.read().strip()
+    singular = os.path.join(config_dir, 'website_url')
+    if os.path.exists(singular):
+        urls = _read_url_file(singular)
+        if urls:
+            return api_key, urls
 
-    return api_key, website_url
+    raise FileNotFoundError(
+        "No upload URL found. Set BASINWX_API_URLS or create "
+        "~/.config/ubair-website/website_urls (see docs for setup)."
+    )

--- a/brc_tools/nwp/basinwx.py
+++ b/brc_tools/nwp/basinwx.py
@@ -246,12 +246,12 @@ def export_latest_surface_layers(
     written_paths.append(index_path)
 
     if upload:
-        from brc_tools.download.push_data import load_config, send_json_to_server
+        from brc_tools.download.push_data import load_config_urls, send_json_to_all
 
-        api_key, config_url = load_config()
-        url = server_url or config_url
+        api_key, config_urls = load_config_urls()
+        urls = [server_url] if server_url else config_urls
         for path in written_paths:
-            send_json_to_server(url, str(path), upload_bucket, api_key)
+            send_json_to_all(urls, str(path), upload_bucket, api_key)
 
     return written_paths
 

--- a/in_progress/README.md
+++ b/in_progress/README.md
@@ -1,2 +1,59 @@
-# In Progress or under modification...
-As we get the repository on its feet, this will be a place for messy code before we can begin branching etc. 
+# `in_progress/` — mining archive
+
+Old exploratory code kept deliberately so patterns can be lifted into
+`brc_tools/` when needed. **Do not edit these files** — treat them as
+read-only snapshots. To reuse a pattern, extract it into the library
+and reference the source commit in the new module.
+
+## Status key
+- **mine** — contains ideas or code worth lifting. Named below with the idea.
+- **stale** — superseded by current library; kept only for history.
+- **broken** — runs network/import side-effects at module load; excluded from `pytest` via `pyproject.toml` `testpaths = ["tests"]`.
+
+## Index
+
+### Top level
+| File                     | Status  | Mine for |
+|--------------------------|---------|----------|
+| `download_hrrr.ipynb`    | mine    | Early Herbie→xarray patterns, region subsetting. Most ideas now in `brc_tools/nwp/source.py`; re-check before extending NWPSource. |
+| `download_rrfs.ipynb`    | mine    | RRFS-specific Herbie quirks. Compare against `lookups.toml` RRFS entries. |
+| `download_aqm.ipynb`     | mine    | AQM exploration; nothing in `brc_tools/` yet (see WISHLIST "Move AQM code"). Starting point if you need AQM. |
+| `xsection.ipynb`         | mine    | Cross-section prototype. WISHLIST Priority 3. Mine pressure-level interpolation logic. |
+
+### `aqm/`
+Pre-library AQM exploration — patterns to lift when `brc_tools/models/aqm.py` is built (WISHLIST item).
+
+| File                        | Status  | Mine for |
+|-----------------------------|---------|----------|
+| `aqm_explorer.py`           | mine    | Main AQM exploration code path. |
+| `updated-aqm-explorer.py`   | mine    | Later iteration; diff against `aqm_explorer.py` to see what changed. |
+| `simple_aqm_explorer.py`    | mine    | Minimal variant — good starting scaffold. |
+| `aqm-demo.py`               | stale   | Thin demo; use explorer variants instead. |
+| `aqm-claude-demo2.py`       | stale   | LLM-generated fragment; not self-contained. |
+| `ext_herbie_tests.ipynb`    | mine    | Herbie edge-case experiments. |
+| `hrrr_test.py`              | broken  | Runs `xr.merge` at import; excluded from test discovery. Mine for HRRR product query patterns only. |
+
+### `notebooks/`
+Gemini/o3-mini prompt experiments from a previous exploration phase. Most are redundant with current library; a few have novel ideas.
+
+| File                             | Status  | Mine for |
+|----------------------------------|---------|----------|
+| `hrrr_height_cross_section.py`   | mine    | Height-based vertical slicing — directly relevant to WISHLIST "Cross-section plotting". |
+| `hrrr_native_levels.py`          | mine    | Native-level HRRR access (vs pressure interpolation). Niche but useful. |
+| `hrrr_drybulb_option.py`         | mine    | Dry-bulb temperature handling — worth checking before extending derived fields. |
+| `kvel_wind.ipynb`                | stale   | Early KVEL exploration; superseded by `scripts/case_study_kvel_westerly.py` and `case_study_kvel_foehn.py`. |
+| `synoptic_raw_download.ipynb`    | stale   | Raw SynopticPy usage; superseded by `ObsSource`. |
+| `gemini_parallel-aqm.py`         | stale   | Parallelism experiment. |
+| `gemini_refactored-aqm.py`       | stale   | Refactor attempt. |
+| `gemini_rrfs_no_herbie.py`       | stale   | RRFS-without-Herbie — interesting only if Herbie is ever dropped. |
+| `gemini_tryhard_{gfs,hrrr,nam,rrfs}.py` | stale | Prompt-engineering attempts; nothing in them that isn't in current NWPSource. |
+| `o3_mini_high_rrfs.py`           | stale   | Similar territory. |
+
+## Workflow for extracting code
+1. Find the pattern you need (grep this index first, then the files).
+2. Write the new module in `brc_tools/`.
+3. Add a commit message referencing the source file, e.g. `feat(nwp): add cross-section helper (adapted from in_progress/notebooks/hrrr_height_cross_section.py)`.
+4. Do **not** delete the source file; leave the archive intact for future miners.
+
+## Before writing new exploration code
+Check whether it belongs in `scripts/` as a case study or directly in `brc_tools/` as a library function. Only fall back to `in_progress/` when the direction is genuinely unclear.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ Repository = "https://github.com/binghamresearchcenter/brc-tools.git"
 where = ["."]
 include = ["brc_tools*"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py39"

--- a/tests/test_push_data.py
+++ b/tests/test_push_data.py
@@ -1,0 +1,114 @@
+"""Tests for load_config_urls and send_json_to_all fan-out semantics."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from brc_tools.download import push_data
+
+
+VALID_KEY = "a" * 32
+
+
+@pytest.fixture
+def env_clear(monkeypatch):
+    monkeypatch.delenv("BASINWX_API_URLS", raising=False)
+    monkeypatch.setenv("DATA_UPLOAD_API_KEY", VALID_KEY)
+    return monkeypatch
+
+
+class TestLoadConfigUrls:
+    def test_env_var_wins(self, env_clear, tmp_path, monkeypatch):
+        env_clear.setenv("BASINWX_API_URLS", "https://a.example, https://b.example/")
+        monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path) if p == "~" else p)
+        api_key, urls = push_data.load_config_urls()
+        assert api_key == VALID_KEY
+        assert urls == ["https://a.example", "https://b.example"]
+
+    def test_plural_file_falls_back(self, env_clear, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".config" / "ubair-website"
+        config_dir.mkdir(parents=True)
+        (config_dir / "website_urls").write_text("https://one.example,https://two.example\n")
+        monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path) if p == "~" else p)
+        api_key, urls = push_data.load_config_urls()
+        assert urls == ["https://one.example", "https://two.example"]
+
+    def test_singular_file_back_compat(self, env_clear, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".config" / "ubair-website"
+        config_dir.mkdir(parents=True)
+        (config_dir / "website_url").write_text("https://only.example\n")
+        monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path) if p == "~" else p)
+        api_key, urls = push_data.load_config_urls()
+        assert urls == ["https://only.example"]
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("DATA_UPLOAD_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="DATA_UPLOAD_API_KEY"):
+            push_data.load_config_urls()
+
+    def test_wrong_length_key_raises(self, monkeypatch):
+        monkeypatch.setenv("DATA_UPLOAD_API_KEY", "short")
+        with pytest.raises(ValueError, match="32 characters"):
+            push_data.load_config_urls()
+
+    def test_no_source_raises(self, env_clear, tmp_path, monkeypatch):
+        monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path) if p == "~" else p)
+        with pytest.raises(FileNotFoundError):
+            push_data.load_config_urls()
+
+
+class TestSendJsonToAll:
+    def test_empty_urls_raise(self, tmp_path):
+        fpath = tmp_path / "x.json"
+        fpath.write_text("{}")
+        with pytest.raises(ValueError):
+            push_data.send_json_to_all([], str(fpath), "observations", VALID_KEY)
+
+    def test_primary_and_mirror_both_ok(self, tmp_path):
+        fpath = tmp_path / "x.json"
+        fpath.write_text("{}")
+        with mock.patch.object(push_data, "_post_json_to_url", return_value=True) as m:
+            results = push_data.send_json_to_all(
+                ["https://a", "https://b"], str(fpath), "observations", VALID_KEY
+            )
+        assert results == {"https://a": True, "https://b": True}
+        assert m.call_count == 2
+        roles = [kw["role"] for _, kw in [(c.args, c.kwargs) for c in m.call_args_list]]
+        assert roles == ["PRIMARY", "MIRROR"]
+
+    def test_mirror_failure_is_non_fatal(self, tmp_path, capsys):
+        fpath = tmp_path / "x.json"
+        fpath.write_text("{}")
+        with mock.patch.object(push_data, "_post_json_to_url", side_effect=[True, False]):
+            results = push_data.send_json_to_all(
+                ["https://primary", "https://mirror"], str(fpath), "observations", VALID_KEY
+            )
+        assert results == {"https://primary": True, "https://mirror": False}
+        captured = capsys.readouterr().out
+        assert "mirror uploads failed" in captured
+        assert "https://mirror" in captured
+
+    def test_primary_failure_raises(self, tmp_path):
+        fpath = tmp_path / "x.json"
+        fpath.write_text("{}")
+        with mock.patch.object(push_data, "_post_json_to_url", side_effect=[False, True]):
+            with pytest.raises(RuntimeError, match="Primary upload"):
+                push_data.send_json_to_all(
+                    ["https://primary", "https://mirror"], str(fpath), "observations", VALID_KEY
+                )
+
+
+class TestLegacyCompat:
+    def test_load_config_returns_primary(self, env_clear):
+        env_clear.setenv("BASINWX_API_URLS", "https://primary.example,https://mirror.example")
+        api_key, url = push_data.load_config()
+        assert api_key == VALID_KEY
+        assert url == "https://primary.example"
+
+    def test_send_json_to_server_signature_unchanged(self, tmp_path):
+        fpath = tmp_path / "x.json"
+        fpath.write_text("{}")
+        with mock.patch.object(push_data, "_post_json_to_url", return_value=True) as m:
+            push_data.send_json_to_server("https://a.example", str(fpath), "observations", VALID_KEY)
+        m.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds `send_json_to_all()` and `load_config_urls()` so CHPC can push the same JSON to basinwx.com + basinwx.dev (or any N URLs) from one call.
- Primary URL failure raises; mirror failures log WARN but don't fail the job — mirrors the semantics already implemented in `ubair-website/chpc-deployment/test_upload.sh`.
- Keeps `send_json_to_server()` and `load_config()` intact because `clyfar` imports them; their migration needs a separate cross-repo PR.

## Motivation
`ubair-website` PR #178 landed on `dev` on 2026-04-22 and introduced `BASINWX_API_URLS` as the canonical comma-separated fan-out env var. Until now `brc-tools` has only ever read a single URL (`~/.config/ubair-website/website_url`), so `basinwx.dev` was receiving nothing from CHPC. This change closes that gap.

Diagnostic on 2026-04-23: obs + metadata are landing fresh on `.com` (verified via `/api/filelist/observations`, 39 082 files, latest 18:00Z), but `.dev` had only `test_observation.json`. After this merges and `BASINWX_API_URLS` is set on the cron host, `.dev` will receive the same stream.

## Resolution order for upload URLs (`load_config_urls`)
1. `BASINWX_API_URLS` env var (comma-separated, first = primary, rest = mirrors).
2. `~/.config/ubair-website/website_urls` (plural file, same format).
3. `~/.config/ubair-website/website_url` (legacy singular file → one-element list).

Error if none present. `DATA_UPLOAD_API_KEY` env var is still the sole source for the API key.

## Migrated callers
- `brc_tools/download/get_map_obs.py` — obs + metadata.
- `brc_tools/nwp/basinwx.py` — HRRR surface layers; `--server-url` still works (wraps to one-element list).
- `brc_tools/download/get_road_forecast.py` — road forecast payload.

`brc_tools/download/push_outlook.py` is intentionally deferred: the FFION outlook pipeline is paused for the season (ended 2026-03-30) and will migrate when it next runs.

## Tests
`tests/test_push_data.py` — 12 new tests:
- `load_config_urls` env-var wins / plural-file fallback / singular-file back-compat / missing-key raises / wrong-length-key raises / no-source raises.
- `send_json_to_all` empty-urls raises / both-ok / mirror-failure-non-fatal (captures stdout to assert WARN) / primary-failure-raises.
- Legacy-compat: `load_config` returns primary URL; `send_json_to_server` signature unchanged.

`pyproject.toml` adds `testpaths = ["tests"]` so pytest no longer auto-imports `in_progress/aqm/hrrr_test.py` (which runs `xr.merge` at import and errors on conflicting variables). 61/61 tests pass.

## Docs bundled
- `README.md` — document fan-out resolution order and why `send_json_to_server` is preserved.
- `WISHLIST-TASKS.md` — Priority 5 (CLAUDE.md overhaul + roadmap brainstorm) and Priority 6 (seasonal ops pause/resume, HRRR cron install) added for the next cold-start agent.
- `in_progress/README.md` — rewritten as a mining index (every file tagged mine/stale/broken with what to lift from it) since we keep the archive rather than prune it.

## Test plan
- [x] `pytest` — 61 passed, 0 failed, 1 warning (pre-existing Herbie deprecation).
- [x] `send_json_to_server` signature byte-identical for `clyfar` compat (verified by `TestLegacyCompat::test_send_json_to_server_signature_unchanged`).
- [ ] After merge, on the cron host: `export BASINWX_API_URLS="https://basinwx.com,https://basinwx.dev"`, rerun `get_map_obs.py` once, verify `map_obs_*.json` appears at both `https://basinwx.{com,dev}/api/static/observations/` within ~30 s.
- [ ] Confirm `/api/filelist/observations` on both sites shows today's filename.

## Known follow-ups (not in this PR)
- Cron install for `scripts/export_hrrr_surface_layers.py` on the CHPC cron host (identify host first — not `notch137`).
- `/api/filelist.json` on `ubair-website` serves a 2025-07-31 fossil (`server/server.js:128-135`). Prefer `/api/filelist/:dataType`. Fix needs a separate PR on `ubair-website`.
- `clyfar`'s import of `send_json_to_server` — migrate it to `send_json_to_all` next time clyfar ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)