### PR TITLE
WRF staging-hygiene batch: manifest schema v2, token preflight, cross-repo handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging** (branch `feat/wrf-input-staging`): stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin); GEFS two-stream still optional. Status: `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detailed handoff: `docs/WRF-INPUT-STAGING.md`. If arriving from `brc-wrf`, read `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
+- **WRF-input staging** (branch `feat/wrf-input-staging`): stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin); GEFS two-stream still optional. Status: `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detailed handoff: `docs/WRF-INPUT-STAGING.md`. If arriving from `brc-wrf`, read `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`; handing the run side back to `brc-wrf`, use `docs/HANDOFF-TO-BRC-WRF.md`.
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -41,6 +41,7 @@ figures/          generated output (gitignored)
 - `docs/WRF-INPUT-STAGING.md` — WRF/WPS GRIB staging: status, microtasks, CHPC DTN + SLURM
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — terse WRF staging state and reading packet
 - `docs/WRF-GEFS-NAM-FIELD-MAP.md` — DRAFT GEFS/NAM two-stream field-map (NOT proven)
+- `docs/HANDOFF-TO-BRC-WRF.md` — paste-prompt to hand the WRF run side to a brc-wrf session
 - `WISHLIST-TASKS.md` — prioritised backlog
 
 When introducing or editing a topic, find its canonical home above and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging** (branch `feat/wrf-input-staging`): stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin); merge gate met, GEFS two-stream still optional. Handoff + microtasks + CHPC/SLURM: `docs/WRF-INPUT-STAGING.md`.
+- **WRF-input staging** (branch `feat/wrf-input-staging`): stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin); GEFS two-stream still optional. Status: `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detailed handoff: `docs/WRF-INPUT-STAGING.md`. If arriving from `brc-wrf`, read `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -36,6 +36,7 @@ figures/          generated output (gitignored)
 - `docs/CROSS-REPO-SYNC.md` — sync protocol with clyfar / ubair-website / preprint
 - `docs/nwp/ROADMAP.md` — HRRR/RRFS strategy and phase tracker
 - `docs/WRF-INPUT-STAGING.md` — WRF/WPS GRIB staging: status, microtasks, CHPC DTN + SLURM
+- `docs/WRF-STAGING-STATE-PLAYBOOK.md` — terse WRF staging state and reading packet
 - `WISHLIST-TASKS.md` — prioritised backlog
 
 When introducing or editing a topic, find its canonical home above and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,8 @@ with headers `x-api-key` (32-char hex from `DATA_UPLOAD_API_KEY`) and
 a cross-repo PR. Operational deployment lives in `docs/CHPC-REFERENCE.md`.
 
 ## Conventions
-- **UTC internally, always.** `datetime.timezone.utc`, never pytz.
+- **UTC internally, always.** `datetime.timezone.utc`, never pytz. (Servers sit in different local zones — UTC is the portable invariant; convert to Mountain only at display.)
+- **No path crosses machines.** CHPC and the Linode/Akamai website hub share **no filesystem**; absolute paths (`/uufs`, `/scratch`, `~`) are machine-local (CHPC-only here). The cross-machine seam is the **HTTP URL contract** (`BASINWX_API_URLS` / `~/.config/ubair-website/website_url`), never a shared path; in-repo doc/code references use **relative** paths. Same discipline as UTC: commit the portable invariant (UTC / URL / relative), never the machine-specific form. **Cold-start check:** if a doc or script hands an absolute path to the *other* server, that's a bug.
 - **Polars** preferred over pandas for new code.
 - **American English** in code identifiers (British prose is fine).
 - **Imports**: stdlib → third-party → local.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging**: stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin) and **merged to `main` via PR #22**; GEFS two-stream still optional. A post-merge staging-hygiene batch (manifest schema v2 + token preflight) is on branch `feat/wrf-input-staging` (PR open). Status: `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detailed handoff: `docs/WRF-INPUT-STAGING.md`. If arriving from `brc-wrf`, read `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`; handing the run side back to `brc-wrf`, use `docs/HANDOFF-TO-BRC-WRF.md` (+ `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md` for the cross-repo wiring/caretaker pass).
+- **WRF-input staging**: GRIB → scratch for WPS/WRF (brc-tools' half; the model run is `brc-wrf`'s). NAM-only proven & merged; GEFS+NAM two-stream optional/unproven. State → `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detail → `docs/WRF-INPUT-STAGING.md`; cross-repo handoffs → `docs/HANDOFF-TO-BRC-WRF.md` + `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md`; arriving from brc-wrf → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -85,8 +85,8 @@ a cross-repo PR. Operational deployment lives in `docs/CHPC-REFERENCE.md`.
 pytest tests/
 ```
 Local Python work: use a conda env that carries the deps (herbie, polars, pandas,
-matplotlib, requests) — `clyfar-nov2025` works — not bare `python`. (There is no
-dedicated `brc-tools` env.)
+matplotlib, requests). On this CHPC checkout `clyfar-nov2025` already has them;
+fresh setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
 
 ## Related repos
 - `ubair-website` — Node.js receiver for uploads (data contract).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging** (branch `feat/wrf-input-staging`): stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin); GEFS two-stream still optional. Status: `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detailed handoff: `docs/WRF-INPUT-STAGING.md`. If arriving from `brc-wrf`, read `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`; handing the run side back to `brc-wrf`, use `docs/HANDOFF-TO-BRC-WRF.md`.
+- **WRF-input staging**: stage GRIB (GEFS reforecast + NAM analysis) to scratch for WRF/WPS. **End-to-end validated** (NAM-only single-stream → WPS → `real.exe` → `wrf.exe` `SUCCESS COMPLETE WRF`, Jan-2013 Basin) and **merged to `main` via PR #22**; GEFS two-stream still optional. A post-merge staging-hygiene batch (manifest schema v2 + token preflight) is on branch `feat/wrf-input-staging` (PR open). Status: `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detailed handoff: `docs/WRF-INPUT-STAGING.md`. If arriving from `brc-wrf`, read `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`; handing the run side back to `brc-wrf`, use `docs/HANDOFF-TO-BRC-WRF.md` (+ `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md` for the cross-repo wiring/caretaker pass).
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -31,7 +31,9 @@ figures/          generated output (gitignored)
 ## Doc map (single source of truth per topic)
 - `README.md` — install + minimal quick usage (human onboarding)
 - `docs/walkthroughs/` — plain-language per-tool walk-throughs + shared glossary (new-hire entry point)
+- `docs/README.md` — index of the `docs/` directory (mirrors this map)
 - `docs/API-REFERENCE.md` — full module / function reference
+- `docs/API-CLIENTS.md` — external API-client helpers (e.g. FlightAware/AeroAPI)
 - `docs/CASE-STUDY-GUIDE.md` — how to write a case-study script (pattern, conventions)
 - `docs/CHPC-REFERENCE.md` — CHPC account, partitions, salloc, cron (incl. HRRR upload)
 - `docs/WEBSITE-INTEGRATION.md` — BasinWX upload contract (endpoint, auth, dataTypes, schemas, fan-out)
@@ -42,6 +44,7 @@ figures/          generated output (gitignored)
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — terse WRF staging state and reading packet
 - `docs/WRF-GEFS-NAM-FIELD-MAP.md` — DRAFT GEFS/NAM two-stream field-map (NOT proven)
 - `docs/HANDOFF-TO-BRC-WRF.md` — paste-prompt to hand the WRF run side to a brc-wrf session
+- `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md` — cross-repo wiring + AGENTS-caretaker handoff to brc-wrf
 - `WISHLIST-TASKS.md` — prioritised backlog
 
 When introducing or editing a topic, find its canonical home above and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,9 @@ a cross-repo PR. Operational deployment lives in `docs/CHPC-REFERENCE.md`.
 ```
 pytest tests/
 ```
-Local Python work: use the `brc-tools` conda env, not bare `python`.
+Local Python work: use a conda env that carries the deps (herbie, polars, pandas,
+matplotlib, requests) — `clyfar-nov2025` works — not bare `python`. (There is no
+dedicated `brc-tools` env.)
 
 ## Related repos
 - `ubair-website` — Node.js receiver for uploads (data contract).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,20 +23,24 @@ brc_tools/        installable package
   utils/          lookups, small helpers
 scripts/          operational scripts + case studies
 docs/             canonical project docs (see Doc map below)
