### PR TITLE
docs(wrf): mark staging batch merged (handoff currency)

### DIFF
--- a/docs/HANDOFF-TO-BRC-WRF-HYGIENE.md
+++ b/docs/HANDOFF-TO-BRC-WRF-HYGIENE.md
@@ -48,8 +48,7 @@ Add a short block to `AGENTS.md` (keep AGENTS.md the short routing file; detail 
 ## 4. brc-tools side (done this session)
 - Doc-map drift + stale merge-status fixed; `CROSS-REPO-SYNC.md` now notes this seam.
 - Both root scratch notes deleted.
-- Staging-hygiene batch pushed to `origin/feat/wrf-input-staging`; PR open against `main`
-  (find it via `gh pr list --repo Bingham-Research-Center/brc-tools`).
+- Staging-hygiene batch **merged to `main`** (PR #23, merge commit `52908df`, 2026-06-16).
 - Matching item: microtask **#32** (brc-wrf docs reference the brc-tools staging doc + scratch
   layout) — close it as part of §1–§3.
 

--- a/docs/WRF-INPUT-STAGING.md
+++ b/docs/WRF-INPUT-STAGING.md
@@ -5,8 +5,9 @@
 
 **Status:** ✅ **end-to-end validated** (2026-06-13). NAM-only staging drove WPS → `real.exe` →
 `wrf.exe` to `SUCCESS COMPLETE WRF` for the Jan-2013 Basin case on `notch392` (full evidence in
-§2). The merge gate (Microtask 30, "merge only after a successful `real.exe`") is now **met** —
-merging `feat/wrf-input-staging` → `main` is the only remaining step. **Scope of the proof:**
+§2). The merge gate (Microtask 30, "merge only after a successful `real.exe`") was **met**, and the
+work is now **merged to `main`** (NAM-only via PR #22; the staging-hygiene batch — schema v2 + token
+preflight — via PR #23, `52908df`, 2026-06-16). **Scope of the proof:**
 NAM-only single-stream (`Vtable.NAM`); a *known* 12/4 km nested Basin domain (not a fresh
 standalone 4 km); the GEFS reforecast two-stream path is **not** yet run. Validated at commit
 `3384912` (this branch's base, == the staged source `33849121…`, before this session's hardening
@@ -16,7 +17,7 @@ sidecar) and do not touch how GRIB is downloaded or laid out, so the proof still
 **Branch reconciled with `origin/main`.** A merge commit on `feat/wrf-input-staging` folds in
 upstream's slimmed `CLAUDE.md`, the `brc_tools/api/` package, and the `in_progress/` cleanup; the
 WRF files and `lookups.toml` did not collide. The in-flight `WISHLIST-TASKS.md` /
-`docs/CHPC-REFERENCE.md` edits are committed. (Not pushed — awaiting review.)
+`docs/CHPC-REFERENCE.md` edits are committed and merged to `main`.
 
 **Goal of this track:** produce, from NWP data, the GRIB inputs WRF/WPS actually want for a Uinta
 Basin case (test case: **2013-01-31 12Z → 2013-02-02 00Z**, one domain, ~4 km), stage them to
@@ -287,7 +288,7 @@ Everything in §2 was run on **notchpeak1 (login node)**. Honest audit:
    skin temp. *(Two-stream `fg_name='GEFS','NAM'` only if reforecast forcing is pursued — still open.)*
 3. ✅ `real.exe` produces `wrfinput_d01` + `wrfbdy_d01` with **no missing mandatory field**.
 4. ✅ `wrf.exe` reaches **SUCCESS COMPLETE WRF**; `wrfout*` archived to `lawson-group6`.
-5. ⏳ Only **then** merge `feat/wrf-input-staging` → `main` — **gate met**, merge pending.
+5. ✅ Merged to `main` — NAM-only via PR #22; staging-hygiene batch via PR #23 (`52908df`, 2026-06-16).
 
 ---
 

--- a/docs/WRF-STAGING-STATE-PLAYBOOK.md
+++ b/docs/WRF-STAGING-STATE-PLAYBOOK.md
@@ -48,7 +48,7 @@ Those belong in `brc-wrf`, using CHPC settings from `brc-knowledge`.
 
 | Order | Next move | Stop point |
 | --- | --- | --- |
-| 1 | Merge or otherwise settle `feat/wrf-input-staging` after review. | `main` contains the proven staging boundary. |
+| 1 | ✅ Done — `feat/wrf-input-staging` merged to `main` (PR #22 NAM-only, PR #23 hygiene batch). | `main` now contains the proven staging boundary. |
 | 2 | Keep NAM-only as the baseline proof. | Do not rename it as GEFS+NAM. |
 | 3 | Decide whether GEFS+NAM is needed for the next science question. | If yes, design the WPS two-stream proof with `brc-wrf`; if no, improve NAM repeatability. |
 | 4 | If GEFS+NAM is pursued, run a no-download design pass first. | Confirm Vtable, source split, and expected missing fields before WPS. |


### PR DESCRIPTION
Status-line-only currency pass after the PR #23 merge (`52908df`): the three WRF status docs (HANDOFF-TO-BRC-WRF-HYGIENE, WRF-STAGING-STATE-PLAYBOOK, WRF-INPUT-STAGING) now read 'merged to main' instead of 'PR open / merge pending / awaiting review'. No behavior change. Clears stale lines before the brc-wrf handoff.