### PR TITLE
feat(nwp): Stage A — HRRR surface-layer push (basinwx.dev cron)

### DIFF
--- a/brc_tools/download/get_road_forecast.py
+++ b/brc_tools/download/get_road_forecast.py
@@ -201,7 +201,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--upload-bucket",
-        default="forecasts",
+        default="road-forecast",
         help="Upload bucket name passed to the shared uploader",
     )
     return parser.parse_args()

--- a/brc_tools/download/get_road_forecast.py
+++ b/brc_tools/download/get_road_forecast.py
@@ -201,7 +201,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--upload-bucket",
-        default="road-forecast",
+        default="forecasts",
         help="Upload bucket name passed to the shared uploader",
     )
     return parser.parse_args()

--- a/scripts/cron/run_hrrr_surface_push.sh
+++ b/scripts/cron/run_hrrr_surface_push.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Stage A cron wrapper: export HRRR surface layers and upload to basinwx.dev.
+#
+# Until PR #176 (ubair-website HRRR display) lands on the ops branch, this
+# wrapper pins BASINWX_API_URLS to the dev site so .com is not polluted with
+# files it cannot render. After ops catches up, unset BASINWX_API_URLS here
+# (or delete the line) so load_config_urls() falls back to
+# ~/.config/ubair-website/website_urls and fans out to both sites.
+#
+# Install on notchpeak1:
+#   45 0,6,12,18 * * * ~/gits/brc-tools/scripts/cron/run_hrrr_surface_push.sh
+set -euo pipefail
+
+export BASINWX_API_URLS="https://basinwx.dev"
+
+CONDA_ENV="${CONDA_ENV:-brc-tools}"
+REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
+LOG_DIR="${LOG_DIR:-$HOME/logs}"
+LOG_FILE="${LOG_FILE:-${LOG_DIR}/hrrr_surface.log}"
+
+mkdir -p "${LOG_DIR}"
+
+# Ensure DATA_UPLOAD_API_KEY is exported by the user's shell profile.
+# shellcheck disable=SC1090
+source "${HOME}/.bashrc"
+conda activate "${CONDA_ENV}"
+
+cd "${REPO_DIR}"
+
+{
+  echo "[run_hrrr_surface_push] $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  python scripts/export_hrrr_surface_layers.py --upload
+} >> "${LOG_FILE}" 2>&1


### PR DESCRIPTION
## Summary
- Fix `get_road_forecast.py` upload-bucket default from `road-forecast` → `forecasts` so it passes the ubair-website server's dataTypeMap (latent bug: prior runs were being rejected server-side).
- Add `scripts/cron/run_hrrr_surface_push.sh`: conda-activating cron wrapper that pins `BASINWX_API_URLS=https://basinwx.dev` and calls `export_hrrr_surface_layers.py --upload`. Logs to `~/logs/hrrr_surface.log`.

Stage A of a three-stage HRRR → BasinWX rollout tracking issue #10. Stages B (waypoint forecasts) and C (KVEL crosswind) will land in separate PRs.

## Why .dev-only
PR #176 (HRRR surface display) in `ubair-website` is on `dev` but not yet on `ops`, so pushing HRRR JSON to `.com` today would store files the site cannot render. When #176 lands on `ops`, drop the `BASINWX_API_URLS` export from the wrapper and fan-out will resume from `~/.config/ubair-website/website_urls`.

## User action required after merge
Install on notchpeak1 (compute nodes can't SSH there):
```
45 0,6,12,18 * * * ~/gits/brc-tools/scripts/cron/run_hrrr_surface_push.sh
```
Widen to hourly after a clean first week.

## Test plan
- [ ] `python scripts/export_hrrr_surface_layers.py --server-url https://basinwx.dev` from notchpeak1 writes a valid surface-layer JSON.
- [ ] `curl https://basinwx.dev/api/filelist/forecasts | jq` shows `forecast_hrrr_surface_layers_*.json`.
- [ ] `/forecast_weather` on basinwx.dev renders the HRRR surface map.
- [ ] `pytest tests/` still green (75/75 pre-change, no tests added in this stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)