### PR TITLE
feat(nwp): Stage B — HRRR waypoint-forecast export (us40_dense)

### DIFF
--- a/brc_tools/nwp/point_extract.py
+++ b/brc_tools/nwp/point_extract.py
@@ -1,0 +1,84 @@
+"""Point extraction helpers shared by waypoint and aviation payload builders."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Iterable
+
+import numpy as np
+import xarray as xr
+
+from brc_tools.nwp._crop import nearest_point_value
+
+
+def _isfinite(value) -> bool:
+    return value is not None and bool(np.isfinite(value))
+
+
+def _coerce_float(value) -> float | None:
+    arr = np.asarray(value)
+    if arr.size == 0:
+        return None
+    if arr.size != 1:
+        raise ValueError(f"Expected scalar, got array of shape {arr.shape}")
+    scalar = arr.item()
+    return float(scalar) if np.isfinite(scalar) else None
+
+
+def extract_point_series(
+    ds: xr.Dataset,
+    lat: float,
+    lon: float,
+    variables: Iterable[str],
+    *,
+    method: str = "kdtree_2d",
+) -> dict[str, list[float | None]]:
+    """Extract per-variable time series at the grid point nearest ``(lat, lon)``.
+
+    Returns a dict keyed by variable name; each value is a list aligned with
+    the dataset's ``time`` coordinate. Missing variables are returned as
+    all-``None`` lists of the same length. Non-finite values become ``None``
+    so the payload is JSON-safe.
+    """
+    pt = nearest_point_value(ds, lat, lon, method=method)
+    n_time = int(pt.sizes.get("time", 1))
+    out: dict[str, list[float | None]] = {}
+    for var in variables:
+        if var not in pt.data_vars:
+            out[var] = [None] * n_time
+            continue
+        series: list[float | None] = []
+        if "time" in pt[var].dims:
+            for t_idx in range(n_time):
+                series.append(_coerce_float(pt[var].isel(time=t_idx).values))
+        else:
+            series.append(_coerce_float(pt[var].values))
+        out[var] = series
+    return out
+
+
+def valid_times_iso(ds: xr.Dataset) -> list[str]:
+    """Return the dataset's ``time`` coordinate as ISO-Z strings."""
+    if "time" not in ds.coords:
+        return []
+    values = np.atleast_1d(ds["time"].values)
+    return [_np_datetime_to_isoz(v) for v in values]
+
+
+def valid_times_datetime(ds: xr.Dataset) -> list[dt.datetime]:
+    """Return the dataset's ``time`` coordinate as tz-naive UTC datetimes."""
+    if "time" not in ds.coords:
+        return []
+    values = np.atleast_1d(ds["time"].values)
+    return [_np_datetime_to_utc_naive(v) for v in values]
+
+
+def _np_datetime_to_utc_naive(value: np.datetime64) -> dt.datetime:
+    seconds = value.astype("datetime64[s]").astype(int)
+    return dt.datetime.fromtimestamp(int(seconds), tz=dt.timezone.utc).replace(
+        tzinfo=None
+    )
+
+
+def _np_datetime_to_isoz(value: np.datetime64) -> str:
+    return _np_datetime_to_utc_naive(value).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/brc_tools/nwp/waypoint_forecast.py
+++ b/brc_tools/nwp/waypoint_forecast.py
@@ -1,0 +1,201 @@
+"""Build HRRR waypoint-forecast JSON payloads for the BasinWX website."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Iterable
+
+import numpy as np
+import xarray as xr
+
+from brc_tools.nwp.derived import add_wind_fields, pa_to_hpa, temp_K_to_C
+from brc_tools.nwp.point_extract import extract_point_series, valid_times_iso
+from brc_tools.nwp.source import NWPSource, load_lookups
+
+DEFAULT_REGION = "uinta_basin"
+DEFAULT_FORECAST_HOURS = tuple(range(0, 19))
+
+SOURCE_VARIABLES = [
+    "temp_2m",
+    "dewpoint_2m",
+    "wind_u_10m",
+    "wind_v_10m",
+    "rh_2m",
+    "mslp",
+    "precip_1hr",
+]
+
+FIELD_SPECS: dict[str, dict[str, object]] = {
+    "temp_2m_c": {
+        "source": "temp_2m",
+        "label": "Temperature",
+        "units": "Celsius",
+        "precision": 1,
+        "transform": "K_to_C",
+    },
+    "dewpoint_2m_c": {
+        "source": "dewpoint_2m",
+        "label": "Dewpoint",
+        "units": "Celsius",
+        "precision": 1,
+        "transform": "K_to_C",
+    },
+    "wind_speed_10m_ms": {
+        "source": "wind_speed_10m",
+        "label": "Wind Speed",
+        "units": "m/s",
+        "precision": 1,
+        "transform": None,
+    },
+    "wind_dir_10m_deg": {
+        "source": "wind_dir_10m",
+        "label": "Wind Direction",
+        "units": "deg_true",
+        "precision": 0,
+        "transform": None,
+    },
+    "rh_2m_pct": {
+        "source": "rh_2m",
+        "label": "Relative Humidity",
+        "units": "percent",
+        "precision": 0,
+        "transform": None,
+    },
+    "mslp_hpa": {
+        "source": "mslp",
+        "label": "Mean Sea-Level Pressure",
+        "units": "hPa",
+        "precision": 1,
+        "transform": "pa_to_hpa",
+    },
+    "rainfall_1h_mm": {
+        "source": "precip_1hr",
+        "label": "Rainfall",
+        "units": "mm",
+        "precision": 1,
+        "transform": None,
+    },
+}
+
+
+def fetch_waypoint_dataset(
+    *,
+    init_time: dt.datetime,
+    forecast_hours: Iterable[int],
+    region: str = DEFAULT_REGION,
+    source: NWPSource | None = None,
+) -> xr.Dataset:
+    """Fetch the HRRR surface variables needed for the waypoint payload."""
+    src = source or NWPSource("hrrr")
+    ds = src.fetch(
+        init_time=init_time,
+        forecast_hours=list(forecast_hours),
+        variables=SOURCE_VARIABLES,
+        region=region,
+    )
+    return add_wind_fields(ds)
+
+
+def build_waypoint_payload(
+    ds: xr.Dataset,
+    *,
+    group: str,
+    init_time: dt.datetime,
+    forecast_hours: Iterable[int],
+    region: str = DEFAULT_REGION,
+    field_specs: dict[str, dict[str, object]] | None = None,
+) -> dict[str, object]:
+    """Serialise a HRRR dataset into the BasinWX waypoint-forecast JSON shape."""
+    lookups = load_lookups()
+    group_cfg = lookups.get("waypoint_groups", {}).get(group)
+    if group_cfg is None:
+        raise ValueError(f"Unknown waypoint group {group!r}")
+    all_waypoints = lookups.get("waypoints", {})
+
+    specs = field_specs or FIELD_SPECS
+    init_utc = _ensure_utc(init_time)
+    hours = [int(h) for h in forecast_hours]
+
+    stations_out: list[dict[str, object]] = []
+    for wp_name in group_cfg:
+        wp = all_waypoints[wp_name]
+        raw_series = extract_point_series(
+            ds,
+            wp["lat"],
+            wp["lon"],
+            variables=SOURCE_VARIABLES + ["wind_speed_10m", "wind_dir_10m"],
+        )
+        forecasts = _convert_series(raw_series, specs)
+        stations_out.append(
+            {
+                "id": wp_name,
+                "name": wp_name.replace("_", " ").title(),
+                "lat": float(wp["lat"]),
+                "lon": float(wp["lon"]),
+                "elevation_m": float(wp.get("elevation_m", float("nan")))
+                if wp.get("elevation_m") is not None
+                else None,
+                "reference_stid": wp.get("reference_stid"),
+                "forecasts": forecasts,
+            }
+        )
+
+    variable_meta = {
+        name: {
+            "label": spec["label"],
+            "units": spec["units"],
+            "precision": spec["precision"],
+        }
+        for name, spec in specs.items()
+    }
+
+    payload: dict[str, object] = {
+        "model": "hrrr",
+        "product": "waypoint_forecast",
+        "group": group,
+        "region": region,
+        "init_time": _isoformat_utc(init_utc),
+        "generated_at": _isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+        "forecast_hours": hours,
+        "valid_times": valid_times_iso(ds),
+        "variables": variable_meta,
+        "stations": stations_out,
+    }
+    return payload
+
+
+def _convert_series(
+    raw: dict[str, list[float | None]],
+    specs: dict[str, dict[str, object]],
+) -> dict[str, list[float | None]]:
+    out: dict[str, list[float | None]] = {}
+    for output_name, spec in specs.items():
+        source = spec["source"]
+        series = raw.get(source)
+        if series is None:
+            continue
+        transform = spec.get("transform")
+        precision = int(spec.get("precision", 1))
+        converted: list[float | None] = []
+        for value in series:
+            if value is None:
+                converted.append(None)
+                continue
+            if transform == "K_to_C":
+                converted.append(round(float(temp_K_to_C(value)), precision))
+            elif transform == "pa_to_hpa":
+                converted.append(round(float(pa_to_hpa(value)), precision))
+            else:
+                converted.append(round(float(value), precision))
+        out[output_name] = converted
+    return out
+
+
+def _ensure_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _isoformat_utc(value: dt.datetime) -> str:
+    return _ensure_utc(value).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/scripts/cron/run_hrrr_waypoint_push.sh
+++ b/scripts/cron/run_hrrr_waypoint_push.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Stage B cron wrapper: export HRRR waypoint-forecast JSON and upload to basinwx.dev.
+#
+# Pin to .dev until the ubair-website waypoint consumer lands on ops. After
+# that, drop BASINWX_API_URLS so fan-out is driven by website_urls.
+#
+# Install on notchpeak1:
+#   50 * * * * ~/gits/brc-tools/scripts/cron/run_hrrr_waypoint_push.sh
+set -euo pipefail
+
+export BASINWX_API_URLS="https://basinwx.dev"
+
+CONDA_ENV="${CONDA_ENV:-brc-tools}"
+REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
+LOG_DIR="${LOG_DIR:-$HOME/logs}"
+LOG_FILE="${LOG_FILE:-${LOG_DIR}/hrrr_waypoints.log}"
+GROUP="${GROUP:-us40_dense}"
+
+mkdir -p "${LOG_DIR}"
+
+# shellcheck disable=SC1090
+source "${HOME}/.bashrc"
+conda activate "${CONDA_ENV}"
+
+cd "${REPO_DIR}"
+
+{
+  echo "[run_hrrr_waypoint_push] $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  python scripts/export_hrrr_waypoint_forecast.py --upload --group "${GROUP}"
+} >> "${LOG_FILE}" 2>&1

--- a/scripts/export_hrrr_waypoint_forecast.py
+++ b/scripts/export_hrrr_waypoint_forecast.py
@@ -1,0 +1,151 @@
+"""Export HRRR waypoint-forecast JSON for the BasinWX website."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+from pathlib import Path
+
+from brc_tools.nwp import NWPSource
+from brc_tools.nwp.waypoint_forecast import (
+    DEFAULT_FORECAST_HOURS,
+    DEFAULT_REGION,
+    build_waypoint_payload,
+    fetch_waypoint_dataset,
+)
+
+LOG = logging.getLogger(__name__)
+
+DEFAULT_GROUP = "us40_dense"
+DEFAULT_UPLOAD_BUCKET = "forecasts"
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parents[1] / "data" / "basinwx"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export HRRR waypoint forecast JSON for BasinWX",
+    )
+    parser.add_argument(
+        "--group",
+        default=DEFAULT_GROUP,
+        help=f"Waypoint group from lookups.toml (default: {DEFAULT_GROUP})",
+    )
+    parser.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help=f"Fetch bounding-box region (default: {DEFAULT_REGION})",
+    )
+    parser.add_argument(
+        "--max-fxx",
+        type=int,
+        default=max(DEFAULT_FORECAST_HOURS),
+        help=f"Maximum forecast hour (default: {max(DEFAULT_FORECAST_HOURS)})",
+    )
+    parser.add_argument(
+        "--init-time",
+        default=None,
+        help="Optional HRRR init time (YYYY-MM-DD HH); defaults to latest available",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload the JSON to BasinWX after writing",
+    )
+    parser.add_argument(
+        "--upload-bucket",
+        default=DEFAULT_UPLOAD_BUCKET,
+        help=f"Upload bucket (default: {DEFAULT_UPLOAD_BUCKET})",
+    )
+    parser.add_argument(
+        "--server-url",
+        default=None,
+        help="Override server URL (default: read from ~/.config/ubair-website/website_urls or BASINWX_API_URLS)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write JSON locally but never upload",
+    )
+    return parser.parse_args()
+
+
+def _resolve_init_time(arg: str | None, source: NWPSource) -> dt.datetime:
+    if arg:
+        return dt.datetime.strptime(arg, "%Y-%m-%d %H")
+    return source.latest_init()
+
+
+def _output_path(output_dir: Path, init_time: dt.datetime, group: str) -> Path:
+    stamp = init_time.strftime("%Y%m%d_%H%M")
+    return output_dir / f"forecast_hrrr_waypoints_{group}_{stamp}Z.json"
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    args = parse_args()
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        src = NWPSource("hrrr")
+        init_time = _resolve_init_time(args.init_time, src)
+        forecast_hours = list(range(0, args.max_fxx + 1))
+
+        LOG.info(
+            "Fetching HRRR waypoint forecast: init=%s group=%s fxx=0..%d",
+            init_time.strftime("%Y-%m-%d %HZ"),
+            args.group,
+            args.max_fxx,
+        )
+        ds = fetch_waypoint_dataset(
+            init_time=init_time,
+            forecast_hours=forecast_hours,
+            region=args.region,
+            source=src,
+        )
+        payload = build_waypoint_payload(
+            ds,
+            group=args.group,
+            init_time=init_time,
+            forecast_hours=forecast_hours,
+            region=args.region,
+        )
+    except Exception as exc:
+        LOG.error("HRRR waypoint forecast build failed: %s", exc)
+        return 1
+
+    output_path = _output_path(output_dir, init_time, args.group)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, allow_nan=False)
+    LOG.info("Wrote %s", output_path)
+
+    if args.upload and not args.dry_run:
+        try:
+            from brc_tools.download.push_data import load_config_urls, send_json_to_all
+
+            api_key, config_urls = load_config_urls()
+            urls = [args.server_url] if args.server_url else config_urls
+            send_json_to_all(urls, str(output_path), args.upload_bucket, api_key)
+        except Exception as exc:
+            LOG.error("HRRR waypoint forecast upload failed: %s", exc)
+            return 1
+    else:
+        LOG.info("Upload skipped")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_waypoint_forecast.py
+++ b/tests/test_waypoint_forecast.py
@@ -1,0 +1,103 @@
+"""Shape-level tests for the HRRR waypoint-forecast JSON payload."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from brc_tools.nwp.waypoint_forecast import FIELD_SPECS, build_waypoint_payload
+
+
+@pytest.fixture
+def basin_dataset() -> xr.Dataset:
+    """Synthetic HRRR surface grid covering the Uinta Basin with 2 time steps."""
+    lats = np.linspace(40.1, 40.5, 5)
+    lons = np.linspace(-111.3, -109.3, 5)
+    lon2d, lat2d = np.meshgrid(lons, lats)
+    times = np.array(
+        [np.datetime64("2026-04-24T12:00:00"),
+         np.datetime64("2026-04-24T13:00:00")]
+    )
+    shape = (2, lat2d.shape[0], lat2d.shape[1])
+    ds = xr.Dataset(
+        data_vars={
+            "temp_2m": (("time", "y", "x"), np.full(shape, 283.15)),
+            "dewpoint_2m": (("time", "y", "x"), np.full(shape, 273.15)),
+            "wind_u_10m": (("time", "y", "x"), np.full(shape, 3.0)),
+            "wind_v_10m": (("time", "y", "x"), np.full(shape, 4.0)),
+            "wind_speed_10m": (("time", "y", "x"), np.full(shape, 5.0)),
+            "wind_dir_10m": (("time", "y", "x"), np.full(shape, 216.87)),
+            "rh_2m": (("time", "y", "x"), np.full(shape, 55.0)),
+            "mslp": (("time", "y", "x"), np.full(shape, 101300.0)),
+            "precip_1hr": (("time", "y", "x"), np.full(shape, 0.4)),
+        },
+        coords={
+            "time": times,
+            "latitude": (("y", "x"), lat2d),
+            "longitude": (("y", "x"), lon2d),
+        },
+    )
+    return ds
+
+
+def test_payload_topshape(basin_dataset):
+    init = dt.datetime(2026, 4, 24, 12, 0)
+    payload = build_waypoint_payload(
+        basin_dataset,
+        group="basin_full",
+        init_time=init,
+        forecast_hours=[0, 1],
+    )
+    assert payload["model"] == "hrrr"
+    assert payload["product"] == "waypoint_forecast"
+    assert payload["group"] == "basin_full"
+    assert payload["init_time"] == "2026-04-24T12:00:00Z"
+    assert payload["forecast_hours"] == [0, 1]
+    assert len(payload["valid_times"]) == 2
+    assert set(FIELD_SPECS.keys()).issubset(payload["variables"].keys())
+    assert len(payload["stations"]) == 6  # basin_full
+
+
+def test_payload_stations_have_forecasts(basin_dataset):
+    init = dt.datetime(2026, 4, 24, 12, 0)
+    payload = build_waypoint_payload(
+        basin_dataset,
+        group="basin_full",
+        init_time=init,
+        forecast_hours=[0, 1],
+    )
+    for station in payload["stations"]:
+        assert "id" in station and "lat" in station and "lon" in station
+        for field in FIELD_SPECS:
+            assert field in station["forecasts"]
+            assert len(station["forecasts"][field]) == 2
+
+
+def test_unit_transforms(basin_dataset):
+    init = dt.datetime(2026, 4, 24, 12, 0)
+    payload = build_waypoint_payload(
+        basin_dataset,
+        group="basin_full",
+        init_time=init,
+        forecast_hours=[0, 1],
+    )
+    station = payload["stations"][0]
+    # 283.15 K -> 10.0 C
+    assert station["forecasts"]["temp_2m_c"][0] == pytest.approx(10.0, abs=0.05)
+    # 101300 Pa -> 1013.0 hPa
+    assert station["forecasts"]["mslp_hpa"][0] == pytest.approx(1013.0, abs=0.05)
+    # 5 m/s wind_speed carries through unchanged
+    assert station["forecasts"]["wind_speed_10m_ms"][0] == pytest.approx(5.0, abs=0.05)
+
+
+def test_unknown_group_raises(basin_dataset):
+    with pytest.raises(ValueError, match="Unknown waypoint group"):
+        build_waypoint_payload(
+            basin_dataset,
+            group="definitely_not_a_group",
+            init_time=dt.datetime(2026, 4, 24, 12, 0),
+            forecast_hours=[0],
+        )


### PR DESCRIPTION
## Summary
- New `brc_tools/nwp/point_extract.py`: shared nearest-grid-point helper consumed by this stage and Stage C.
- New `brc_tools/nwp/waypoint_forecast.py`: payload builder with default `FIELD_SPECS` (temp, dewpoint, wind speed/dir, rh, mslp, rainfall). Single-file-per-init JSON so the site fetches the whole meteogram page in one request.
- New `scripts/export_hrrr_waypoint_forecast.py`: CLI with `--dry-run`, `--group`, `--server-url`, `--upload-bucket` (default `forecasts`).
- New `scripts/cron/run_hrrr_waypoint_push.sh`: `.dev`-pinned cron wrapper (cadence `50 * * * *`).
- 4 new pytest cases covering payload shape, per-station forecast arrays, unit transforms (K→C, Pa→hPa), and unknown-group error.

Stage B of the HRRR → BasinWX rollout (issue #10). Builds on the surface-layer schema convention from Stage A (#18). Independent of Stage A — no file conflicts.

## JSON shape
```
{
  "model": "hrrr", "product": "waypoint_forecast", "group": "us40_dense",
  "init_time": "...", "forecast_hours": [0..18], "valid_times": [...],
  "variables": { "temp_2m_c": {...}, ... },
  "stations": [ { "id", "lat", "lon", "elevation_m", "reference_stid",
                  "forecasts": { "temp_2m_c": [...], ... } }, ... ]
}
```
Filename: `forecast_hrrr_waypoints_us40_dense_YYYYMMDD_HHMMZ.json`
Bucket: `forecasts` (accepted by `ubair-website` `dataUpload.js` dataTypeMap).

## Coordination
- A small `ubair-website` consumer to render this JSON is a concurrent follow-up; payloads can sit in the bucket until then.
- Cron install on notchpeak1 (user-side):
  ```
  50 * * * * ~/gits/brc-tools/scripts/cron/run_hrrr_waypoint_push.sh
  ```

## Test plan
- [x] `pytest tests/test_waypoint_forecast.py` — 4/4 green.
- [x] Full suite `pytest tests/` — 79/79 green (4 new).
- [ ] `python scripts/export_hrrr_waypoint_forecast.py --dry-run` on notchpeak1 produces a valid JSON for the latest init.
- [ ] Live push to `.dev`; `curl https://basinwx.dev/api/static/forecasts/forecast_hrrr_waypoints_*.json | jq keys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)