### PR TITLE
feat(road): emit flat points[] for ubair-website road parser

### DIFF
--- a/brc_tools/download/get_road_forecast.py
+++ b/brc_tools/download/get_road_forecast.py
@@ -83,6 +83,7 @@ def build_road_payload(
     ]
 
     routes_out: dict[str, dict[str, object]] = {}
+    points_out: list[dict[str, object]] = []
     for route_id, corridor in ROAD_CORRIDORS.items():
         route_forecasts = forecasts_by_route.get(route_id, {})
         waypoints_out = []
@@ -106,6 +107,20 @@ def build_road_payload(
                     "forecasts": forecast_arrays,
                 }
             )
+            points_out.append(
+                {
+                    "route_id": route_id,
+                    "name": waypoint["name"],
+                    "lat": waypoint["lat"],
+                    "lon": waypoint["lon"],
+                    "elevation_m": waypoint["elevation_m"],
+                    "reference_stid": waypoint["reference_stid"],
+                    "forecasts": [
+                        {"valid_time": valid_time, **hour}
+                        for valid_time, hour in zip(valid_times, hourly_values)
+                    ],
+                }
+            )
 
         routes_out[route_id] = {
             "name": corridor["name"],
@@ -121,6 +136,7 @@ def build_road_payload(
         "valid_times": valid_times,
         "variables": ROAD_FORECAST_VARIABLES_META,
         "routes": routes_out,
+        "points": points_out,
         "cameras": [],
     }
 

--- a/tests/test_road_forecast_logic.py
+++ b/tests/test_road_forecast_logic.py
@@ -64,3 +64,30 @@ def test_build_road_payload_preserves_hourly_shape():
         -1.0,
         -1.0,
     ]
+
+
+def test_build_road_payload_emits_flat_points_for_website():
+    init_time = dt.datetime(2026, 3, 17, 12, tzinfo=dt.timezone.utc)
+    hourly_template = [{"temp_2m": -1.0, "wind_speed_10m": 3.0}] * 3
+    forecasts_by_route = {
+        "us40": {0: hourly_template},
+        "us191": {},
+        "basin_roads": {},
+    }
+
+    payload = build_road_payload(
+        init_time=init_time,
+        max_fxx=3,
+        forecasts_by_route=forecasts_by_route,
+    )
+
+    points = payload["points"]
+    assert len(points) == 17  # 9 + 4 + 4 across all corridors
+    first = points[0]
+    assert first["route_id"] == "us40"
+    assert {"lat", "lon", "name", "forecasts"} <= set(first)
+    assert len(first["forecasts"]) == 3
+    step_zero = first["forecasts"][0]
+    assert step_zero["valid_time"] == "2026-03-17T13:00:00Z"
+    assert step_zero["temp_2m"] == -1.0
+    assert step_zero["wind_speed_10m"] == 3.0


### PR DESCRIPTION
## Summary
- Makes road-forecast JSON consumable by `ubair-website`'s `roadWeatherService.getHRRRConditionAtPoint` (server/roadWeatherService.js:399-415), which short-circuits without a flat top-level `points[]`.
- Supplements the existing `routes{}.waypoints[]` structure rather than replacing it — no future internal consumer of route grouping is broken.
- Each point carries a per-step `forecasts[]` array with `valid_time` embedded, matching the `nearest.forecasts?.[0]` access pattern at line 420 and future-proofing for indices > 0.
- Units already match the website's expectations (temp °C, wind m/s, visibility km, precip mm).

## Why this is needed
This is the deeper blocker the apr27 handoff practical test surfaced. The naming-only fix in PR #18 (revert bucket default) restores the upload destination but the payload itself was still incompatible with the parser. Both were required: bucket revert lands the file in the right place; this PR makes the file's shape readable.

## Design choices (per `roadforecast_shape_blocker.md`)
- **Replace vs supplement?** Supplement. Cheapest coordination; no internal consumer reads `routes` today, but keeping the route grouping costs ~zero and preserves route name + ordering for future use.
- **Per-step array vs index-0 only?** Full per-step array. Website ignores indices > 0 today but will likely want them later.
- **Point cardinality.** Option (a) flatten current 17 waypoints (us40 + us191 + basin_roads). Upgrade to interpolated densification later if `gatherSourcesForSegment` segment midpoints want finer granularity.

## Test plan
- [x] `pytest tests/test_road_forecast_logic.py` — new test asserts 17 points, route_id tagging, forecasts list length, valid_time format, unit values.
- [x] Full suite (62 tests) green.
- [ ] After merge: dry-run from notchpeak1, upload to `.dev`, hit `/api/road-weather/forecast` and confirm a non-null response (currently 404 even after PR #18 fix).
- [ ] After merge: coordinate with website team to add a `road-forecast` entry to `ubair-website/DATA_MANIFEST.json`.

## Notes
- Stacks logically after PR #18 (#18 fixes the upload bucket so the file lands at the right path; this PR fixes the file's shape so the parser reads it). The two changes are independent at the code level; PR #18 does not need to merge first.
- See `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` (repo root) for the original handoff that prompted this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)