+  walkthroughs/   plain-language per-tool guides + glossary
 tests/            pytest suite
 figures/          generated output (gitignored)
 ```
 
 ## Doc map (single source of truth per topic)
 - `README.md` — install + minimal quick usage (human onboarding)
+- `docs/walkthroughs/` — plain-language per-tool walk-throughs + shared glossary (new-hire entry point)
 - `docs/API-REFERENCE.md` — full module / function reference
 - `docs/CASE-STUDY-GUIDE.md` — how to write a case-study script (pattern, conventions)
 - `docs/CHPC-REFERENCE.md` — CHPC account, partitions, salloc, cron (incl. HRRR upload)
+- `docs/WEBSITE-INTEGRATION.md` — BasinWX upload contract (endpoint, auth, dataTypes, schemas, fan-out)
 - `docs/ENVIRONMENT-SETUP.md` — conda / venv setup
 - `docs/CROSS-REPO-SYNC.md` — sync protocol with clyfar / ubair-website / preprint
 - `docs/nwp/ROADMAP.md` — HRRR/RRFS strategy and phase tracker
 - `docs/WRF-INPUT-STAGING.md` — WRF/WPS GRIB staging: status, microtasks, CHPC DTN + SLURM
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — terse WRF staging state and reading packet
+- `docs/WRF-GEFS-NAM-FIELD-MAP.md` — DRAFT GEFS/NAM two-stream field-map (NOT proven)
 - `WISHLIST-TASKS.md` — prioritised backlog
 
 When introducing or editing a topic, find its canonical home above and

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > AI agents: see [`CLAUDE.md`](CLAUDE.md) for project context.
 > Documentation index: [`docs/`](docs/). Current focus: HRRR/RRFS ingest in [`docs/nwp/`](docs/nwp/).
+> New here (and not a meteorologist)? Start with [`docs/walkthroughs/`](docs/walkthroughs/) — one short copy-paste page per tool, plus a glossary.
 
 Shared Python utilities for atmospheric data operations at the Bingham
 Research Center. Pulls weather observations (SynopticPy) and NWP model
@@ -75,6 +76,12 @@ it directly**. New brc-tools code should use `send_json_to_all(urls, ...)`
 instead; the legacy function stays intact until `clyfar` migrates (tracked as
 a follow-up, needs a cross-repo PR per
 [`docs/CROSS-REPO-SYNC.md`](docs/CROSS-REPO-SYNC.md)).
+
+## Open threads / TODO
+
+Active backlog and open action items live in [`WISHLIST-TASKS.md`](WISHLIST-TASKS.md)
+(the canonical prioritised backlog). Cross-repo WRF state lives in
+[`docs/WRF-STAGING-STATE-PLAYBOOK.md`](docs/WRF-STAGING-STATE-PLAYBOOK.md).
 
 ## Authors
 

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -2,6 +2,21 @@
 
 Completed items are removed once merged; git history is the record.
 
+## WRF-input staging (branch `feat/wrf-input-staging`)
+
+A separate active lane: stage GRIB (GEFSv12 reforecast + NAM analysis) to scratch
+for WRF/WPS, with a provenance manifest + case contract. **NAM-only single-stream is
+proven end-to-end** (WPS → `real.exe` → `wrf.exe`); the **GEFS+NAM two-stream path is
+not** proven. brc-tools owns download/staging/manifest only — WPS/`real.exe`/`wrf.exe`/
+Slurm run profiles stay in `brc-wrf`.
+
+- Canonical docs: `docs/WRF-INPUT-STAGING.md` (full handoff) and
+  `docs/WRF-STAGING-STATE-PLAYBOOK.md` (terse state).
+- Cross-repo entry point: `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
+- The remaining staging-microtask backlog (#4–#13, #31, …) lives in
+  `../brc-wrf/doc/BRC_WRF_MICROTASK_HANDOFF.md` — that handoff is the source of truth
+  for this lane; not duplicated here.
+
 ## Priority 1: Reliability
 
 The NWP/obs pipeline is functional but undertested. One regression in

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -18,11 +18,12 @@ in every case study.
 The case study pipeline proves the NWP library works. Closing #10 means
 the website receives fresh HRRR forecasts automatically.
 
-- [ ] **Define BasinWX JSON contract for HRRR waypoint forecasts** — document the expected JSON shape, variable names (`PM_25_concentration` vs `pm25_concentration`), and upload endpoint. Needs `reference/WEBSITE-INTEGRATION.md`.
+- [ ] **Define BasinWX JSON contract for HRRR waypoint forecasts** — document the expected JSON shape, variable names (`PM_25_concentration` vs `pm25_concentration`), and upload endpoint. Generic upload contract now documented in `docs/WEBSITE-INTEGRATION.md`; this item remains for the HRRR-waypoint-specific variable naming.
 - [ ] **HRRR waypoint forecast script** — scheduled script that calls `NWPSource.fetch()` → `extract_at_waypoints()` → formats JSON → `push_data.send_json_to_server()`. Target: hourly cron on CHPC.
 - [ ] Test data export format matches the JSON contract above.
 - [ ] Add structured logging to the operational script (replace print statements for scheduled/unattended runs).
 - [ ] **Road-forecast `points[]` projection** — `brc_tools/download/get_road_forecast.py` currently emits `routes{routeId: {waypoints[]}}` but `ubair-website/server/roadWeatherService.js:400` (`getHRRRConditionAtPoint`) reads `hrrrForecast.points[]`. Without a flat `points[]` the website parser returns `null` even when the file is uploaded. Design questions to resolve: (a) replace `routes{}` or supplement it (downstream consumers TBD); (b) per-point `forecasts[{valid_time, temp_2m, ...}]` array vs single `forecasts[0]` only — `roadWeatherService.js:420` reads index 0 only; (c) cardinality — flatten all route waypoints into one `points[]` or sample a denser grid. Cite: handoff `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` §"DATATYPE 1 — road-forecast", and `dataUpload.js:189` (only `dataType==='road-forecast'` triggers `latest.json` side-effect — keep that bucket).
+- [ ] **Dark website dataTypes (2026-04-27 handoff)** — three products the website expects but brc-tools never emits: `forecast_hrrr_kvel_crosswind_*` (PR #183), `forecast_hrrr_surface_layers_*` (PR #176), and the `forecasts` clustering fan-out gap to `.dev`. Schemas + endpoint contract in `docs/WEBSITE-INTEGRATION.md`.
 
 ## Priority 3: Analysis capability
 
@@ -32,6 +33,7 @@ Extend the case study toolkit for deeper diagnostics.
 - [ ] **Profile plotting** (`visualize/profile.py`) — single-station vertical profile. Stubs exist.
 - [ ] HRRR sub-hourly (15-min) support — product "subh" is defined in lookups.toml but untested.
 - [ ] GEFS ensemble workflows — spread, probability, lagged ensemble. Config exists; no analysis code yet.
+- [ ] **Synoptic USGS-HYDRO access** — the token lacks network `mnet_id=203`, so `stream_flow`/`gage_height` queries return zero. Email `support@synopticdata.com` to add it; interim workaround = USGS NWIS direct (`dataretrieval`). Fact folded into `docs/CHPC-REFERENCE.md`; full evidence in root `SYNOPTIC-TOKEN-USGS-DIAGNOSIS.md`. `scripts/inventory_streamflow_vernal.py` lights up once granted.
 
 ## Priority 4: Developer experience
 
@@ -61,6 +63,10 @@ here so the next cold-start agent knows to tackle it.
 - [ ] **Update "Key data-flow anchor" in CLAUDE.md** post-fan-out to mention
   `send_json_to_all` + `BASINWX_API_URLS` (small; bundle with the overhaul
   above unless a cold-start agent wants a quick win first).
+- [ ] **Retire folded root scratch notes (human gate)** — `WEBSITE-BRCTOOLS-HANDOFF-apr27.md`
+  (contract folded into `docs/WEBSITE-INTEGRATION.md`; keep until its website PRs
+  #176/#183/#188 close) and `SYNOPTIC-TOKEN-USGS-DIAGNOSIS.md` (fact folded into
+  `docs/CHPC-REFERENCE.md`). Delete both once their open actions close.
 
 ## Priority 6: Seasonal ops (pause/resume)
 

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -37,7 +37,7 @@ the website receives fresh HRRR forecasts automatically.
 - [ ] **HRRR waypoint forecast script** — scheduled script that calls `NWPSource.fetch()` → `extract_at_waypoints()` → formats JSON → `push_data.send_json_to_server()`. Target: hourly cron on CHPC.
 - [ ] Test data export format matches the JSON contract above.
 - [ ] Add structured logging to the operational script (replace print statements for scheduled/unattended runs).
-- [ ] **Road-forecast `points[]` projection** — `brc_tools/download/get_road_forecast.py` currently emits `routes{routeId: {waypoints[]}}` but `ubair-website/server/roadWeatherService.js:400` (`getHRRRConditionAtPoint`) reads `hrrrForecast.points[]`. Without a flat `points[]` the website parser returns `null` even when the file is uploaded. Design questions to resolve: (a) replace `routes{}` or supplement it (downstream consumers TBD); (b) per-point `forecasts[{valid_time, temp_2m, ...}]` array vs single `forecasts[0]` only — `roadWeatherService.js:420` reads index 0 only; (c) cardinality — flatten all route waypoints into one `points[]` or sample a denser grid. Cite: handoff `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` §"DATATYPE 1 — road-forecast", and `dataUpload.js:189` (only `dataType==='road-forecast'` triggers `latest.json` side-effect — keep that bucket).
+- [ ] **Road-forecast `points[]` projection** — `brc_tools/download/get_road_forecast.py` currently emits `routes{routeId: {waypoints[]}}` but `ubair-website/server/roadWeatherService.js:400` (`getHRRRConditionAtPoint`) reads `hrrrForecast.points[]`. Without a flat `points[]` the website parser returns `null` even when the file is uploaded. Design questions to resolve: (a) replace `routes{}` or supplement it (downstream consumers TBD); (b) per-point `forecasts[{valid_time, temp_2m, ...}]` array vs single `forecasts[0]` only — `roadWeatherService.js:420` reads index 0 only; (c) cardinality — flatten all route waypoints into one `points[]` or sample a denser grid. Cite: `docs/WEBSITE-INTEGRATION.md` (road-forecast §) and `dataUpload.js:189` (only `dataType==='road-forecast'` triggers `latest.json` side-effect — keep that bucket).
 - [ ] **Dark website dataTypes (2026-04-27 handoff)** — three products the website expects but brc-tools never emits: `forecast_hrrr_kvel_crosswind_*` (PR #183), `forecast_hrrr_surface_layers_*` (PR #176), and the `forecasts` clustering fan-out gap to `.dev`. Schemas + endpoint contract in `docs/WEBSITE-INTEGRATION.md`.
 
 ## Priority 3: Analysis capability
@@ -48,7 +48,7 @@ Extend the case study toolkit for deeper diagnostics.
 - [ ] **Profile plotting** (`visualize/profile.py`) — single-station vertical profile. Stubs exist.
 - [ ] HRRR sub-hourly (15-min) support — product "subh" is defined in lookups.toml but untested.
 - [ ] GEFS ensemble workflows — spread, probability, lagged ensemble. Config exists; no analysis code yet.
-- [ ] **Synoptic USGS-HYDRO access** — the token lacks network `mnet_id=203`, so `stream_flow`/`gage_height` queries return zero. Email `support@synopticdata.com` to add it; interim workaround = USGS NWIS direct (`dataretrieval`). Fact folded into `docs/CHPC-REFERENCE.md`; full evidence in root `SYNOPTIC-TOKEN-USGS-DIAGNOSIS.md`. `scripts/inventory_streamflow_vernal.py` lights up once granted.
+- [ ] **Synoptic USGS-HYDRO access** — the token lacks network `mnet_id=203`, so `stream_flow`/`gage_height` queries return zero. Email `support@synopticdata.com` to add it; interim workaround = USGS NWIS direct (`dataretrieval`). Fact + evidence folded into `docs/CHPC-REFERENCE.md`. `scripts/inventory_streamflow_vernal.py` lights up once granted.
 
 ## Priority 4: Developer experience
 
@@ -71,17 +71,11 @@ here so the next cold-start agent knows to tackle it.
 - [ ] **Roadmap brainstorm** — prepare a small doc (`docs/ROADMAP.md` or
   similar) that captures the next 6–12 months of work in outcome terms, not
   task lists. Input to the CLAUDE.md overhaul.
-- [ ] **Prune root + file contents** for AI-and-human readability: remove
-  stale `docs/` entries (PIPELINE-ARCHITECTURE aspirational, `nwp/MERGE-PLAN`
-  historical), consolidate `docs/nwp/` archive, and make sure every top-level
-  file earns its place.
+- [ ] **Prune root + file contents** for AI-and-human readability: keep
+  `docs/nwp/` tight and make sure every top-level file earns its place.
 - [ ] **Update "Key data-flow anchor" in CLAUDE.md** post-fan-out to mention
   `send_json_to_all` + `BASINWX_API_URLS` (small; bundle with the overhaul
   above unless a cold-start agent wants a quick win first).
-- [ ] **Retire folded root scratch notes (human gate)** — `WEBSITE-BRCTOOLS-HANDOFF-apr27.md`
-  (contract folded into `docs/WEBSITE-INTEGRATION.md`; keep until its website PRs
-  #176/#183/#188 close) and `SYNOPTIC-TOKEN-USGS-DIAGNOSIS.md` (fact folded into
-  `docs/CHPC-REFERENCE.md`). Delete both once their open actions close.
 
 ## Priority 6: Seasonal ops (pause/resume)
 

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -44,8 +44,10 @@ import socket
 import subprocess
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from urllib.parse import quote
 
 import fasteners
 import requests
@@ -1055,6 +1057,94 @@ def verify_manifest(manifest_path: str | Path) -> dict:
     return {"ok": n_ok == len(results), "n_files": len(results), "n_ok": n_ok, "results": results}
 
 
+# ── token preflight (reforecast S3 prefix vs configured wps_variable_levels) ──
+
+
+def _list_s3_keys(url: str, connect_timeout: float, read_timeout: float) -> list[str]:
+    """GET an S3 ``list-type=2`` URL and return every ``<Key>`` in the response.
+
+    Namespace-agnostic XML parse (matches tags whose localname is ``Key``, so it is
+    immune to the ``xmlns`` on ``ListBucketResult``). Warns if the listing is truncated
+    (``IsTruncated=true``); a reforecast member/bucket dir holds ~21 files, far under the
+    1000-key page limit, so a single page is expected.
+    """
+    timeout = (connect_timeout, read_timeout)
+    with requests.get(url, timeout=timeout) as resp:
+        resp.raise_for_status()
+        body = resp.content
+    root = ET.fromstring(body)
+    keys: list[str] = []
+    truncated = False
+    for elem in root.iter():
+        tag = elem.tag.rsplit("}", 1)[-1]  # strip any {namespace}
+        if tag == "Key" and elem.text:
+            keys.append(elem.text)
+        elif tag == "IsTruncated" and (elem.text or "").strip().lower() == "true":
+            truncated = True
+    if truncated:
+        LOG.warning("S3 listing truncated (>1000 keys?) at %s; results may be partial.", url)
+    return keys
+
+
+def preflight_tokens(
+    *,
+    init_time: str | dt.datetime,
+    member: int = 0,
+    source: str = DEFAULT_SOURCE,
+    fxx: int = 12,
+    variable_levels: list[str] | None = None,
+    connect_timeout: float = DEFAULT_HTTP_CONNECT_TIMEOUT,
+    read_timeout: float = DEFAULT_HTTP_READ_TIMEOUT,
+) -> dict:
+    """Diff the reforecast S3 prefix listing against the configured ``wps_variable_levels``.
+
+    Lists the per-variable files actually present at the reforecast init/member/bucket
+    prefix on S3 and compares their variable-level tokens to the configured set, catching
+    dataset drift across the 2000-2019 archive **before** a stage commits to downloads.
+    One S3 ``list-type=2`` GET; no GRIB is fetched. Returns
+    ``{prefix, bucket, member, configured, available, missing, extra, ok}`` where
+    ``missing`` are configured-but-absent tokens, ``extra`` present-but-unconfigured, and
+    ``ok`` is ``True`` when nothing configured is missing.
+    """
+    init_dt = _parse_init_time(init_time)
+    lu = load_lookups()
+    cfg = lu["models"].get(source, {})
+    breakpoint_fxx = int(cfg.get("fxx_bucket_breakpoint", 240))
+    member_token = _member_token(member)
+    bucket = _fxx_bucket(int(fxx), breakpoint_fxx)
+    configured = list(variable_levels or cfg.get("wps_variable_levels", []))
+
+    prefix = f"GEFSv12/reforecast/{init_dt:%Y}/{init_dt:%Y%m%d%H}/{member_token}/{bucket}/"
+    url = (
+        "https://noaa-gefs-retrospective.s3.amazonaws.com/?list-type=2&prefix="
+        + quote(prefix, safe="")  # encode the Days:1-10 colon + the slashes
+    )
+    keys = _list_s3_keys(url, connect_timeout, read_timeout)
+
+    # Recover each variable-level token by stripping the deterministic
+    # "_<yyyymmdd><hh>_<member>.grib2" suffix (derived from _reforecast_filename — DRY).
+    suffix = _reforecast_filename("", init_dt, member_token)
+    available = sorted(
+        {
+            name[: -len(suffix)]
+            for name in (k.rsplit("/", 1)[-1] for k in keys)
+            if name.endswith(suffix) and len(name) > len(suffix)
+        }
+    )
+    missing = sorted(set(configured) - set(available))
+    extra = sorted(set(available) - set(configured))
+    return {
+        "prefix": prefix,
+        "bucket": bucket,
+        "member": member_token,
+        "configured": configured,
+        "available": available,
+        "missing": missing,
+        "extra": extra,
+        "ok": not missing,
+    }
+
+
 # ── orchestrator ────────────────────────────────────────────────────────────
 
 
@@ -1249,6 +1339,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--verify-manifest", default=None, metavar="PATH",
         help="Re-hash staged files against a manifest JSON and exit (integrity check).",
     )
+    parser.add_argument(
+        "--preflight", action="store_true",
+        help="List the reforecast S3 prefix for --init-time/--members[0] and diff against "
+             "wps_variable_levels, then exit (catches token drift; one live S3 GET).",
+    )
     parser.add_argument("--no-quicklook", action="store_true", help="Skip quicklook figures.")
     parser.add_argument("--obs-check", action="store_true", help="Attempt SynopticPy obs overlay (opt-in).")
     parser.add_argument("--no-validate-tokens", action="store_true", help="Skip the H.inventory() token guard.")
@@ -1301,6 +1396,25 @@ def main(argv: list[str] | None = None) -> int:
         )
         _print_plan(plan)
         return 0
+
+    if args.preflight:
+        report = preflight_tokens(
+            init_time=args.init_time,
+            member=members[0] if members else 0,
+            source=sources[0] if sources else DEFAULT_SOURCE,
+            fxx=fxx_window[0],
+            variable_levels=variable_levels,
+            connect_timeout=args.connect_timeout,
+            read_timeout=args.read_timeout,
+        )
+        print(f"preflight {report['member']} s3://noaa-gefs-retrospective/{report['prefix']}")
+        print(f"  available={len(report['available'])} configured={len(report['configured'])}")
+        if report["missing"]:
+            print("  MISSING (configured, not on S3): " + ", ".join(report["missing"]))
+        if report["extra"]:
+            print("  extra (on S3, not configured): " + ", ".join(report["extra"]))
+        print("preflight: " + ("OK" if report["ok"] else "DRIFT"))
+        return 0 if report["ok"] else 1
 
     try:
         manifest_path = stage_case(

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -802,8 +802,13 @@ def build_manifest(
     interval_hours: int,
     sources: list[str],
     staged: list[StagedFile],
+    elapsed_seconds: float | None = None,
 ) -> dict:
-    """Compose the staging manifest (case block + provenance + per-file list)."""
+    """Compose the staging manifest (case block + provenance + per-file list).
+
+    ``elapsed_seconds`` is the end-to-end staging wall-time measured by the caller
+    (:func:`stage_case`); ``None`` when the manifest is built outside a timed run.
+    """
     lu = load_lookups()
     region_cfg = lu.get("regions", {}).get(region, {})
     bbox = (
@@ -836,6 +841,15 @@ def build_manifest(
             "git_sha": _git_sha(),
             "herbie_version": _herbie_version(),
             "generated_at": _isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+            "total_bytes": int(sum(s.size_bytes for s in staged)),
+            "elapsed_seconds": (
+                round(float(elapsed_seconds), 3) if elapsed_seconds is not None else None
+            ),
+            "note": (
+                "total_bytes is the on-disk footprint of staged_files (not bytes "
+                "transferred -- skip-existing files inflate it); elapsed_seconds is "
+                "end-to-end staging wall-time (includes sha256 + move), null if unmeasured."
+            ),
         },
         "staged_files": [asdict(s) for s in staged],
     }
@@ -1083,6 +1097,7 @@ def stage_case(
         interval_hours = _interval_hours_for_sources(src_list, lu)
 
     staged: list[StagedFile] = []
+    t0 = time.perf_counter()  # end-to-end staging wall-time (incl. sha256 + move)
     for src in src_list:
         if src == DEFAULT_NAM_SOURCE:
             staged.extend(
@@ -1119,6 +1134,7 @@ def stage_case(
         interval_hours=interval_hours,
         sources=list(src_list),
         staged=staged,
+        elapsed_seconds=time.perf_counter() - t0,
     )
     case_dir = Path(output_root) / case
     manifest_path = write_manifest(manifest, case_dir)

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -66,7 +66,9 @@ DEFAULT_SCRATCH_ROOT = Path(
     f"/scratch/general/vast/{os.environ.get('USER', 'user')}/wrf_inputs"
 )
 TOOL_NAME = "brc-tools"
-MANIFEST_SCHEMA_VERSION = 1
+# v2: added staged_files[].lead_times_source + provenance.total_bytes/elapsed_seconds.
+# Additive only; brc-wrf reads the contract sidecar, and verify_manifest still reads v1.
+MANIFEST_SCHEMA_VERSION = 2
 CONTRACT_SCHEMA_VERSION = 1
 
 # Split HTTP timeouts for direct GETs: a short connect bound (so a wedged socket
@@ -134,6 +136,11 @@ class StagedFile:
     size_bytes: int
     sha256: str
     created_at: str
+    # Provenance of ``lead_times``: "inventory" (parsed from a live Herbie inventory at
+    # download), "analysis" (NAM single-cycle, always [0]), "idx" (recovered from a
+    # co-located ``<file>.idx`` on the skip-existing path), or "skip-no-idx" (skip path
+    # with no sidecar idx — ``lead_times`` is empty; re-run with overwrite for full fidelity).
+    lead_times_source: str = "inventory"
 
 
 # ── token / path helpers ────────────────────────────────────────────────────
@@ -283,6 +290,22 @@ def _lead_times_from_inventory(inv) -> list[int]:
     if inv is None:
         return []
     hours = {h for h in (_parse_lead(v) for v in _inv_lead_values(inv)) if h is not None}
+    return sorted(hours)
+
+
+def _lead_times_from_idx(idx_path: Path) -> list[int]:
+    """Best-effort sorted integer lead-time list from a co-located GRIB ``.idx`` sidecar.
+
+    The idx is the wgrib-style inventory text written next to a GRIB; each line carries a
+    forecast-time token (e.g. ``...:3 hour fcst:...``) that :func:`_parse_lead` already
+    understands. Returns ``[]`` on any read/parse failure, so the caller falls back to a
+    degraded (but labelled) skip entry rather than raising.
+    """
+    try:
+        text = Path(idx_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    hours = {h for h in (_parse_lead(line) for line in text.splitlines()) if h is not None}
     return sorted(hours)
 
 
@@ -478,6 +501,7 @@ def stage_reforecast(
                     size_bytes=dest.stat().st_size,
                     sha256=_sha256(dest),
                     created_at=_isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+                    lead_times_source="inventory",
                 )
             )
             LOG.info("staged %s -> %s (%d bytes)", token, dest, dest.stat().st_size)
@@ -490,11 +514,20 @@ def _record_existing(
 ) -> StagedFile:
     """Build a StagedFile for an already-present file without re-downloading.
 
-    ``lead_times`` is left empty because deriving it would require an
-    ``H.inventory()`` network call, which the skip-existing path deliberately
-    avoids; ``remote_url`` is reconstructed deterministically. Use
-    ``overwrite=True`` for a full-fidelity manifest.
+    The skip-existing path deliberately avoids an ``H.inventory()`` network call, so
+    ``lead_times`` is recovered offline only from a co-located ``<dest>.idx`` sidecar
+    *if one is present* (``lead_times_source="idx"``). In normal operation no idx is
+    co-located — staging moves only the GRIB, not its idx — so the entry is recorded
+    empty and labelled ``"skip-no-idx"``; re-run with ``overwrite=True`` for
+    full-fidelity lead times. ``remote_url`` is reconstructed deterministically.
     """
+    idx_path = Path(str(dest) + ".idx")
+    if idx_path.exists():
+        lead_times = _lead_times_from_idx(idx_path)
+        lead_times_source = "idx" if lead_times else "skip-no-idx"
+    else:
+        lead_times = []
+        lead_times_source = "skip-no-idx"
     return StagedFile(
         source=source,
         herbie_model=herbie_model,
@@ -503,13 +536,14 @@ def _record_existing(
         init_time=_isoformat_utc(init_dt),
         variable_level=token,
         fxx_bucket=bucket,
-        lead_times=[],
+        lead_times=lead_times,
         product=str(cfg.get("default_product", "")),
         local_path=str(dest),
         remote_url=_reforecast_remote_url(token, init_dt, member_token, bucket),
         size_bytes=dest.stat().st_size,
         sha256=_sha256(dest),
         created_at=_isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+        lead_times_source=lead_times_source,
     )
 
 
@@ -657,6 +691,7 @@ def _nam_staged_file(
         size_bytes=dest.stat().st_size,
         sha256=_sha256(dest),
         created_at=_isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+        lead_times_source="analysis",
     )
 
 

--- a/docs/CHPC-REFERENCE.md
+++ b/docs/CHPC-REFERENCE.md
@@ -85,6 +85,7 @@ Swap to `--server-url https://www.basinwx.com` for production.
 | `ModuleNotFoundError: brc_tools` | PYTHONPATH unset or wrong env | Activate the env and re-source `~/.bashrc` |
 | Conda not found | Shell not initialised | `source ~/software/pkg/miniforge3/etc/profile.d/conda.sh` |
 | `df` reports "Too many levels of symbolic links" on a group volume | autofs fault on this node | Try a different node; volume may still be intact elsewhere |
+| Synoptic `stream_flow` / `gage_height` queries return zero stations | The token lacks the **USGS HYDRO** network (`mnet_id=203`) — it's a separate entitlement, not bundled with state/20-yr access | Email `support@synopticdata.com` to add network 203; meanwhile pull gauges directly from **USGS NWIS** (`pip install dataretrieval`, or `https://waterservices.usgs.gov/nwis/`) |
 
 ## Team members (CHPC access)
 

--- a/docs/CROSS-REPO-SYNC.md
+++ b/docs/CROSS-REPO-SYNC.md
@@ -67,6 +67,13 @@ These files must stay aligned across repos:
 > still use `AGENT-INDEX.md`. The `CONTRADICTIONS-REPORT.md` file lives in
 > `clyfar` and `preprint-clyfar-v0p9` (where the MSLP-unit issue actually
 > resides), not in brc-tools.
+>
+> **Note (2026-06-16, brc-tools-local):** brc-tools also has a separate seam to
+> **brc-wrf** (the WRF model fork) for WRF-input GRIB staging — *not* one of the 4
+> repos above. Its contract is the manifest/contract sidecar boundary; the protocol
+> lives in `docs/WRF-INPUT-STAGING.md`, `docs/HANDOFF-TO-BRC-WRF.md`, and
+> `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md` (cross-repo wiring + caretaker). Keep that
+> seam's docs in sync there, not here.
 
 ## Workflow for Making Changes
 

--- a/docs/HANDOFF-TO-BRC-WRF-HYGIENE.md
+++ b/docs/HANDOFF-TO-BRC-WRF-HYGIENE.md
@@ -1,0 +1,63 @@
+# Handoff to brc-wrf — cross-repo hygiene & caretaker pass
+
+From a brc-tools session, 2026-06-16. Keep the brc-tools↔brc-wrf wiring rock-solid, make
+`AGENTS.md` self-maintaining, and trim BRC-added cruft. **Never touch the WRF source tree**
+(arch/, chem/, dyn_em/, frame/, phys/, Registry, configure, compile, Makefile, …).
+
+## 0. Trustable context
+- Wiring audited 2026-06-16: every `../brc-tools`↔`../brc-wrf` doc link resolves, both
+  directions, zero broken. Don't re-fix — keep it true (§2 caretaker check).
+- brc-tools shipped a staging-hygiene batch (manifest **schema v2** + token preflight); see
+  `../brc-tools/docs/WRF-INPUT-STAGING.md` §4. It does **not** change the proven NAM-only
+  path, the scratch layout, or the contract sidecar — so the WRF run side is unchanged.
+  brc-wrf consumes the **contract sidecar**, not `staged_files` (confirmed in
+  `brc-cases/wrf_case.py`), so the additive schema bump is a no-op for you.
+
+## 1. Wiring verification (rock-solid) — do first, ~2 min
+From brc-wrf root:
+
+    grep -rno "\.\./brc-tools[^ )\"\`]*" AGENTS.md README.md brc-docs doc brc-cases \
+      | sed 's/^[^:]*:[0-9]*://' | sort -u \
+      | while read p; do [ -e "$p" ] && echo "OK  $p" || echo "BROKEN $p"; done
+
+Expect all OK. If BROKEN: the brc-tools file moved — fix the reference here (don't invent a
+path). Optional content note in AGENTS.md "Current Run Truth": "manifest schema v2 (additive);
+brc-wrf reads the contract sidecar, not staged_files."
+
+## 2. AGENTS caretaker — make doc-currency a habit
+Add a short block to `AGENTS.md` (keep AGENTS.md the short routing file; detail stays in
+`doc/BRC_WRF_MICROTASK_HANDOFF.md`):
+
+    ## Doc Currency (caretaker)
+    When any of these change, update the named file IN THE SAME COMMIT:
+    - brc-tools contract/manifest fields or staging flags -> "Current Run Truth" here.
+    - A proof state flips (e.g. GEFS+NAM two-stream proven) -> "Current Run Truth" here +
+      brc-docs/BRC-WRF-STATE-PLAYBOOK.md + brc-docs/BRC-WRF-FIRST-CASE.md.
+    - Any ../brc-tools path renamed -> run the §1 link-check and fix references.
+    README.md = humans; AGENTS.md = agents. Don't duplicate run logic into README.md.
+
+## 3. Parse down (BRC-added files only — WRF source is off-limits)
+- `TASK-PRIORITIES-JUNE13.md` (root, dated) — superseded by `doc/BRC_WRF_MICROTASK_HANDOFF.md`.
+  Fold any still-live items into the board, then delete.
+- `doc/BRC_WRF_HANDOFF.md` overlaps the microtask board — reduce to a 3-line pointer or delete.
+- `brc-docs/` (7 files) — audited current; light plain-language pass only, no deletions.
+- `README.md` (human-aimed, ~99 lines) — confirm it carries a useful **human** resource list
+  (WRF registration/user guide, CHPC + WRF quickstart in `brc-knowledge`, the BRC docs index)
+  and routes humans, not agents. Keep AI routing in AGENTS.md.
+
+## 4. brc-tools side (done this session)
+- Doc-map drift + stale merge-status fixed; `CROSS-REPO-SYNC.md` now notes this seam.
+- Both root scratch notes deleted.
+- Staging-hygiene batch pushed to `origin/feat/wrf-input-staging`; PR open against `main`
+  (find it via `gh pr list --repo Bingham-Research-Center/brc-tools`).
+- Matching item: microtask **#32** (brc-wrf docs reference the brc-tools staging doc + scratch
+  layout) — close it as part of §1–§3.
+
+## Outstanding / caveats / intentionally left
+- **Outstanding test:** brc-tools `--preflight` is offline-tested only; the live S3 list-URL
+  format is unverified — first live run is the real test.
+- **Caveat:** manifest is schema v2 (additive); if brc-wrf ever parses the manifest directly,
+  treat extra fields as expected (you currently read the contract, so no action).
+- **Caveat:** local brc-tools `main` is stale behind `origin/main` (#22) — harmless, FYI.
+- **Intentionally left:** WRF source tree untouched; GEFS+NAM two-stream still unproven
+  (optional); brc-wrf cleanup (§2–§3) is handed to you, not done from the brc-tools session.

--- a/docs/HANDOFF-TO-BRC-WRF.md
+++ b/docs/HANDOFF-TO-BRC-WRF.md
@@ -1,0 +1,72 @@
+# Hand-off to brc-wrf — WRF run side
+
+Mirror of `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md` (which runs brc-wrf →
+brc-tools). Paste the block below into a fresh Claude Code session started in
+`~/gits/brc-wrf`. Paths inside it are **relative to the brc-wrf repo root**
+(sibling checkout); every path and command was resolution-checked on 2026-06-15.
+
+## What brc-tools changed (2026-06-15, branch `feat/wrf-input-staging`)
+
+- `docs/WRF-INPUT-STAGING.md`: added a state banner; **stripped the WRF-run Slurm
+  profile from §5b** (it now points runs back to brc-wrf — the DTN *staging* job
+  stays, it's ours); added a mixed-manifest warning; reconciled the
+  "pre-contract manifest" ↔ "reconstructed legacy contract" vocabulary; relabeled
+  run-benchmark microtasks **#26/#27 as brc-wrf-owned**.
+- New `docs/WRF-GEFS-NAM-FIELD-MAP.md` — DRAFT two-stream field map (NOT proven).
+- New `docs/walkthroughs/wrf-staging.md` — the brc-tools staging boundary spoke.
+
+## Paste prompt (optimised for AI ingest)
+
+```text
+You are a Claude Code session in ~/gits/brc-wrf, picking up the WRF RUN side after a
+brc-tools docs/contract pass (2026-06-15). brc-tools owns GRIB staging ONLY; WPS,
+real.exe, wrf.exe, and the Slurm RUN profile are yours.
+
+GROUND TRUTH (do not re-derive):
+- NAM-only single-stream is PROVEN end-to-end (WPS -> real.exe -> wrf.exe, Jan-2013 Basin).
+- GEFS+NAM two-stream is NOT proven.
+- STOP POINTS: no sbatch / WPS / real.exe / wrf.exe without explicit human approval.
+
+READ (batch, in order):
+- brc-docs/BRC-WRF-STATE-PLAYBOOK.md
+- brc-docs/BRC-WRF-FIRST-CASE.md
+- ../brc-tools/docs/WRF-INPUT-STAGING.md
+- ../brc-tools/docs/WRF-GEFS-NAM-FIELD-MAP.md
+- ../brc-tools/docs/walkthroughs/wrf-staging.md
+
+CHEAP CHECKS FIRST (no model runs; only local file hashing / metadata):
+  python ../brc-tools/scripts/stage_wrf_inputs.py --verify-manifest \
+    /scratch/general/vast/$USER/wrf_inputs/<case>/manifest_<case>.json
+  python brc-cases/wrf_case.py validate brc-cases/jan2013_basin_nam.case.yaml --strict-files
+
+PICK ONE GOAL:
+
+(A) Close brc-tools handoff issue 4 — prove a FRESH contract validates:
+    1. Have brc-tools stage a fresh NAM-only case; get contract_<case>.json on scratch
+       (python ../brc-tools/scripts/stage_wrf_inputs.py --plan ... first, then the DTN job).
+    2. Point the case yaml's forcing.contract_path at that fresh contract, NOT the reconstructed
+       fallback brc-cases/jan2013_basin_nam.contract.json.
+    3. python brc-cases/wrf_case.py validate <case>.yaml --strict-files   # must pass clean
+    4. Once it passes, retire the reconstructed-legacy contract fallback.
+
+(B) Attempt the two-stream GEFS+NAM proof (field map: ../brc-tools/docs/WRF-GEFS-NAM-FIELD-MAP.md):
+    1. Build Vtable.GEFS: _pres + _abv700mb split, SPECHUMD (no RH on pressure), height-level 10m
+       winds. Resolve bgrnd-soil vs NAM-fill (the open question in the field map).
+    2. ungrib the staged gefs_reforecast/ dir; confirm intermediate files hold all expected fields.
+    3. metgrid fg_name='GEFS','NAM' (NAM as filler), interval_seconds=10800 (3h reforecast cadence).
+    4. STOP — show the met_em field list + any missing-mandatory-field warning BEFORE real.exe.
+    5. On approval: real.exe, then wrf.exe -> SUCCESS COMPLETE WRF; quicklook vs the NAM-only baseline.
+
+THEN (brc-wrf-owned benchmarks, formerly brc-tools #26/#27):
+    Scaling: sweep --ntasks {16,28,56}, find the knee. Memory: right-size --mem.
+    Update brc-docs/BRC-WRF-STATE-PLAYBOOK.md with the result.
+
+Leave a breadcrumb per step: command, evidence, owner repo, stop point. Absolute /scratch paths are
+CHPC-local and fine here; never hand an absolute path to a different machine (CLAUDE.md convention).
+```
+
+## Verified (2026-06-15)
+
+- All 5 READ paths + the stage script resolve from `~/gits/brc-wrf`.
+- `wrf_case.py validate <case_file> --strict-files` is the real validator CLI.
+- `--verify-manifest` and `--plan` are real `stage_wrf_inputs.py` flags.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,12 +3,15 @@
 Project documentation. Topical files only — agent context lives in
 `../CLAUDE.md`, the human entry point in `../README.md`.
 
+- **walkthroughs/** — plain-language per-tool guides + GLOSSARY (start here if new).
 - **API-REFERENCE.md** — full module / function reference.
 - **API-CLIENTS.md** — external API wrappers (FlightAware, FR24, Perplexity, Mistral) under `brc_tools/api/`.
 - **CASE-STUDY-GUIDE.md** — how to write a case-study script.
 - **CHPC-REFERENCE.md** — canonical CHPC account, partitions, salloc, cron (incl. HRRR upload).
 - **CROSS-REPO-SYNC.md** — protocol for keeping the four sibling repos aligned.
+- **WEBSITE-INTEGRATION.md** — BasinWX upload contract (endpoint, auth, dataTypes, schemas).
 - **ENVIRONMENT-SETUP.md** — venv/conda setup for new team members.
 - **WRF-INPUT-STAGING.md** — WRF/WPS GRIB staging handoff, proof evidence, and microtasks.
 - **WRF-STAGING-STATE-PLAYBOOK.md** — plain-language milestone/state packet for the WRF staging side.
+- **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (not proven).
 - **nwp/** — HRRR/RRFS roadmap (current operational focus).

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,6 @@ Project documentation. Topical files only — agent context lives in
 - **CHPC-REFERENCE.md** — canonical CHPC account, partitions, salloc, cron (incl. HRRR upload).
 - **CROSS-REPO-SYNC.md** — protocol for keeping the four sibling repos aligned.
 - **ENVIRONMENT-SETUP.md** — venv/conda setup for new team members.
+- **WRF-INPUT-STAGING.md** — WRF/WPS GRIB staging handoff, proof evidence, and microtasks.
+- **WRF-STAGING-STATE-PLAYBOOK.md** — plain-language milestone/state packet for the WRF staging side.
 - **nwp/** — HRRR/RRFS roadmap (current operational focus).

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,4 +14,5 @@ Project documentation. Topical files only — agent context lives in
 - **WRF-INPUT-STAGING.md** — WRF/WPS GRIB staging handoff, proof evidence, and microtasks.
 - **WRF-STAGING-STATE-PLAYBOOK.md** — plain-language milestone/state packet for the WRF staging side.
 - **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (not proven).
+- **HANDOFF-TO-BRC-WRF.md** — paste-prompt to hand the WRF run side to a brc-wrf session.
 - **nwp/** — HRRR/RRFS roadmap (current operational focus).

--- a/docs/WEBSITE-INTEGRATION.md
+++ b/docs/WEBSITE-INTEGRATION.md
@@ -5,6 +5,11 @@ The data contract between brc-tools (producer) and the `ubair-website` receiver
 boxes are downstream consumers that receive POSTs (they don't pull). Match the
 schemas here and the website lights up automatically.
 
+> **Cross-machine invariant** (canonical: CLAUDE.md Conventions → "No path crosses
+> machines"): CHPC (producer) and the Linode hub (receiver) share **no filesystem**.
+> The *only* interface is the URL contract below — never a shared path. Paths on
+> each side are local to that side.
+
 > **Canonical schema source** is the website repo's `DATA_MANIFEST.json`
 > (e.g. `hrrr_surface_layers` at `DATA_MANIFEST.json:487`). When in doubt, read it
 > there — don't invent fields. The library entry point is

--- a/docs/WEBSITE-INTEGRATION.md
+++ b/docs/WEBSITE-INTEGRATION.md
@@ -1,0 +1,77 @@
+# BasinWX upload contract
+
+The data contract between brc-tools (producer) and the `ubair-website` receiver
+(`basinwx.com` / `.dev`). brc-tools is the single source of truth; both website
+boxes are downstream consumers that receive POSTs (they don't pull). Match the
+schemas here and the website lights up automatically.
+
+> **Canonical schema source** is the website repo's `DATA_MANIFEST.json`
+> (e.g. `hrrr_surface_layers` at `DATA_MANIFEST.json:487`). When in doubt, read it
+> there — don't invent fields. The library entry point is
+> `brc_tools.download.push_data` (see [walkthroughs/upload.md](walkthroughs/upload.md)).
+
+## Endpoint + auth
+
+```
+POST  {server}/api/upload/:dataType        # server = https://www.basinwx.com | https://www.basinwx.dev
+```
+Both headers required:
+- `x-api-key: $DATA_UPLOAD_API_KEY` (32-char hex; same secret on both boxes)
+- `x-client-hostname: <host>.chpc.utah.edu` (or source IP reverse-DNS resolves to `*.chpc.utah.edu`)
+
+**Multipart body (multer):** field name is the literal `file`; filename preserved;
+**10 MB** limit; extensions **JSON / MD / TXT** only (gzip+base64 inside JSON for binary).
+
+**Response:** `{ "success": true, "filename": "...", "dataType": "..." }`.
+`200` stored · `401` bad key · `403` not from CHPC · `413` >10 MB.
+
+**Accepted dataTypes** (anything else → 400):
+```
+observations | metadata | outlooks | llm_outlooks | images | timeseries | forecasts | road-forecast
+```
+
+## Fan-out — `BASINWX_API_URLS`
+
+Comma-separated list; first = primary (must succeed), rest = best-effort mirrors.
+```bash
+export BASINWX_API_URLS="https://www.basinwx.com,https://www.basinwx.dev"
+```
+Use one shared uploader across producers so every product fans out the same way.
+
+## Schemas (compact)
+
+**`road-forecast`** — `POST /api/upload/road-forecast`, filename
+`road_forecast_<YYYYMMDD_HHMMZ>.json`. Server copies it to
+`static/road-forecast/latest.json`. Rejected if `init_time` > 3 h old.
+```jsonc
+{ "init_time": "ISO-8601 Z", "model": "hrrr", "domain": "uintah_basin_roads",
+  "points": [ { "lat": .., "lon": .., "name": "..",
+    "forecasts": [ { "valid_time": "Z",
+      "temp_2m": -2.3,        // °C — NOT Kelvin
+      "precip_1hr": 0.5,      // mm
+      "precip_type": "snow",  // snow|rain|mixed|none
+      "wind_speed_10m": 4.2,  // m/s
+      "visibility": 12.5 } ] } ] }   // km (website ×1000 → metres)
+```
+
+**`forecast_hrrr_kvel_crosswind_*`** — `POST /api/upload/forecasts`,
+filename `forecast_hrrr_kvel_crosswind_<YYYYMMDD_HHMMZ>.json`.
+```jsonc
+{ "product": "aviation_crosswind",   // literal; consumer checks it
+  "model": "hrrr", "init_time": "Z", "valid_times": ["Z", ...],
+  "series": { "crosswind_kt_rwy16": [..], "crosswind_kt_rwy34": [..] },  // knots; ± = side
+  "metadata": { "station": "KVEL", "runway_headings_deg_true": [160, 340] } }
+```
+
+**`forecast_hrrr_surface_layers_*`** — `POST /api/upload/forecasts`,
+filename `forecast_hrrr_surface_layers_<YYYYMMDD_HHMMZ>.json`. **Schema already
+pinned** at website `DATA_MANIFEST.json:487`; `product_type` enum is
+`"surface_layers"`. Read the manifest; don't invent fields.
+
+## Status
+
+This page is the folded **contract reference** (from the 2026-04-27 website
+handoff). The remaining producer/fan-out **work** (the three dark dataTypes,
+clustering fan-out to `.dev`) is tracked in [../WISHLIST-TASKS.md](../WISHLIST-TASKS.md).
+Hard rules: temperatures in °C (not Kelvin); never invent dataTypes without a
+website-side PR; don't regress the observations channel.

--- a/docs/WRF-GEFS-NAM-FIELD-MAP.md
+++ b/docs/WRF-GEFS-NAM-FIELD-MAP.md
@@ -1,0 +1,48 @@
+# GEFS + NAM two-stream field-map (DRAFT)
+
+> **DRAFT — the GEFS+NAM two-stream path is NOT proven through WPS / `real.exe`.**
+> Only the NAM-only single-stream path is validated (see
+> [WRF-INPUT-STAGING.md](WRF-INPUT-STAGING.md)). This page is a design aid for the
+> *future* two-stream work, owned on the WPS side by `brc-wrf`.
+>
+> **Token source of truth:** `brc_tools/nwp/lookups.toml`
+> `[models.gefs_reforecast].wps_variable_levels`. If that list changes, update this.
+
+## Why two streams
+
+The GEFSv12 **reforecast** gives historical (pre-2017) atmospheric forcing but is
+missing several **surface/static** fields WRF needs. An auth-free **NAM 12 km
+analysis** fills those gaps. metgrid then fuses them (`fg_name = 'GEFS','NAM'`,
+NAM as the filler stream).
+
+## What each stream carries
+
+| GEFS reforecast provides (token) | Vtable.GEFS implication | NAM must fill |
+| --- | --- | --- |
+| `hgt/tmp/ugrd/vgrd/spfh _pres` **+** `_abv700mb` (pressure fields **split at 700 hPa** — both halves = full column) | GHT / TT / UU / VV, and humidity as **SPECHUMD** (there is no RH on pressure) | — |
+| `pres_msl`, `pres_sfc`, `hgt_sfc` | PMSL / PSFC / SOILHGT | — |
+| `tmp_2m`, `spfh_2m`, `tmp_sfc`, `ugrd_hgt`, `vgrd_hgt` (10 m **height-level** winds) | 2 m TT / SPECHUMD, 10 m UU / VV | — |
+| `tsoil_bgrnd`, `soilw_bgrnd` (below-ground soil), `weasd_sfc` (snow water eq.) | WEASD maps cleanly; **soil-layer → WPS mapping is an OPEN QUESTION** (the proven run used NAM soil, not these) | proper 4-layer soil (see below) |
+| *(absent)* land-sea mask | — | **NAM `LANDSEA`** |
+| *(absent)* SST / skin temp | — | **NAM `SKINTEMP` / SST** |
+| *(absent)* snow **depth** (`snod`) | — | **NAM `SNOWH`** |
+| *(absent)* 4-layer soil temp/moisture | — | **NAM soil (0-10 / 10-40 / 40-100 / 100-200 cm)** |
+
+(Confirmed against `lookups.toml:89-109` and the `wrf_staging` module docstring,
+which lists land-sea mask, SST, skin temp, and soil as NAM-supplied.)
+
+## Open questions before any two-stream attempt
+
+1. **Soil.** GEFS ships `*_bgrnd` soil tokens, but the validated path took soil
+   from NAM. Decide whether `bgrnd` maps to WRF's 4 fixed layers or stays NAM's job.
+2. **`Vtable.GEFS`** does not exist yet — building/validating it is `brc-wrf` work.
+3. **Cadence.** Reforecast interval is 3 h (`interval_seconds=10800`) vs NAM's 6 h;
+   the contract records this per source.
+
+## Hand-off
+
+Building `Vtable.GEFS` and proving `real.exe` with two streams is **brc-wrf**
+work. From the brc-tools side, staging is driven by
+`scripts/stage_wrf_inputs.py --source gefs_reforecast,nam_analysis` (see
+[walkthroughs/wrf-staging.md](walkthroughs/wrf-staging.md) and
+[WRF-INPUT-STAGING.md](WRF-INPUT-STAGING.md) §3).

--- a/docs/WRF-INPUT-STAGING.md
+++ b/docs/WRF-INPUT-STAGING.md
@@ -160,15 +160,15 @@ full set on a DTN, then prove through WPS/real on the brc-wrf side).
 - [x] **1. [AI] ✅ DONE** — `stage_nam_analysis()`: auth-free NAM 12 km analysis (NCEI `namanl_218`) staged to `<case>/nam_analysis/` with `source="nam_analysis"` manifest entries. Direct HTTP GET, **no NCAR RDA** (Herbie has no NCEI-historical NAM source). Mocked + opt-in-live (`RUN_LIVE_NCEI`) tests; `--source nam_analysis` CLI.
 - [x] **2. [AI] ✅ DONE** — Herbie `search=` lead-time subsetting (`--lead-subset`): only f12–f48 download. Proven `tmp_2m` 58 MB→9.7 MB (6×); full set ~4 GB→~650 MB.
 - [x] **3. [AI] ✅ DONE** — `--plan` / `--dry-run` lists every expected NAM cycle + reforecast object (URL, dest path, byte estimate) **offline**, then exits without downloading (`plan_case`).
-- [ ] **4. [AI]** Add a token-preflight: list the S3 prefix for an init and diff against `wps_variable_levels` (catches dataset drift across years 2000–2019).
-- [ ] **5. [AI]** Unit-test `obs_sanity_overlay` with a synthetic polars DataFrame (currently untested).
-- [ ] **6. [AI]** Have `_record_existing` re-derive `lead_times` from a cached `.idx` if present (avoid degraded skip-manifests), or document the limitation in the manifest itself.
+- [x] **4. [AI] ✅ DONE (offline-tested; live `--preflight` unverified)** — Add a token-preflight: list the S3 prefix for an init and diff against `wps_variable_levels` (catches dataset drift across years 2000–2019).
+- [x] **5. [AI] ✅ DONE** — Unit-test `obs_sanity_overlay` with a synthetic polars DataFrame (currently untested).
+- [x] **6. [AI] ✅ DONE (label-only; schema v2)** — Have `_record_existing` re-derive `lead_times` from a cached `.idx` if present (avoid degraded skip-manifests), or document the limitation in the manifest itself.
 - [ ] **7. [AI]** Multi-member staging proof (c00–p04) + per-member layout/manifest aggregation.
 - [x] **8. [AI] ✅ DONE** — `verify_manifest()` / `--verify-manifest <path>`: re-reads the manifest, checks each staged file's existence + size + recomputed `sha256`, exits nonzero on any mismatch.
 - [x] **9. [AI] ✅ MOOT** — soil now comes from NAM analysis (standard 4-layer 0-10/10-40/40-100/100-200 cm); the reforecast `bgrnd` mapping question only matters if a reforecast-soil run is attempted later.
 - [ ] **10. [AI]** Add an operational `gefs` (post-2017) staging path reusing the same machinery, for recent cases.
-- [ ] **11. [AI]** Record total bytes + elapsed per run into the manifest `provenance` (feeds benchmarking).
-- [ ] **12. [AI]** Handle a window that crosses the 240 h bucket boundary (currently warns + stages one bucket only).
+- [x] **11. [AI] ✅ DONE** — Record total bytes + elapsed per run into the manifest `provenance` (feeds benchmarking).
+- [x] **12. [AI] ✅ DONE (kept warn+partial; test pins it)** — Handle a window that crosses the 240 h bucket boundary (currently warns + stages one bucket only).
 - [ ] **13. [AI]** Pin `wps_variable_levels` per data-year if the reforecast token set differs across 2000–2019.
 
 ### B. brc-wrf side (WPS/WRF validation — the proof)
@@ -191,7 +191,7 @@ full set on a DTN, then prove through WPS/real on the brc-wrf side).
 
 ### D. Cross-cutting / hygiene
 - [x] **30. [H] ✅ GATE MET** — a successful `real.exe` (and full `wrf.exe`) is on record (§2), so `feat/wrf-input-staging` → `main` is unblocked. The merge itself is the only remaining action (branch not yet pushed).
-- [ ] **31. [AI]** Add a `WISHLIST-TASKS.md` entry pointing here.
+- [x] **31. [AI] ✅ DONE** — Add a `WISHLIST-TASKS.md` entry pointing here.
 - [ ] **32. [AI+H]** Ensure brc-wrf docs reference this file + the scratch layout (cross-repo sync).
 - [ ] **33. [H]** Retention: scratch auto-purges at 60 days — promote proven inputs to `lawson-group6` if reused.
 

--- a/docs/WRF-INPUT-STAGING.md
+++ b/docs/WRF-INPUT-STAGING.md
@@ -1,5 +1,8 @@
 # WRF-Input GRIB Staging — Handoff
 
+> **State:** NAM-only is proven end-to-end (WPS → `real.exe` → `wrf.exe`). GEFS+NAM two-stream is **not** proven.
+> **brc-wrf side:** `../brc-wrf/brc-docs/BRC-WRF-STATE-PLAYBOOK.md` · `../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md` (paths from repo root; both repos checked out as siblings).
+
 **Status:** ✅ **end-to-end validated** (2026-06-13). NAM-only staging drove WPS → `real.exe` →
 `wrf.exe` to `SUCCESS COMPLETE WRF` for the Jan-2013 Basin case on `notch392` (full evidence in
 §2). The merge gate (Microtask 30, "merge only after a successful `real.exe`") is now **met** —
@@ -86,6 +89,11 @@ The brc-wrf runtime proof closed the loop. Staged from brc-tools `33849121…`
 - **`wrf.exe`:** Slurm step `13472096.0` completed `0:0` on `notch392` (56 tasks);
   `rsl.out.0000` → `d01 2013-02-02_00:00:00 wrf: SUCCESS COMPLETE WRF`; 37 hourly `wrfout`/domain.
 - **Archive:** `lawson-group6/jrlawson/wrf_archive/jan2013_basin_gefs/run_20260613T044846Z` (194 files, 2.2 G).
+
+> ⚠️ **Don't read NAM-only WPS truth off this mixed-source manifest.** It lists `nam_analysis`
+> (7 files) **and** partial `gefs_reforecast` (21), but WPS consumed **NAM-only**. For what WPS
+> actually ingested, trust the contract / source intent (`wps_fg_name`, `sources`) — not the
+> manifest file list.
 
 **Interpretation:** NAM-only staging is sufficient for the validated 12/4 km Basin case. The GEFS
 reforecast stream stays useful for the optional ensemble/two-stream path, **not** a prerequisite for
@@ -177,8 +185,8 @@ full set on a DTN, then prove through WPS/real on the brc-wrf side).
 - [ ] **23. [H]** Run the **full** stage as a `notchpeak-dtn` job (§5 template); confirm the DTN reaches AWS.
 - [ ] **24. [H]** Verify whether `lawson-np` compute/interactive nodes can reach AWS (proxy?). Ask helpdesk@chpc.utah.edu; record the answer in brc-knowledge.
 - [x] **25. [H] ✅ DONE** — WRF ran on `notch392` (56 tasks, step `13472096.0`) to `SUCCESS COMPLETE WRF`, 37 hourly `wrfout`/domain (§2). Formal scaling/timing sweep (26) still open.
-- [ ] **26. [AI+H]** Scaling benchmark: sweep `--ntasks` (e.g. 16/28/56), record wall-time per sim-hour, find the knee (Basin domains stop scaling after ~dozens of ranks — wrf-on-chpc §8).
-- [ ] **27. [H]** Memory benchmark: confirm actual peak (~50 GiB for 12/4 km) vs `--mem`; right-size.
+- [ ] **26. [brc-wrf]** Scaling benchmark — **WRF-run tuning, owned by `brc-wrf`** (tracked here only for continuity): sweep `--ntasks` (e.g. 16/28/56), record wall-time per sim-hour, find the knee (Basin domains stop scaling after ~dozens of ranks — wrf-on-chpc §8).
+- [ ] **27. [brc-wrf]** Memory benchmark — **WRF-run tuning, owned by `brc-wrf`**: confirm actual peak (~50 GiB for 12/4 km) vs `--mem`; right-size.
 - [x] **28. [H] ✅ DONE** — archived to `lawson-group6/jrlawson/wrf_archive/jan2013_basin_gefs/run_20260613T044846Z` (194 files, 2.2 G), incl. the `rsl.out.0000` success marker. See §5d for the colon-filename rsync gotcha hit during this archive.
 
 ### D. Cross-cutting / hygiene
@@ -207,20 +215,16 @@ It pins `account=dtn / partition=notchpeak-dtn / qos=notchpeak-dtn`, calls the e
 `/scratch/general/vast/$USER/wrf_inputs/jan2013_basin_gefs/`. Quicklook is off on the DTN (no
 matplotlib/cartopy) — render figures separately on a login node from the staged files if wanted.
 
-### 5b. Running WRF — use **notch392** via the validated script
+### 5b. Running WRF — owned by `brc-wrf`
 
-Do **not** reinvent the run script. Submit the validated one:
-```bash
-sbatch ~/gits/brc-knowledge/scholarium/reference-base/resources/run_wrf_feb05.slurm
-```
-It pins `notch392` (56 cores, ~1 TB RAM, ConnectX-6), `lawson-np`, `--mem=180G`, `--time=6:00:00`,
-the validated module stack, and the **mandatory** launcher `srun --mpi=pmi2 -n "$SLURM_NTASKS" ./wrf.exe`
-(bare `mpirun`/`srun -n` are wrong on Intel MPI 2021.1.1). It also archives `wrfout*` to `lawson-group6`.
+brc-tools does **not** own WRF-run Slurm profiles. For the run script, the
+node/task/memory profile, the launcher, and any benchmarking sweep, see `brc-wrf`
++ `brc-knowledge` (paths from repo root; both repos checked out as siblings):
+`../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md` and the validated `run_wrf_feb05.slurm`
+it references.
 
-**Benchmarking sweep** (to "maximise resources"): copy that script per config and vary:
-- `--ntasks` ∈ {16, 28, 56} (keep `--nodes=1`; record wall-time per simulated hour → find the scaling knee).
-- `--mem`: start `180G`; use `--mem=900G` to reserve the whole big-memory node (owned, sole-user → harmless).
-- Keep `--nodelist=notch392` for apples-to-apples; the scaling table is in `wrf-on-chpc-quickstart.md` §8.
+(The DTN **staging** job in §5a is a different thing — that one *is* brc-tools',
+because staging GRIB is our lane; running the model is not.)
 
 ### 5c. Storage & retention
 `/scratch/general/vast/$USER` (50 TiB quota, **60-day atime purge**) for active inputs/runs; promote
@@ -305,6 +309,12 @@ and the manifest filename.
 > `interval_hours=3`. The run itself used the correct 6 h NAM cadence (`interval_seconds=21600`,
 > per WPS); a fresh stage now stamps `interval_hours=6`. Diffing the old manifest against a new one
 > will show this single expected discrepancy.
+>
+> **Vocabulary reconcile (brc-tools ↔ brc-wrf):** what this repo calls a "pre-contract manifest"
+> (above) is the same artifact `brc-wrf` calls a *reconstructed legacy NAM-only contract*
+> (`../brc-wrf/brc-cases/jan2013_basin_nam.contract.json`). The old scratch predates the
+> `contract_<case>.json` sidecar, so `brc-wrf` carries a reconstructed NAM-only contract for strict
+> validation, while a fresh brc-tools stage emits the real sidecar.
 
 **Proof constants for the validated Jan-2013 Basin run (metgrid/real outputs — not auto-emitted):**
 

--- a/docs/WRF-STAGING-STATE-PLAYBOOK.md
+++ b/docs/WRF-STAGING-STATE-PLAYBOOK.md
@@ -1,0 +1,70 @@
+# WRF Staging State Playbook
+
+Short print-oriented explanation for John/JRL and Michael. This file describes
+what `brc-tools` owns in the WRF workflow, what is already proven, and what
+should happen next.
+
+## One-Sentence State
+
+`brc-tools` can stage WRF-ready GRIB inputs for the Jan-2013 Basin case, verify
+their integrity, and hand `brc-wrf` a manifest/contract boundary; the NAM-only
+single-stream path is proven through WPS, `real.exe`, and `wrf.exe`.
+
+## What This Repo Owns
+
+| Owns | Plain language |
+| --- | --- |
+| NWP source access | Herbie/NCEI/S3-facing data discovery and downloads. |
+| WRF input staging | Put GRIB files under `/scratch/general/vast/$USER/wrf_inputs/<case>/`. |
+| Manifest verification | Prove every staged file still exists and matches size/hash. |
+| Case contract | Tell `brc-wrf` the WPS-relevant facts: sources, cadence, `fg_name`, and `interval_seconds`. |
+| Input quicklooks | Sanity maps of staged source data before WPS/WRF consumes it. |
+
+This repo does not run WPS, `real.exe`, `wrf.exe`, or Slurm WRF integrations.
+Those belong in `brc-wrf`, using CHPC settings from `brc-knowledge`.
+
+## What Is Proven
+
+| Item | Status |
+| --- | --- |
+| NAM analysis staging | Proven and used in the successful Jan-2013 WRF proof. |
+| Manifest verification | Proven: the existing proof manifest verifies `28/28 OK`. |
+| Contract sidecar | Implemented for fresh stages; old proof scratch predates this sidecar. |
+| Lead-time subsetting | Implemented for GEFS reforecast to reduce unnecessary download volume. |
+| GEFSv12 reforecast download | Partial staged files proven; full WPS two-stream path not proven. |
+| DTN posture | Full transfer work should run on `notchpeak-dtn`, not login nodes. |
+
+## What `brc-wrf` Has Proven With These Inputs
+
+| Stage | Result |
+| --- | --- |
+| WPS with NAM only | Produced 14 `met_em` files for d01/d02, 6-hour cadence. |
+| `real.exe` | Reached `SUCCESS COMPLETE REAL_EM INIT`. |
+| `wrf.exe` | Reached `SUCCESS COMPLETE WRF`. |
+| Archive | Produced a durable `lawson-group6` run directory. |
+| Visual QA | `brc-wrf` can now render no-run quicklooks from existing artifacts. |
+
+## Where We Should Go Next
+
+| Order | Next move | Stop point |
+| --- | --- | --- |
+| 1 | Merge or otherwise settle `feat/wrf-input-staging` after review. | `main` contains the proven staging boundary. |
+| 2 | Keep NAM-only as the baseline proof. | Do not rename it as GEFS+NAM. |
+| 3 | Decide whether GEFS+NAM is needed for the next science question. | If yes, design the WPS two-stream proof with `brc-wrf`; if no, improve NAM repeatability. |
+| 4 | If GEFS+NAM is pursued, run a no-download design pass first. | Confirm Vtable, source split, and expected missing fields before WPS. |
+| 5 | Keep every full-stage or full-run step behind CHPC ownership boundaries. | DTN for downloads, `brc-wrf` for WPS/WRF, `brc-knowledge` for Slurm truth. |
+
+## Reading Packet
+
+Read these with the matching `brc-wrf` packet:
+
+1. `docs/WRF-INPUT-STAGING.md`
+2. `docs/WRF-STAGING-STATE-PLAYBOOK.md`
+3. `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`
+4. `../brc-wrf/brc-docs/BRC-WRF-STATE-PLAYBOOK.md`
+5. `../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md`
+6. `../brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md` sections 1-3 and Q1
+7. `../brc-knowledge/scholarium/reference-base/resources/wrf-on-chpc-quickstart.md` sections 2, 3, and 8
+
+For a new developer, the key idea is simple: `brc-tools` makes the input pile
+clean and auditable; `brc-wrf` proves WRF can consume it.

--- a/docs/walkthroughs/GLOSSARY.md
+++ b/docs/walkthroughs/GLOSSARY.md
@@ -1,0 +1,22 @@
+# Glossary — plain-language terms
+
+One-line definitions for a developer who is **not** a meteorologist. The
+walk-throughs link here instead of re-explaining terms inline.
+
+| Term | Plain meaning |
+| --- | --- |
+| **foehn** | A warm, dry, gusty downslope wind — air heats as it sinks down the lee of mountains. In the Basin it can spike temperature and crash humidity within an hour. |
+| **cold pool** | A lake of cold, stagnant air that settles in the Basin in winter and traps pollution. "Cold-pool erosion" (when it clears) is a common forecast question here. |
+| **theta-e** (θₑ) | One number bundling an air parcel's heat **and** moisture; used to track air masses. Unit: kelvin. |
+| **MSLP** | Mean sea-level pressure — surface pressure adjusted to sea level so stations at different elevations compare fairly. Stored in pascals (Pa). |
+| **GRIB** | The binary file format weather-model data ships in (gridded fields; one file holds many variables/times). Tools read it; you rarely open it by hand. |
+| **WPS / real.exe / wrf.exe** | The WRF model's three run stages (preprocess GRIB → build initial/boundary conditions → run the forecast). **All three live in the `brc-wrf` repo, not here.** |
+| **waypoint** | A named location (lat/lon, e.g. `vernal`) we pull forecasts/obs at. Collected into "waypoint groups" (e.g. `foehn_path`) in `lookups.toml`. |
+| **init time** | The start time a forecast was launched from (model initialization), written `YYYY-MM-DD HHZ` in UTC (the trailing `Z`). |
+| **fxx / forecast hour** | Hours since the init time. `fxx=6` is the forecast valid 6 h after launch. Also called lead time. |
+| **reforecast** | A modern model re-run over historical dates so old events can be studied. We use the GEFSv12 *reforecast* for pre-2017 cases the operational model can't reach. |
+| **DTN** | CHPC Data Transfer Node (`notchpeak-dtn`) — the internet-connected machine built for big downloads. Run heavy staging here, not on a login or compute node. |
+| **scratch** | Fast, large, **temporary** CHPC disk (`/scratch/general/vast/$USER`). A 60-day purge deletes untouched files — treat it as reproducible-on-demand, not durable storage. |
+| **manifest vs. contract** | Two JSON sidecars WRF staging writes: the **manifest** (`manifest_<case>.json`) lists every staged file + checksums (provenance); the **contract** (`contract_<case>.json`) states the WPS-relevant facts `brc-wrf` should trust (sources, cadence, `fg_name`). When they disagree about intent, trust the contract. |
+
+See also: [API reference](../API-REFERENCE.md) · [walk-through index](README.md)

--- a/docs/walkthroughs/README.md
+++ b/docs/walkthroughs/README.md
@@ -1,0 +1,52 @@
+# brc-tools walk-throughs
+
+Plain-language, copy-paste guides — one short page per tool. Written for a new
+developer who is **not** a meteorologist. For full function signatures see
+[../API-REFERENCE.md](../API-REFERENCE.md); for unfamiliar words see
+[GLOSSARY.md](GLOSSARY.md).
+
+## Step 0 — set up first
+
+Everything below assumes the `brc-tools` conda env. If you haven't built it yet:
+→ **[../ENVIRONMENT-SETUP.md](../ENVIRONMENT-SETUP.md)**.
+
+## What this repo does (one sentence)
+
+brc-tools pulls **observations** (Synoptic) and **model data** (Herbie), then
+**scores**, **plots**, and **uploads** them to the BasinWX website — and stages
+GRIB for WRF, stopping at the `brc-wrf` boundary.
+
+## Who should read what
+
+| You are… | Start here |
+| --- | --- |
+| New dev, not a meteorologist | [GLOSSARY](GLOSSARY.md) → [obs](obs.md) → [nwp-download](nwp-download.md) |
+| Running the operational website push | [upload](upload.md) (+ [contract](../WEBSITE-INTEGRATION.md)) |
+| Investigating a weather event | [case-study](case-study.md) → [../CASE-STUDY-GUIDE.md](../CASE-STUDY-GUIDE.md) |
+| Staging WRF inputs | [wrf-staging](wrf-staging.md) → [../WRF-INPUT-STAGING.md](../WRF-INPUT-STAGING.md) |
+
+## Suggested reading order
+
+[GLOSSARY](GLOSSARY.md) → [obs](obs.md) → [nwp-download](nwp-download.md) →
+[verify](verify.md) → [visualize](visualize.md) → [upload](upload.md) → then
+[case-study](case-study.md) / [aviation](aviation.md) / [wrf-staging](wrf-staging.md)
+as needed.
+
+## Spokes
+
+- [obs.md](obs.md) — pull station observations; scan for events
+- [nwp-download.md](nwp-download.md) — download model forecast grids
+- [verify.md](verify.md) — score forecast vs. obs
+- [visualize.md](visualize.md) — maps and time-series plots
+- [upload.md](upload.md) — push JSON to the BasinWX website
+- [case-study.md](case-study.md) — combine the above for one event
+- [aviation.md](aviation.md) — FlightAware flight data
+- [wrf-staging.md](wrf-staging.md) — stage WRF inputs, then hand off to `brc-wrf`
+- [GLOSSARY.md](GLOSSARY.md) — shared term list
+
+## Not covered here (experimental / stub, by design)
+
+No walk-throughs exist for these because they aren't ready — don't go hunting:
+`verify/infogain` (empty stub), the FlightRadar24 / Perplexity / Mistral API
+clients (stubs / paid-only), and the unexported `visualize/crosssection` +
+`visualize/profile` helpers.

--- a/docs/walkthroughs/aviation.md
+++ b/docs/walkthroughs/aviation.md
@@ -1,0 +1,24 @@
+# Aviation / flight data — walk-through
+
+**What / why:** Look up flights and airport arrivals/departures via FlightAware.
+Used for aviation-weather work around Basin airports (e.g. KVEL).
+
+**Needs:** `FLIGHTAWARE_API_KEY` (or `~/.config/flightaware/api_key`) · conda env `brc-tools`
+
+## Look up airport arrivals
+
+```python
+from brc_tools.api.flightaware import FlightAwareClient
+
+client = FlightAwareClient()
+arrivals = client.get_airport_arrivals("KVEL")     # also: get_flight("UAL123")
+```
+
+**Produces:** a dict (parsed FlightAware AeroAPI v4 JSON).
+
+> **Heads up — experimental:** the FlightRadar24, Perplexity, and Mistral clients
+> under `brc_tools/api/` are stubs / paid-only and not wired into anything yet.
+> Don't rely on them. Auth for all API clients is documented in
+> [../API-CLIENTS.md](../API-CLIENTS.md).
+
+**See also:** [../API-CLIENTS.md](../API-CLIENTS.md) · terms → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/case-study.md
+++ b/docs/walkthroughs/case-study.md
@@ -1,0 +1,27 @@
+# Run a case study — walk-through
+
+**What / why:** A "case study" is one script that combines the other tools —
+download a model run, pull obs, score, and emit figures for a single weather
+event. It's how a forecast question becomes a folder of PNGs.
+
+**Needs:** `SYNOPTIC_TOKEN` (most cases use obs) · conda env `brc-tools`
+
+## Run an existing example
+
+```bash
+python scripts/case_study_20250222.py        # cold-pool erosion / warm front, 22 Feb 2025
+python scripts/case_study_kvel_foehn.py       # foehn detection at Vernal (KVEL)
+python scripts/case_study_kvel_westerly.py    # strong westerly wind ramp at Vernal
+```
+
+**Produces:** figures under `figures/` (gitignored).
+
+## Write your own
+
+Don't start from scratch — follow the pattern doc, which explains the two paths
+(known date vs. scan-and-select) and the shared helpers in
+`brc_tools.nwp.case_study`:
+
+→ **[../CASE-STUDY-GUIDE.md](../CASE-STUDY-GUIDE.md)** (the full how-to)
+
+**See also:** [obs.md](obs.md) · [nwp-download.md](nwp-download.md) · [verify.md](verify.md) · [visualize.md](visualize.md) · terms → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/nwp-download.md
+++ b/docs/walkthroughs/nwp-download.md
@@ -1,0 +1,43 @@
+# Download model forecast data — walk-through
+
+**What / why:** Pull gridded weather-model output (HRRR, GEFS, NAM) for a region,
+then read forecast values at named locations. You'd run this to make maps, build
+time series, or compare a forecast against what was observed.
+
+> Downloading **for WRF** is different — that keeps raw GRIB on disk and lives in
+> [wrf-staging.md](wrf-staging.md). This page is for analysis (data → xarray).
+
+**Needs:** nothing required · `BRC_TOOLS_HERBIE_CACHE` optional (cache dir) · conda env `brc-tools`
+
+## Fetch a region, then extract at waypoints
+
+```python
+from brc_tools.nwp import NWPSource
+from brc_tools.nwp.derived import add_wind_fields
+
+src = NWPSource("hrrr")                    # also "gefs", "rrfs"
+ds = src.fetch(
+    init_time="2025-02-22 12Z",
+    forecast_hours=range(0, 13),           # fxx 0..12
+    variables=["temp_2m", "wind_u_10m", "wind_v_10m", "mslp"],
+    region="uinta_basin",
+)
+ds = add_wind_fields(ds)                    # adds wind_speed_10m, wind_dir_10m
+nwp_df = src.extract_at_waypoints(ds, group="foehn_path")
+```
+
+**Produces:** `ds` is an xarray Dataset `(time, y, x)`; `nwp_df` is a Polars
+DataFrame of per-waypoint time series.
+
+## Line up a forecast with observations
+
+```python
+from brc_tools.nwp.alignment import align_obs_to_nwp
+
+paired = align_obs_to_nwp(obs_df, nwp_df, variables=["temp_2m", "wind_speed_10m"])
+# matches obs to the nearest forecast valid time; columns get _nwp / _obs suffixes
+```
+
+(`obs_df` comes from [obs.md](obs.md). Units are harmonized for you.)
+
+**See also:** signatures → [`API-REFERENCE.md` → NWPSource / derived / alignment](../API-REFERENCE.md) · terms (init time, fxx) → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/obs.md
+++ b/docs/walkthroughs/obs.md
@@ -1,0 +1,42 @@
+# Pull weather observations — walk-through
+
+**What / why:** Get real measurements from weather stations (temperature, wind,
+pressure…) for the Uinta Basin. You'd run this to see what *actually happened*,
+or to find past events worth studying.
+
+**Needs:** `SYNOPTIC_TOKEN` (or `~/.config/SynopticPy/config.toml`) · conda env `brc-tools`
+
+## Get a station time series
+
+```python
+from brc_tools.obs import ObsSource
+
+obs = ObsSource()
+df = obs.timeseries(
+    waypoint_group="foehn_path",          # or: stids=["KVEL", "KPVU"]
+    start="2025-02-22 12Z",
+    end="2025-02-23 06Z",
+    variables=["temp_2m", "wind_speed_10m", "mslp"],
+)
+```
+
+**Produces:** a Polars DataFrame — columns `stid`, `valid_time` (UTC), one per
+variable, plus `waypoint` when you pass a group.
+
+## Find events automatically (scanner)
+
+Scan a station month-by-month and rank candidate days against a rule:
+
+```python
+from brc_tools.obs.scanner import scan_events, detect_foehn
+
+events = scan_events(
+    stid="KVEL",
+    variables=["temp_2m", "dewpoint_2m", "wind_speed_10m", "wind_dir_10m"],
+    months=(3, 4, 5), year=2025,
+    criteria_fn=detect_foehn,             # or detect_wind_ramp
+)
+# events: list of dicts, best first — e.g. {"date": "2025-04-15", "score": ...}
+```
+
+**See also:** signatures → [`API-REFERENCE.md` → ObsSource / scanner](../API-REFERENCE.md) · terms (foehn, waypoint, MSLP) → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/upload.md
+++ b/docs/walkthroughs/upload.md
@@ -1,0 +1,38 @@
+# Push JSON to the BasinWX website — walk-through
+
+**What / why:** Send a finished JSON product to the BasinWX site(s). The website
+just displays whatever we upload, so this is the last step of an operational job.
+Uploads **fan out** to every configured server (production + dev).
+
+**Needs:** `DATA_UPLOAD_API_KEY` (32-char hex) · `BASINWX_API_URLS` (comma list;
+first = primary) · conda env `brc-tools`. The full data contract is in
+[WEBSITE-INTEGRATION.md](../WEBSITE-INTEGRATION.md).
+
+## Run an operational producer (easiest)
+
+```bash
+# Latest Basin observations → JSON → upload
+python brc_tools/download/get_map_obs.py
+
+# Latest HRRR surface layers → JSON → upload
+python scripts/export_hrrr_surface_layers.py --upload --region uinta_basin
+```
+
+## Upload your own JSON (library)
+
+```python
+from brc_tools.download.push_data import save_json, load_config_urls, send_json_to_all
+
+save_json(my_df, "/tmp/forecast.json", orient="records")
+api_key, urls = load_config_urls()                 # from env / ~/.config
+results = send_json_to_all(urls, "/tmp/forecast.json", "forecasts", api_key)
+# results: {url: True/False}; the primary must succeed or it raises
+```
+
+**Produces:** files named `{prefix}_{YYYYMMDD_HHMM}Z.json`, POSTed to each server.
+Check health at `{url}/api/health`.
+
+> `send_json_to_server` (the single-URL primitive) is imported by `clyfar` — don't
+> change its signature without a cross-repo PR (see CLAUDE.md).
+
+**See also:** signatures → [`API-REFERENCE.md`](../API-REFERENCE.md) · contract → [WEBSITE-INTEGRATION.md](../WEBSITE-INTEGRATION.md) · terms → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/verify.md
+++ b/docs/walkthroughs/verify.md
@@ -1,0 +1,33 @@
+# Score a forecast against observations — walk-through
+
+**What / why:** Measure how close a forecast was to reality, per station and
+variable (bias, MAE, RMSE, correlation). You'd run this to compare model runs or
+track skill over a case.
+
+**Needs:** nothing (works on DataFrames you already have) · conda env `brc-tools`
+
+## One call: pair and score
+
+```python
+from brc_tools.verify.deterministic import paired_scores
+
+scores = paired_scores(
+    nwp_df,                                # from NWPSource.extract_at_waypoints()
+    obs_df,                                # from ObsSource.timeseries()
+    variables=["temp_2m", "wind_speed_10m"],
+    tolerance_minutes=30,                  # how close in time a match must be
+)
+# scores columns: waypoint, variable, n_obs, bias, mae, rmse, correlation
+```
+
+`paired_scores` joins the two frames in time and harmonizes units for you, so you
+don't pre-align. For one-off math on plain arrays there are scalar helpers too:
+
+```python
+from brc_tools.verify.deterministic import rmse, bias
+rmse(forecast_array, observed_array)
+```
+
+**Produces:** a Polars DataFrame, one row per (waypoint, variable).
+
+**See also:** signatures → [`API-REFERENCE.md` → verify.deterministic](../API-REFERENCE.md) · terms → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/visualize.md
+++ b/docs/walkthroughs/visualize.md
@@ -1,0 +1,38 @@
+# Make maps and time-series plots — walk-through
+
+**What / why:** Turn model/obs data into figures — a map at one time, a map's
+evolution over forecast hours, or stacked station time series. You'd run this to
+eyeball a forecast or build case-study figures.
+
+**Needs:** matplotlib + cartopy (in the `brc-tools` env) · conda env `brc-tools`
+
+## A map (plan view)
+
+```python
+import matplotlib.pyplot as plt
+from brc_tools.visualize import plot_planview
+
+plot_planview(ds, "wind_speed_10m", time_idx=6, wind_barbs=True)   # ds from nwp-download
+plt.savefig("windmap.png", dpi=150, bbox_inches="tight")
+```
+
+Multi-panel time evolution (one panel per forecast hour):
+
+```python
+from brc_tools.visualize import plot_planview_evolution
+plot_planview_evolution(ds, "temp_2m", ncols=3)
+```
+
+## Station time series (multi-run + obs)
+
+```python
+from brc_tools.visualize import plot_station_timeseries
+
+nwp_series = {"15Z": nwp_df_15z, "16Z": nwp_df_16z}   # {run label: DataFrame}
+fig = plot_station_timeseries(nwp_series, "temp_2m", obs_df=obs_df)
+fig.savefig("timeseries.png", bbox_inches="tight")
+```
+
+**Produces:** matplotlib `Axes`/`Figure` objects — save them with `savefig`.
+
+**See also:** signatures → [`API-REFERENCE.md` → visualize](../API-REFERENCE.md) · terms → [GLOSSARY.md](GLOSSARY.md)

--- a/docs/walkthroughs/wrf-staging.md
+++ b/docs/walkthroughs/wrf-staging.md
@@ -1,0 +1,56 @@
+# Stage WRF inputs — walk-through (boundary)
+
+**What / why:** Download the GRIB files the WRF model needs and lay them out on
+scratch with provenance sidecars. This is **only the input-prep half**. brc-tools
+stops once the files + sidecars exist; running the model is the `brc-wrf` repo's
+job.
+
+> **State:** NAM-only single-stream is proven end-to-end. GEFS+NAM two-stream is
+> **not** proven — see [../WRF-GEFS-NAM-FIELD-MAP.md](../WRF-GEFS-NAM-FIELD-MAP.md).
+
+**Needs:** DTN access for real downloads · conda env `brc-tools`
+
+## Look before you download (cheap, no network)
+
+`--plan` lists the files, URLs, and total bytes, then exits:
+
+```bash
+python scripts/stage_wrf_inputs.py --plan \
+    --case jan2013_basin_gefs --init-time "2013-01-31 12Z" --source nam_analysis
+```
+
+## Do the real stage (on the DTN)
+
+Big downloads run on the Data Transfer Node, not a login/compute node:
+
+```bash
+sbatch scripts/stage_inputs.dtn.slurm        # brc-tools' own staging job
+```
+
+## Check what was staged
+
+```bash
+python scripts/stage_wrf_inputs.py --verify-manifest \
+    /scratch/general/vast/$USER/wrf_inputs/jan2013_basin_gefs/manifest_jan2013_basin_gefs.json
+```
+
+**Produces (on scratch):** raw GRIB under `<case>/<source>/<member>/`, plus
+`manifest_<case>.json` (every file + checksum) and `contract_<case>.json` (the
+WPS-relevant facts `brc-wrf` should trust). See [manifest vs. contract](GLOSSARY.md).
+
+---
+
+## ⛔ Hand-off — the rest lives in `brc-wrf`
+
+brc-tools stops at **GRIB + manifest + contract on scratch**. WPS, `real.exe`,
+`wrf.exe`, and the Slurm **run** profile are owned by `brc-wrf` + `brc-knowledge`.
+Continue there (paths are from the repo root, both repos checked out as siblings):
+
+- `../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md` — run the case end-to-end
+- `../brc-wrf/brc-docs/BRC-WRF-USAGE.md` — WRF/WPS usage + the run wrapper
+- `../brc-wrf/brc-docs/BRC-WRF-STATE-PLAYBOOK.md` — what's proven / next
+
+Full brc-tools-side detail: [../WRF-INPUT-STAGING.md](../WRF-INPUT-STAGING.md) ·
+state: [../WRF-STAGING-STATE-PLAYBOOK.md](../WRF-STAGING-STATE-PLAYBOOK.md).
+
+**See also:** terms (GRIB, WPS, DTN, scratch, reforecast) → [GLOSSARY.md](GLOSSARY.md)

--- a/scripts/inventory_streamflow_vernal.py
+++ b/scripts/inventory_streamflow_vernal.py
@@ -1,0 +1,57 @@
+"""Inventory Synoptic API streamflow/gauge stations within 50 km of Vernal, UT.
+
+Vernal centre: 40.4555 N, -109.5287 W. Radius 31.07 mi (~50 km).
+
+Synoptic stream-related variable names (from /variables): stream_flow (ft3/s),
+gage_height (ft), flow_rate, water_temp.
+"""
+from __future__ import annotations
+
+import polars as pl
+from synoptic.services import Metadata, Networks
+
+VERNAL_LAT = 40.4555
+VERNAL_LON = -109.5287
+RADIUS_MI = 31.07
+
+STREAM_VARS = ["stream_flow", "gage_height", "flow_rate", "water_temp"]
+
+
+def stations_for(var: str) -> pl.DataFrame:
+    try:
+        return Metadata(
+            radius=[VERNAL_LAT, VERNAL_LON, RADIUS_MI],
+            vars=var,
+        ).df()
+    except Exception as exc:
+        print(f"  [{var}] -> {exc}".splitlines()[0])
+        return pl.DataFrame()
+
+
+def main() -> None:
+    nets = Networks().df().select(["mnet_id", "shortname", "longname"])
+
+    print(f"Synoptic inventory within {RADIUS_MI:.1f} mi (~50 km) of Vernal UT "
+          f"({VERNAL_LAT}, {VERNAL_LON})\n")
+
+    for var in STREAM_VARS:
+        df = stations_for(var)
+        n = len(df)
+        print(f"\n=== {var}: {n} station(s) ===")
+        if n == 0 or df.is_empty():
+            continue
+        show = df.join(nets, on="mnet_id", how="left")
+        cols = [c for c in ["stid", "name", "latitude", "longitude", "elevation",
+                            "shortname", "longname"] if c in show.columns]
+        with pl.Config(tbl_rows=-1, fmt_str_lengths=50, tbl_width_chars=200):
+            print(show.select(cols))
+
+    print("\nNote: USGS HYDRO (mnet_id=203) is the Synoptic network that carries "
+          "most USGS NWIS stream gauges. This token does not have access to it "
+          "(restricted network). To enable: request access from Synoptic "
+          "(support@synopticdata.com) or pull gauge data directly from USGS "
+          "NWIS (https://waterservices.usgs.gov).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wrf_quicklook.py
+++ b/tests/test_wrf_quicklook.py
@@ -1,0 +1,64 @@
+"""Unit tests for the WRF-input quicklook obs overlay (synthetic obs; no network).
+
+``obs_sanity_overlay`` reaches Synoptic via ``case_study.fetch_obs``; here that is
+monkeypatched with a synthetic polars DataFrame (or None) so the overlay is exercised
+fully offline. ``obs_sanity_overlay`` does a *function-local* import of ``fetch_obs``,
+so the patch target is the source module attribute ``case_study.fetch_obs``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import polars as pl
+
+from brc_tools.nwp import case_study, wrf_quicklook
+
+
+def _synthetic_obs() -> pl.DataFrame:
+    """A KVEL temp_2m series shaped like ObsSource.timeseries output."""
+    return pl.DataFrame(
+        {
+            "stid": ["KVEL", "KVEL", "KVEL"],
+            "valid_time": [
+                dt.datetime(2013, 1, 31, 12),
+                dt.datetime(2013, 1, 31, 18),
+                dt.datetime(2013, 2, 1, 0),
+            ],
+            "temp_2m": [-5.0, -8.0, -10.5],
+        }
+    )
+
+
+def test_obs_sanity_overlay_renders_png(tmp_path, monkeypatch):
+    monkeypatch.setattr(case_study, "fetch_obs", lambda **_kw: _synthetic_obs())
+    out = wrf_quicklook.obs_sanity_overlay(
+        case="t", event_date="2013-01-31", figure_dir=tmp_path
+    )
+    assert out is not None
+    out = Path(out)
+    assert out.exists() and out.suffix == ".png"
+    assert out.parent == tmp_path  # honored figure_dir
+    assert out.name == "obs_KVEL_temp_2m.png"
+
+
+def test_obs_sanity_overlay_none_when_fetch_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(case_study, "fetch_obs", lambda **_kw: None)
+    assert (
+        wrf_quicklook.obs_sanity_overlay(
+            case="t", event_date="2013-01-31", figure_dir=tmp_path
+        )
+        is None
+    )
+
+
+def test_obs_sanity_overlay_none_when_empty(tmp_path, monkeypatch):
+    empty = pl.DataFrame({"stid": [], "valid_time": [], "temp_2m": []})
+    monkeypatch.setattr(case_study, "fetch_obs", lambda **_kw: empty)
+    assert (
+        wrf_quicklook.obs_sanity_overlay(
+            case="t", event_date="2013-01-31", figure_dir=tmp_path
+        )
+        is None
+    )

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -153,10 +153,11 @@ def test_staged_file_schema():
     expected = {
         "source", "herbie_model", "member", "member_int", "init_time",
         "variable_level", "fxx_bucket", "lead_times", "product", "local_path",
-        "remote_url", "size_bytes", "sha256", "created_at",
+        "remote_url", "size_bytes", "sha256", "created_at", "lead_times_source",
     }
     assert set(d) == expected
     assert d["init_time"].endswith("Z") and isinstance(d["member_int"], int)
+    assert d["lead_times_source"] == "inventory"  # default when not given
 
 
 def test_nam_cycle_enumeration():
@@ -206,6 +207,7 @@ def test_stage_reforecast_moves_into_layout(tmp_path, fake_herbie):
         assert dest.parent == tmp_path / "t" / "gefs_reforecast" / "c00"
         assert sf.member == "c00" and sf.member_int == 0
         assert sf.lead_times == _FULL_LEADS  # whole bucket parsed from inventory
+        assert sf.lead_times_source == "inventory"
         assert sf.sha256 and sf.size_bytes == len(_VALID_GRIB)
         assert sf.remote_url and sf.remote_url.endswith(".grib2")
     assert fake_herbie.last_search is None  # whole-file download, no byte-range subset
@@ -232,6 +234,35 @@ def test_stage_reforecast_skips_existing(tmp_path, fake_herbie):
     assert len(staged) == 1
     assert fake_herbie.init_count == 0  # Herbie never constructed
     assert fake_herbie.download_count == 0
+
+
+def test_skip_existing_labels_idx_and_no_idx(tmp_path, fake_herbie):
+    dest = _canonical_staging_path(
+        tmp_path, "t", "gefs_reforecast", "c00", "tmp_2m_2013013100_c00.grib2"
+    )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(_VALID_GRIB)
+
+    kw = dict(
+        init_time="2013-01-31 00Z", variable_levels=["tmp_2m"], member=0,
+        output_root=tmp_path, case="t", herbie_save_dir=tmp_path / "cache",
+    )
+
+    # (a) no co-located idx -> empty lead_times, explicitly labelled "skip-no-idx"
+    staged = stage_reforecast(**kw)
+    assert staged[0].lead_times == []
+    assert staged[0].lead_times_source == "skip-no-idx"
+
+    # (b) a co-located <dest>.idx is parsed offline -> recovered leads, labelled "idx"
+    Path(str(dest) + ".idx").write_text(
+        "1:0:d=2013013100:TMP:2 m above ground:12 hour fcst:ENS=low-res ctl\n"
+        "2:100:d=2013013100:TMP:2 m above ground:24 hour fcst:ENS=low-res ctl\n"
+        "3:200:d=2013013100:TMP:2 m above ground:36 hour fcst:ENS=low-res ctl\n"
+    )
+    staged = stage_reforecast(**kw)
+    assert staged[0].lead_times == [12, 24, 36]
+    assert staged[0].lead_times_source == "idx"
+    assert fake_herbie.download_count == 0  # both runs hit the skip path, no download
 
 
 def test_validate_tokens_raises_on_empty_inventory(tmp_path, fake_herbie):

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -7,6 +7,7 @@ A live smoke test that hits real S3 is gated behind ``RUN_LIVE_HERBIE=1`` and th
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import socket
 from pathlib import Path
@@ -314,6 +315,23 @@ def test_remote_url_recorded(tmp_path, fake_herbie):
         herbie_save_dir=tmp_path / "cache",
     )
     assert staged[0].remote_url.startswith("https://noaa-gefs-retrospective.s3.amazonaws.com/")
+
+
+def test_fxx_window_crossing_bucket_warns_and_stages_first(tmp_path, fake_herbie, caplog):
+    # An fxx window straddling the 240 h breakpoint (200 -> Days:1-10, 300 -> Days:10-16):
+    # current contract is warn + stage only the first bucket (a true split needs a
+    # bucket-in-filename layout change, out of scope). Pin that so a change is deliberate.
+    with caplog.at_level(logging.WARNING, logger="brc_tools.nwp.wrf_staging"):
+        staged = stage_reforecast(
+            init_time="2013-01-31 00Z", variable_levels=["tmp_2m"], member=0,
+            output_root=tmp_path, case="t", herbie_save_dir=tmp_path / "cache",
+            fxx_window=(200, 300),
+        )
+    assert len(staged) == 1
+    assert staged[0].fxx_bucket == "Days:1-10"  # only the first bucket is staged
+    warnings_ = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("bucket" in r.getMessage().lower() for r in warnings_)  # breakpoint warned
+    assert any("240" in r.getMessage() for r in warnings_)
 
 
 # ── NAM analysis stager (mocked HTTP) ────────────────────────────────────────

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -439,8 +439,37 @@ def test_build_manifest_shape():
     assert m["case"]["sources"] == ["gefs_reforecast"]
     assert m["provenance"]["generated_at"].endswith("Z")
     assert "git_sha" in m["provenance"] and "tool_version" in m["provenance"]
+    assert m["provenance"]["total_bytes"] == 123  # sum of staged size_bytes
+    assert m["provenance"]["elapsed_seconds"] is None  # not passed -> null
     assert len(m["staged_files"]) == 1
     assert m["staged_files"][0]["variable_level"] == "tmp_2m"
+
+
+def test_manifest_records_total_bytes_and_elapsed():
+    def _sf(size: int) -> StagedFile:
+        return StagedFile(
+            source="nam_analysis", herbie_model="", member="", member_int=0,
+            init_time="2013-01-31T12:00:00Z", variable_level="all", fxx_bucket="analysis",
+            lead_times=[0], product="x", local_path="/x/f", remote_url="h",
+            size_bytes=size, sha256="a", created_at="2026-06-15T00:00:00Z",
+        )
+
+    m = build_manifest(
+        case="c", region="uinta_basin_wide",
+        requested_window=("2013-01-31T12:00:00Z", "2013-02-02T00:00:00Z"),
+        interval_hours=6, sources=["nam_analysis"], staged=[_sf(100), _sf(250)],
+        elapsed_seconds=1.23456,
+    )
+    assert m["provenance"]["total_bytes"] == 350  # footprint = sum of size_bytes
+    assert m["provenance"]["elapsed_seconds"] == 1.235  # rounded to 3 dp
+
+    m0 = build_manifest(
+        case="c", region="uinta_basin_wide",
+        requested_window=("2013-01-31T12:00:00Z", "2013-02-02T00:00:00Z"),
+        interval_hours=6, sources=["nam_analysis"], staged=[],
+    )
+    assert m0["provenance"]["total_bytes"] == 0
+    assert m0["provenance"]["elapsed_seconds"] is None  # unmeasured
 
 
 def test_write_manifest_roundtrips(tmp_path):

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -616,6 +616,91 @@ def test_verify_manifest_pass_and_detects_corruption(tmp_path):
     assert "size" in problems["b.grib2"] or "sha256" in problems["b.grib2"]
 
 
+# ── token preflight (offline; mocked S3 listing) ─────────────────────────────
+
+
+class _FakeXMLResponse:
+    """Stand-in for a (non-streamed) requests response carrying an S3 listing body."""
+
+    def __init__(self, body: bytes, status_code: int = 200):
+        self.content = body
+        self.status_code = status_code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+def _s3_listing_xml(keys: list[str], truncated: bool = False) -> bytes:
+    """Minimal S3 ``ListBucketResult`` (namespaced, like the real API) for given keys."""
+    ns = "http://s3.amazonaws.com/doc/2006-03-01/"
+    contents = "".join(f"<Contents><Key>{k}</Key><Size>123</Size></Contents>" for k in keys)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<ListBucketResult xmlns="{ns}">'
+        "<Name>noaa-gefs-retrospective</Name>"
+        f"<IsTruncated>{'true' if truncated else 'false'}</IsTruncated>"
+        f"{contents}"
+        "</ListBucketResult>"
+    ).encode("utf-8")
+
+
+def _reforecast_keys(tokens, *, member_token="c00", bucket="Days:1-10") -> list[str]:
+    return [
+        f"GEFSv12/reforecast/2013/2013013100/{member_token}/{bucket}/"
+        f"{tok}_2013013100_{member_token}.grib2"
+        for tok in tokens
+    ]
+
+
+def test_preflight_tokens_diffs_against_configured(monkeypatch):
+    # present on "S3": two configured + one unconfigured; one configured token omitted
+    body = _s3_listing_xml(_reforecast_keys(["hgt_pres", "tmp_2m", "weasd_extra"]))
+    captured = {}
+
+    def fake_get(url, timeout=None):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _FakeXMLResponse(body)
+
+    monkeypatch.setattr(wrf_staging.requests, "get", fake_get)
+
+    report = wrf_staging.preflight_tokens(
+        init_time="2013-01-31 00Z", member=0,
+        variable_levels=["hgt_pres", "tmp_2m", "spfh_2m"],  # spfh_2m absent -> missing
+        connect_timeout=3.0, read_timeout=9.0,
+    )
+    assert report["bucket"] == "Days:1-10" and report["member"] == "c00"
+    assert report["available"] == ["hgt_pres", "tmp_2m", "weasd_extra"]  # incl. _abv-style names safe
+    assert report["missing"] == ["spfh_2m"]
+    assert report["extra"] == ["weasd_extra"]
+    assert report["ok"] is False
+    # prefix is URL-encoded (the Days:1-10 colon) and the timeout tuple is threaded through
+    assert "Days%3A1-10" in captured["url"]
+    assert captured["timeout"] == (3.0, 9.0)
+
+
+def test_preflight_tokens_handles_split_token_suffix_and_ok(monkeypatch):
+    # the 700 hPa split token must survive suffix-stripping (end-anchored)
+    keys = _reforecast_keys(["hgt_pres", "hgt_pres_abv700mb"])
+    monkeypatch.setattr(
+        wrf_staging.requests, "get",
+        lambda url, timeout=None: _FakeXMLResponse(_s3_listing_xml(keys)),
+    )
+    report = wrf_staging.preflight_tokens(
+        init_time="2013-01-31 00Z", member=0,
+        variable_levels=["hgt_pres", "hgt_pres_abv700mb"],
+    )
+    assert report["available"] == ["hgt_pres", "hgt_pres_abv700mb"]
+    assert report["missing"] == [] and report["extra"] == [] and report["ok"] is True
+
+
 # ── case contract + interval derivation ──────────────────────────────────────
 
 


### PR DESCRIPTION
Post-merge hygiene batch on the WRF-input staging lane (PR #22 already merged the proven NAM-only path to `main`). Nine commits: 6 staging-code microtasks + 1 §4 doc tick + 2 cross-repo doc-hygiene commits. **No change to the proven NAM-only path, scratch layout, or contract sidecar.**

## Staging code (microtasks from ../brc-wrf MICROTASK_HANDOFF)
- **#6** label degraded skip-manifests + **manifest schema v1→2** (additive: `staged_files[].lead_times_source`). Verified safe vs brc-wrf — its `validate_manifest` reads only `manifest_kind`/`case.name`/`case.sources`; behavioral facts come from the contract sidecar.
- **#11** `provenance.total_bytes` (footprint) + `provenance.elapsed_seconds` (staging wall-time).
- **#4** offline-testable S3 token preflight (`preflight_tokens` / `--preflight`) — diffs the reforecast S3 prefix vs `wps_variable_levels`. ⚠️ live `--preflight` URL format unverified (mocked in tests).
- **#5** `obs_sanity_overlay` synthetic-polars test (new `tests/test_wrf_quicklook.py`).
- **#12** pin the 240 h bucket-boundary warn+partial behavior (test only; kept current behavior per decision).
- **#31** WISHLIST pointer to the WRF staging lane.

## Docs hygiene
- CLAUDE.md doc-map drift + stale merge status fixed; WISHLIST references cleaned after deleting two folded root scratch notes; scoped `CROSS-REPO-SYNC.md` note for the brc-wrf seam.
- New `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md` (cross-repo wiring check + AGENTS caretaker + parse-down handoff).

## Tests
- `pytest tests/` → **100 passed, 2 skipped** (live-gated).
- `--verify-manifest` of the existing v1 scratch proof manifest → **28/28 OK** (v2 reads v1).

## Notes
- Cross-repo links audited both directions — zero broken.
- PR #3 ("Remove legacy documentation…") appears **stale** (removes files already absent from the tree) — recommend closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
