### PR TITLE
feat(nwp): Stage C — HRRR sub-hourly KVEL crosswind export

### DIFF
--- a/brc_tools/nwp/aviation.py
+++ b/brc_tools/nwp/aviation.py
@@ -1,0 +1,219 @@
+"""Airport-relative HRRR wind payloads for the BasinWX aviation page.
+
+Fetches HRRR surface winds via Herbie directly so the native sub-hourly
+(15-min) time axis of the ``subh`` product is preserved.  NWPSource's
+normalize_coords replaces the GRIB time coord with a single init+fxx
+stamp, which collapses subh output to hourly — this module bypasses that.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Iterable
+
+import numpy as np
+import xarray as xr
+from herbie import Herbie
+
+from brc_tools.nwp._crop import nearest_point_value
+from brc_tools.nwp.derived import crosswind_kt, headwind_kt, wind_direction, wind_speed, KT_PER_MS
+from brc_tools.nwp.source import load_lookups
+
+LOG = logging.getLogger(__name__)
+
+DEFAULT_PRODUCT = "subh"
+DEFAULT_MAX_FXX = 6
+SEARCH_U10 = "UGRD:10 m above ground"
+SEARCH_V10 = "VGRD:10 m above ground"
+SEARCH_GUST = "GUST:surface"
+
+
+def fetch_airport_winds(
+    *,
+    init_time: dt.datetime,
+    forecast_hours: Iterable[int],
+    product: str = DEFAULT_PRODUCT,
+) -> xr.Dataset:
+    """Fetch HRRR 10 m U/V plus surface gust across a list of forecast hours.
+
+    Uses Herbie directly so the native time axis (4 × 15-min per hour for
+    ``subh``; one hourly step for ``sfc``) is preserved across the concat.
+    """
+    slices: list[xr.Dataset] = []
+    for fxx in forecast_hours:
+        H = Herbie(init_time, model="hrrr", product=product, fxx=int(fxx))
+        pieces: list[xr.Dataset] = []
+        for search in (SEARCH_U10, SEARCH_V10, SEARCH_GUST):
+            try:
+                piece = H.xarray(search, remove_grib=False)
+            except Exception as exc:
+                LOG.warning("Herbie fetch failed f%03d %r: %s", int(fxx), search, exc)
+                continue
+            if isinstance(piece, list):
+                piece = xr.merge(piece, compat="override", combine_attrs="drop")
+            pieces.append(_clean_dataset(piece))
+        if not pieces:
+            continue
+        slices.append(xr.merge(pieces, compat="override", combine_attrs="drop"))
+
+    if not slices:
+        raise RuntimeError(
+            f"No HRRR {product} data fetched for init={init_time} "
+            f"fxx={list(forecast_hours)}"
+        )
+
+    merged = xr.concat(slices, dim="time", combine_attrs="drop")
+    return merged.sortby("time")
+
+
+def build_airport_crosswind_payload(
+    ds: xr.Dataset,
+    *,
+    airport: str,
+    init_time: dt.datetime,
+    product: str = DEFAULT_PRODUCT,
+) -> dict[str, object]:
+    """Serialise airport-relative wind data into the BasinWX aviation JSON shape."""
+    airport_cfg = _airport_config(airport)
+    lat = float(airport_cfg["lat"])
+    lon = float(airport_cfg["lon"])
+    runway_headings = [int(h) for h in airport_cfg["runway_headings_deg"]]
+
+    pt = nearest_point_value(ds, lat, lon, method="kdtree_2d")
+
+    u = np.asarray(pt["u10"].values if "u10" in pt.data_vars else pt["UGRD"].values)
+    v = np.asarray(pt["v10"].values if "v10" in pt.data_vars else pt["VGRD"].values)
+    gust_ms = _get_gust_ms(pt)
+
+    speed_kt = wind_speed(u, v) * KT_PER_MS
+    dir_deg = wind_direction(u, v)
+
+    variables = {
+        "wind_speed_kt": {"label": "Wind Speed", "units": "kt", "precision": 1},
+        "wind_dir_deg": {"label": "Wind Direction", "units": "deg_true", "precision": 0},
+        "gust_kt": {"label": "Gust", "units": "kt", "precision": 1},
+    }
+    series: dict[str, list[float | None]] = {
+        "wind_speed_kt": _round_series(speed_kt, 1),
+        "wind_dir_deg": _round_series(dir_deg, 0),
+        "gust_kt": _round_series(
+            gust_ms * KT_PER_MS if gust_ms is not None else _nan_like(u),
+            1,
+        ),
+    }
+
+    for heading in runway_headings:
+        cw_key = f"crosswind_kt_{heading:03d}"
+        hw_key = f"headwind_kt_{heading:03d}"
+        variables[cw_key] = {
+            "label": f"Crosswind (Rwy {heading // 10:02d})",
+            "units": "kt",
+            "precision": 1,
+        }
+        variables[hw_key] = {
+            "label": f"Headwind (Rwy {heading // 10:02d})",
+            "units": "kt",
+            "precision": 1,
+        }
+        series[cw_key] = _round_series(crosswind_kt(u, v, heading), 1)
+        series[hw_key] = _round_series(headwind_kt(u, v, heading), 1)
+
+    valid_times, forecast_minutes = _time_axes(pt, init_time)
+
+    return {
+        "model": "hrrr_subh" if product == "subh" else "hrrr",
+        "product": "aviation_crosswind",
+        "airport": airport,
+        "name": airport_cfg.get("name"),
+        "lat": lat,
+        "lon": lon,
+        "elevation_m": float(airport_cfg.get("elevation_m", 0.0)),
+        "runway_headings_deg": runway_headings,
+        "init_time": _isoformat_utc(_ensure_utc(init_time)),
+        "generated_at": _isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+        "valid_times": valid_times,
+        "forecast_minutes": forecast_minutes,
+        "variables": variables,
+        "series": series,
+    }
+
+
+def _airport_config(airport: str) -> dict[str, object]:
+    lookups = load_lookups()
+    airports = lookups.get("airports", {})
+    if airport not in airports:
+        raise ValueError(f"Unknown airport {airport!r} in lookups.toml")
+    return airports[airport]
+
+
+def _clean_dataset(ds: xr.Dataset) -> xr.Dataset:
+    keep = {"time", "valid_time", "step", "latitude", "longitude", "y", "x"}
+    drop = [n for n in ds.coords if n not in keep and n not in ds.dims]
+    if drop:
+        ds = ds.drop_vars(drop, errors="ignore")
+    if "step" in ds.coords and "valid_time" in ds.coords:
+        ds = ds.drop_vars("step", errors="ignore")
+    if "valid_time" in ds.coords and "time" in ds.coords:
+        ds = ds.drop_vars("time", errors="ignore").rename({"valid_time": "time"})
+    elif "valid_time" in ds.coords:
+        ds = ds.rename({"valid_time": "time"})
+    if "time" in ds.coords and "time" not in ds.dims:
+        ds = ds.expand_dims("time")
+    return ds
+
+
+def _get_gust_ms(pt: xr.Dataset) -> np.ndarray | None:
+    for name in ("gust", "GUST", "i10fg", "fg10"):
+        if name in pt.data_vars:
+            return np.asarray(pt[name].values)
+    return None
+
+
+def _nan_like(arr: np.ndarray) -> np.ndarray:
+    out = np.empty_like(arr, dtype=float)
+    out.fill(np.nan)
+    return out
+
+
+def _round_series(values: np.ndarray, precision: int) -> list[float | None]:
+    arr = np.atleast_1d(np.asarray(values, dtype=float))
+    rounded = np.round(arr, decimals=precision)
+    return [
+        None if not np.isfinite(v) else float(v)
+        for v in rounded
+    ]
+
+
+def _time_axes(
+    pt: xr.Dataset, init_time: dt.datetime
+) -> tuple[list[str], list[int]]:
+    init_utc = _ensure_utc(init_time)
+    init_np = np.datetime64(init_utc.replace(tzinfo=None))
+    valid_times: list[str] = []
+    forecast_minutes: list[int] = []
+    if "time" not in pt.coords:
+        return valid_times, forecast_minutes
+    for value in np.atleast_1d(pt["time"].values):
+        valid_times.append(_np_isoz(value))
+        delta_min = int((value - init_np) / np.timedelta64(1, "m"))
+        forecast_minutes.append(delta_min)
+    return valid_times, forecast_minutes
+
+
+def _np_isoz(value: np.datetime64) -> str:
+    seconds = value.astype("datetime64[s]").astype(int)
+    return (
+        dt.datetime.fromtimestamp(int(seconds), tz=dt.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+def _ensure_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _isoformat_utc(value: dt.datetime) -> str:
+    return _ensure_utc(value).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/brc_tools/nwp/derived.py
+++ b/brc_tools/nwp/derived.py
@@ -72,6 +72,45 @@ def wind_components(speed, direction_deg):
     return u, v
 
 
+KT_PER_MS = 1.94384
+
+
+def headwind_kt(u_ms, v_ms, runway_heading_deg):
+    """Headwind component along a runway heading, in knots.
+
+    Positive = opposing the aircraft (conventional aviation sign).
+
+    Parameters
+    ----------
+    u_ms, v_ms : array-like
+        Eastward and northward wind components (m/s).
+    runway_heading_deg : float or array-like
+        Runway heading in degrees true (0 = N, 90 = E).
+    """
+    theta = np.radians(np.asarray(runway_heading_deg))
+    u = np.asarray(u_ms)
+    v = np.asarray(v_ms)
+    return -(u * np.sin(theta) + v * np.cos(theta)) * KT_PER_MS
+
+
+def crosswind_kt(u_ms, v_ms, runway_heading_deg):
+    """Crosswind component across a runway heading, in knots.
+
+    Positive = from the right of the aircraft (conventional aviation sign).
+
+    Parameters
+    ----------
+    u_ms, v_ms : array-like
+        Eastward and northward wind components (m/s).
+    runway_heading_deg : float or array-like
+        Runway heading in degrees true (0 = N, 90 = E).
+    """
+    theta = np.radians(np.asarray(runway_heading_deg))
+    u = np.asarray(u_ms)
+    v = np.asarray(v_ms)
+    return (v * np.sin(theta) - u * np.cos(theta)) * KT_PER_MS
+
+
 # ---------------------------------------------------------------------------
 # Thermodynamic quantities
 # ---------------------------------------------------------------------------

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -204,6 +204,15 @@ us40_dense = [
     "split_mountain", "dinosaur",
 ]
 
+# ── Airports (aviation exports) ────────────────────────────────────────────
+
+[airports.KVEL]
+name = "Vernal Regional Airport"
+lat = 40.4408
+lon = -109.5104
+elevation_m = 1609
+runway_headings_deg = [160, 340]  # true, not magnetic
+
 # ── Aliases: surface / near-surface ─────────────────────────────────────────
 
 [aliases.temp_2m]

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -396,6 +396,15 @@ basin_ns_landmarks = [
     "ouray", "vernal", "dutch_john", "manila",
 ]
 
+# ── Airports (aviation exports) ────────────────────────────────────────────
+
+[airports.KVEL]
+name = "Vernal Regional Airport"
+lat = 40.4408
+lon = -109.5104
+elevation_m = 1609
+runway_headings_deg = [160, 340]  # true, not magnetic
+
 # ── Aliases: surface / near-surface ─────────────────────────────────────────
 
 [aliases.temp_2m]

--- a/scripts/cron/run_hrrr_kvel_crosswind_push.sh
+++ b/scripts/cron/run_hrrr_kvel_crosswind_push.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Stage C cron wrapper: export HRRR KVEL cross-wind forecast and upload to basinwx.dev.
+#
+# BLOCKED on ubair-website consumer: aviation.html is a scaffold with no JSON
+# reader. Do NOT enable this cron until the website PR that renders this
+# payload has landed on .dev. Once it does, install on notchpeak1 with:
+#   55 * * * * ~/gits/brc-tools/scripts/cron/run_hrrr_kvel_crosswind_push.sh
+set -euo pipefail
+
+export BASINWX_API_URLS="https://basinwx.dev"
+
+CONDA_ENV="${CONDA_ENV:-brc-tools}"
+REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
+LOG_DIR="${LOG_DIR:-$HOME/logs}"
+LOG_FILE="${LOG_FILE:-${LOG_DIR}/hrrr_kvel_crosswind.log}"
+AIRPORT="${AIRPORT:-KVEL}"
+PRODUCT="${PRODUCT:-subh}"
+MAX_FXX="${MAX_FXX:-6}"
+
+mkdir -p "${LOG_DIR}"
+
+# shellcheck disable=SC1090
+source "${HOME}/.bashrc"
+conda activate "${CONDA_ENV}"
+
+cd "${REPO_DIR}"
+
+{
+  echo "[run_hrrr_kvel_crosswind_push] $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  python scripts/export_hrrr_kvel_crosswind.py \
+    --upload --airport "${AIRPORT}" --product "${PRODUCT}" --max-fxx "${MAX_FXX}"
+} >> "${LOG_FILE}" 2>&1

--- a/scripts/export_hrrr_kvel_crosswind.py
+++ b/scripts/export_hrrr_kvel_crosswind.py
@@ -1,0 +1,149 @@
+"""Export HRRR sub-hourly cross-wind forecast at KVEL for the BasinWX aviation page."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+from pathlib import Path
+
+from brc_tools.nwp import NWPSource
+from brc_tools.nwp.aviation import (
+    DEFAULT_MAX_FXX,
+    DEFAULT_PRODUCT,
+    build_airport_crosswind_payload,
+    fetch_airport_winds,
+)
+
+LOG = logging.getLogger(__name__)
+
+DEFAULT_AIRPORT = "KVEL"
+DEFAULT_UPLOAD_BUCKET = "forecasts"
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parents[1] / "data" / "basinwx"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export HRRR cross-wind forecast for a BasinWX airport",
+    )
+    parser.add_argument(
+        "--airport",
+        default=DEFAULT_AIRPORT,
+        help=f"Airport key from lookups.toml (default: {DEFAULT_AIRPORT})",
+    )
+    parser.add_argument(
+        "--product",
+        default=DEFAULT_PRODUCT,
+        choices=["subh", "sfc"],
+        help=f"HRRR product (default: {DEFAULT_PRODUCT}; sfc = hourly fallback)",
+    )
+    parser.add_argument(
+        "--max-fxx",
+        type=int,
+        default=DEFAULT_MAX_FXX,
+        help=f"Maximum forecast hour (default: {DEFAULT_MAX_FXX})",
+    )
+    parser.add_argument(
+        "--init-time",
+        default=None,
+        help="Optional HRRR init time (YYYY-MM-DD HH); defaults to latest available",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload the JSON to BasinWX after writing",
+    )
+    parser.add_argument(
+        "--upload-bucket",
+        default=DEFAULT_UPLOAD_BUCKET,
+        help=f"Upload bucket (default: {DEFAULT_UPLOAD_BUCKET})",
+    )
+    parser.add_argument(
+        "--server-url",
+        default=None,
+        help="Override server URL (default: read from ~/.config/ubair-website/website_urls or BASINWX_API_URLS)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write JSON locally but never upload",
+    )
+    return parser.parse_args()
+
+
+def _resolve_init_time(arg: str | None) -> dt.datetime:
+    if arg:
+        return dt.datetime.strptime(arg, "%Y-%m-%d %H")
+    return NWPSource("hrrr").latest_init()
+
+
+def _output_path(output_dir: Path, airport: str, init_time: dt.datetime) -> Path:
+    stamp = init_time.strftime("%Y%m%d_%H%M")
+    return output_dir / f"forecast_hrrr_{airport.lower()}_crosswind_{stamp}Z.json"
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    args = parse_args()
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        init_time = _resolve_init_time(args.init_time)
+        forecast_hours = list(range(0, args.max_fxx + 1))
+        LOG.info(
+            "Fetching HRRR %s %s init=%s fxx=0..%d",
+            args.product,
+            args.airport,
+            init_time.strftime("%Y-%m-%d %HZ"),
+            args.max_fxx,
+        )
+        ds = fetch_airport_winds(
+            init_time=init_time,
+            forecast_hours=forecast_hours,
+            product=args.product,
+        )
+        payload = build_airport_crosswind_payload(
+            ds,
+            airport=args.airport,
+            init_time=init_time,
+            product=args.product,
+        )
+    except Exception as exc:
+        LOG.error("HRRR aviation crosswind build failed: %s", exc)
+        return 1
+
+    output_path = _output_path(output_dir, args.airport, init_time)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, allow_nan=False)
+    LOG.info("Wrote %s", output_path)
+
+    if args.upload and not args.dry_run:
+        try:
+            from brc_tools.download.push_data import load_config_urls, send_json_to_all
+
+            api_key, config_urls = load_config_urls()
+            urls = [args.server_url] if args.server_url else config_urls
+            send_json_to_all(urls, str(output_path), args.upload_bucket, api_key)
+        except Exception as exc:
+            LOG.error("HRRR aviation crosswind upload failed: %s", exc)
+            return 1
+    else:
+        LOG.info("Upload skipped")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_aviation_wind.py
+++ b/tests/test_aviation_wind.py
@@ -1,0 +1,148 @@
+"""Unit tests for crosswind / headwind math and aviation payload shape."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from brc_tools.nwp.aviation import build_airport_crosswind_payload
+from brc_tools.nwp.derived import KT_PER_MS, crosswind_kt, headwind_kt
+
+
+class TestCrosswindMath:
+    """Canonical cases for runway-relative wind decomposition.
+
+    Wind vector (u, v) is eastward/northward in m/s; runway heading is
+    degrees true (0 = N, 90 = E). Positive headwind = opposes aircraft,
+    positive crosswind = from the right of the aircraft.
+    """
+
+    def test_calm_wind(self):
+        assert headwind_kt(0.0, 0.0, 0) == pytest.approx(0.0)
+        assert crosswind_kt(0.0, 0.0, 0) == pytest.approx(0.0)
+
+    def test_pure_headwind_runway_360(self):
+        # Aircraft landing on runway 36 (heading 0°/true north).
+        # Wind FROM the north at 10 m/s -> u=0, v=-10.
+        hw = headwind_kt(0.0, -10.0, 0)
+        cw = crosswind_kt(0.0, -10.0, 0)
+        assert hw == pytest.approx(10.0 * KT_PER_MS, rel=1e-6)
+        assert cw == pytest.approx(0.0, abs=1e-9)
+
+    def test_pure_tailwind_runway_360(self):
+        # Wind FROM the south -> u=0, v=+10.
+        hw = headwind_kt(0.0, 10.0, 0)
+        assert hw == pytest.approx(-10.0 * KT_PER_MS, rel=1e-6)
+
+    def test_right_crosswind_runway_360(self):
+        # Aircraft heading north; wind FROM the east (right of aircraft)
+        # at 10 m/s -> u=-10, v=0. Expect positive crosswind.
+        cw = crosswind_kt(-10.0, 0.0, 0)
+        hw = headwind_kt(-10.0, 0.0, 0)
+        assert cw == pytest.approx(10.0 * KT_PER_MS, rel=1e-6)
+        assert hw == pytest.approx(0.0, abs=1e-9)
+
+    def test_left_crosswind_runway_360(self):
+        # Aircraft heading north; wind FROM the west -> u=+10, v=0.
+        cw = crosswind_kt(10.0, 0.0, 0)
+        assert cw == pytest.approx(-10.0 * KT_PER_MS, rel=1e-6)
+
+    def test_pure_headwind_runway_090(self):
+        # Aircraft heading 090 (east). Wind FROM the east -> u=-10, v=0.
+        hw = headwind_kt(-10.0, 0.0, 90)
+        cw = crosswind_kt(-10.0, 0.0, 90)
+        assert hw == pytest.approx(10.0 * KT_PER_MS, rel=1e-6)
+        assert cw == pytest.approx(0.0, abs=1e-9)
+
+    def test_kvel_runway_16_quartering(self):
+        # KVEL runway 16 heading = 160° true. 45° right of heading = 205°.
+        # Wind FROM 205° at 10 m/s (u, v from wind_components):
+        #   u = -10 sin(205°), v = -10 cos(205°).
+        from brc_tools.nwp.derived import wind_components
+
+        u, v = wind_components(10.0, 205.0)
+        hw = headwind_kt(u, v, 160)
+        cw = crosswind_kt(u, v, 160)
+        # 45° quartering headwind from the right: hw = cw = 10/sqrt(2).
+        expected = 10.0 / np.sqrt(2.0) * KT_PER_MS
+        assert hw == pytest.approx(expected, rel=1e-6)
+        assert cw == pytest.approx(expected, rel=1e-6)
+
+    def test_array_input(self):
+        u = np.array([0.0, -10.0, 10.0])
+        v = np.array([-10.0, 0.0, 0.0])
+        hw = headwind_kt(u, v, 0)
+        cw = crosswind_kt(u, v, 0)
+        np.testing.assert_allclose(hw, np.array([10.0, 0.0, 0.0]) * KT_PER_MS, atol=1e-9)
+        np.testing.assert_allclose(cw, np.array([0.0, 10.0, -10.0]) * KT_PER_MS, atol=1e-9)
+
+
+class TestAviationPayload:
+    """Shape-level validation of the aviation JSON payload."""
+
+    @pytest.fixture
+    def kvel_dataset(self) -> xr.Dataset:
+        """Minimal synthetic HRRR grid centred on KVEL with 3 time steps."""
+        lats = np.array([[40.40, 40.40, 40.40],
+                         [40.44, 40.44, 40.44],
+                         [40.48, 40.48, 40.48]])
+        lons = np.array([[-109.55, -109.51, -109.47],
+                         [-109.55, -109.51, -109.47],
+                         [-109.55, -109.51, -109.47]])
+        times = np.array(
+            [np.datetime64("2026-04-24T12:00:00"),
+             np.datetime64("2026-04-24T12:15:00"),
+             np.datetime64("2026-04-24T12:30:00")]
+        )
+        # Constant 10 m/s southerly wind (u=0, v=+10).
+        u = np.zeros((3, 3, 3), dtype=float)
+        v = np.full((3, 3, 3), 10.0, dtype=float)
+        ds = xr.Dataset(
+            data_vars={
+                "u10": (("time", "y", "x"), u),
+                "v10": (("time", "y", "x"), v),
+                "gust": (("time", "y", "x"), np.full((3, 3, 3), 12.0)),
+            },
+            coords={
+                "time": times,
+                "latitude": (("y", "x"), lats),
+                "longitude": (("y", "x"), lons),
+            },
+        )
+        return ds
+
+    def test_payload_shape(self, kvel_dataset):
+        init = dt.datetime(2026, 4, 24, 12, 0)
+        payload = build_airport_crosswind_payload(
+            kvel_dataset, airport="KVEL", init_time=init, product="subh"
+        )
+        assert payload["model"] == "hrrr_subh"
+        assert payload["airport"] == "KVEL"
+        assert payload["runway_headings_deg"] == [160, 340]
+        assert payload["forecast_minutes"] == [0, 15, 30]
+        assert len(payload["valid_times"]) == 3
+        for key in ("wind_speed_kt", "wind_dir_deg", "gust_kt",
+                    "crosswind_kt_160", "crosswind_kt_340",
+                    "headwind_kt_160", "headwind_kt_340"):
+            assert key in payload["variables"]
+            assert key in payload["series"]
+            assert len(payload["series"][key]) == 3
+
+    def test_payload_values_southerly_wind(self, kvel_dataset):
+        # u=0, v=+10: wind blows toward north, FROM south (180°).
+        # Runway 160 (SSE heading) faces the wind -> positive headwind;
+        # runway 340 (NNW heading) has wind from behind -> negative headwind.
+        init = dt.datetime(2026, 4, 24, 12, 0)
+        payload = build_airport_crosswind_payload(
+            kvel_dataset, airport="KVEL", init_time=init
+        )
+        wind_speed = payload["series"]["wind_speed_kt"][0]
+        assert wind_speed == pytest.approx(10.0 * KT_PER_MS, rel=1e-2)
+        hw_340 = payload["series"]["headwind_kt_340"][0]
+        hw_160 = payload["series"]["headwind_kt_160"][0]
+        assert hw_160 > 0
+        assert hw_340 < 0
+        assert hw_340 == pytest.approx(-hw_160, rel=1e-6)


### PR DESCRIPTION
## Summary
- `brc_tools/nwp/derived.py`: add `crosswind_kt`, `headwind_kt`, and a shared `KT_PER_MS` constant. Runway heading is degrees true; positive headwind = opposing aircraft; positive crosswind = from the right.
- `brc_tools/nwp/lookups.toml`: add `[airports.KVEL]` with `runway_headings_deg = [160, 340]` true.
- `brc_tools/nwp/aviation.py`: airport-relative wind payload builder. **Calls Herbie directly** instead of through `NWPSource.fetch` because `NWPSource._normalise.normalize_coords` unconditionally replaces the GRIB time coord with a single `init + fxx h` stamp, which collapses the HRRR `subh` 4-step 15-min axis back to hourly. The direct path preserves the native 15-min cadence.
- `scripts/export_hrrr_kvel_crosswind.py`: CLI with `--product {subh,sfc}`, `--max-fxx` (default 6 hours — tactical aviation window), `--dry-run`, `--server-url`.
- `scripts/cron/run_hrrr_kvel_crosswind_push.sh`: `.dev`-pinned cron wrapper. **Install gated** on the website consumer below.
- `tests/test_aviation_wind.py`: 10 tests covering calm / pure headwind / pure tailwind / left & right crosswind / KVEL 45° quartering / array input / payload shape / directional semantics.

Stage C of the HRRR → BasinWX rollout (issue #10). Independent of Stages A (#18) and B (#19).

## JSON shape
```
{
  "model": "hrrr_subh", "product": "aviation_crosswind",
  "airport": "KVEL", "lat", "lon", "elevation_m",
  "runway_headings_deg": [160, 340],
  "init_time": "...", "valid_times": [...], "forecast_minutes": [0, 15, 30, ...],
  "variables": { "wind_speed_kt", "wind_dir_deg", "gust_kt",
                 "crosswind_kt_160", "crosswind_kt_340",
                 "headwind_kt_160", "headwind_kt_340" },
  "series": { "<key>": [values...], ... }
}
```
Filename: `forecast_hrrr_kvel_crosswind_YYYYMMDD_HHMMZ.json`
Bucket: `forecasts`.

## Blocked on
- **`ubair-website`** aviation consumer: `views/aviation.html` is currently scaffold-only with a "Coming Soon" overlay and no JS reading the `forecasts` bucket. Do not install the cron until that consumer lands on `dev` — files would pile up invisibly.

## Known caveat — HRRR subh
The `subh` product is flagged "untested" in `WISHLIST-TASKS.md` (line 32). First live run should confirm `forecast_minutes` actually contains 15-min steps; if not, the workaround in `aviation.py` needs refinement. Falls back cleanly to `--product sfc` (hourly) if needed.

## Test plan
- [x] `pytest tests/test_aviation_wind.py` — 10/10 green.
- [x] Full suite `pytest tests/` — 85/85 green on this branch (10 new).
- [ ] `python scripts/export_hrrr_kvel_crosswind.py --dry-run --product subh --max-fxx 6` against a recent init produces JSON with `forecast_minutes = [0, 15, 30, ...]`.
- [ ] Live `.dev` push only after the aviation consumer PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)