### PR TITLE
docs: sync CLAUDE.md with brc-wrf churn + api/ migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging**: GRIB → scratch for WPS/WRF (brc-tools' half; the model run is `brc-wrf`'s). NAM-only proven & merged; GEFS+NAM two-stream optional/unproven. State → `docs/WRF-STAGING-STATE-PLAYBOOK.md`; detail → `docs/WRF-INPUT-STAGING.md`; cross-repo handoffs → `docs/HANDOFF-TO-BRC-WRF.md` + `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md`; arriving from brc-wrf → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
+- **WRF-input staging**: stage GRIB → scratch as a `manifest_<case>.json` + `contract_<case>.json` handshake that `brc-wrf` consumes for WPS/WRF. brc-tools owns staging/manifests/contracts/NWP-download + the reusable `visualize/grid.py` quicklook helpers; WPS/`real.exe`/`wrf.exe`/run-Slurm stay in `brc-wrf`. NAM-only proven & merged; GEFS+NAM two-stream optional/unproven; RAP source requested by brc-wrf, not yet added. State → `docs/WRF-STAGING-STATE-PLAYBOOK.md`; cross-repo entry → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md` (full WRF doc set in Doc map below).
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -17,9 +17,9 @@ brc_tools/        installable package
   nwp/            NWPSource (Herbie), lookups.toml, derived, alignment, case_study, wrf_staging (WRF/WPS GRIB)
   obs/            ObsSource (SynopticPy wrapper), scanner (event detection)
   verify/         deterministic metrics (paired_scores, RMSE/bias/MAE)
-  visualize/      planview maps, timeseries panels
+  visualize/      planview maps, timeseries panels, grid.py (reusable field/section plots; consumed by brc-wrf)
   download/       Synoptic obs script, push_data uploader, HRRR helpers
-  aviation/       FlightAware spec-fetch helpers (being retired into api/)
+  api/            external API clients: FlightAware, FR24, Perplexity, Mistral (shared _auth)
   utils/          lookups, small helpers
 scripts/          operational scripts + case studies
 docs/             canonical project docs (see Doc map below)
@@ -54,10 +54,15 @@ edit there; do not duplicate into CLAUDE.md.
 `brc_tools.download.push_data.send_json_to_server(server_address, fpath, file_data, API_KEY)`
 POSTs `multipart/form-data` to `{server_address}/api/upload/{file_data}`
 with headers `x-api-key` (32-char hex from `DATA_UPLOAD_API_KEY`) and
-`x-client-hostname` (must end `.chpc.utah.edu`). Server URL from
-`~/.config/ubair-website/website_url`. Health: `/api/health`.
+`x-client-hostname` (must end `.chpc.utah.edu`). Server URL resolves
+`BASINWX_API_URLS` (env, comma-sep for fan-out) → `~/.config/ubair-website/website_urls`
+→ `website_url` (legacy). Health: `/api/health`.
 **`clyfar` imports this function** — do not change its signature without
 a cross-repo PR. Operational deployment lives in `docs/CHPC-REFERENCE.md`.
+
+A second cross-repo interface: `brc_tools.visualize.grid` (`plot_grid_field`,
+`plot_vertical_section`) is imported by `brc-wrf`'s `wrf_quicklook.py` — treat its
+public signatures as load-bearing too.
 
 ## Conventions
 - **UTC internally, always.** `datetime.timezone.utc`, never pytz. (Servers sit in different local zones — UTC is the portable invariant; convert to Mountain only at display.)
@@ -69,17 +74,26 @@ a cross-repo PR. Operational deployment lives in `docs/CHPC-REFERENCE.md`.
 - **JSON filenames**: `generate_json_fpath()` → `{prefix}_{YYYYMMDD_HHMM}Z.json`.
 - **API calls**: wrap in try/except; log and continue; retry with backoff at boundaries only.
 - **NWP code** lives in `brc_tools/nwp/`, not `brc_tools/download/`.
-- **Units**: NWP temps in K, MSLP in Pa, wind in m/s. Obs already in C / hPa / m/s. Convert at the boundary.
+- **Units**: NWP temps in K, MSLP in Pa, wind in m/s. Obs already in C / Pa / m/s (Synoptic returns Pa — `lookups.toml` `synoptic_units`). Convert at the boundary.
 - **Lookups** (`brc_tools/nwp/lookups.toml`) is the source of truth for models, regions, waypoints, waypoint groups, variable aliases. Read it; don't duplicate its contents into docs.
 
 ## Environment variables
 | Var | Purpose | Required? |
 |-----|---------|-----------|
 | `DATA_UPLOAD_API_KEY` | BasinWX upload auth | for uploads |
+| `BASINWX_API_URLS` | BasinWX upload URL(s), comma-sep fan-out; overrides `~/.config/ubair-website/website_url(s)` | optional |
 | `SYNOPTIC_TOKEN` | Synoptic obs (also via `~/.config/SynopticPy/config.toml`) | for obs |
-| `FLIGHTAWARE_API_KEY` | FlightAware AeroAPI | aviation only |
+| `FLIGHTAWARE_API_KEY` | FlightAware AeroAPI (`api/` clients) | aviation only |
+| `PERPLEXITY_API_KEY` | Perplexity client + `.mcp.json` MCP server | optional |
+| `MISTRAL_API_KEY` | Mistral client + `.mcp.json` MCP server | optional |
 | `BRC_TOOLS_HERBIE_CACHE` | NWP GRIB cache dir override | optional |
+| `BRC_TOOLS_HRRR_CACHE` | HRRR GRIB cache dir override | optional |
 | `BRC_TOOLS_LOCK_DIR` | Parallel-download lock dir | optional |
+| `BRC_TOOLS_HTTP_IPV4_ONLY` | Force IPv4 (CHPC DTN IPv6-hang workaround) | optional |
+
+All `api/` clients resolve keys via `brc_tools.api._auth.load_api_key(VAR)` — env var
+first, then optional `~/.config/<svc>/api_key`; `FR24_API_KEY` is reserved for the
+skeleton FlightRadar24 client.
 
 ## Testing
 ```
@@ -92,6 +106,8 @@ fresh setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
 ## Related repos
 - `ubair-website` — Node.js receiver for uploads (data contract).
 - `clyfar` — ozone forecast; imports `brc_tools.download.push_data`.
+- `brc-wrf` — WRF runs; consumes brc-tools staging (`manifest`/`contract` sidecars) + imports `brc_tools.visualize.grid`.
+- `brc-knowledge` — canonical CHPC infra + validated Slurm run scripts (referenced, not imported).
 - `preprint-clyfar-v0p9` — LaTeX manuscript.
 
 Governed by `.github/CODEOWNERS`; PRs require review from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging**: stage GRIB → scratch as a `manifest_<case>.json` + `contract_<case>.json` handshake that `brc-wrf` consumes for WPS/WRF. brc-tools owns staging/manifests/contracts/NWP-download + the reusable `visualize/grid.py` quicklook helpers; WPS/`real.exe`/`wrf.exe`/run-Slurm stay in `brc-wrf`. NAM-only proven & merged; GEFS+NAM two-stream optional/unproven; RAP source requested by brc-wrf, not yet added. State → `docs/WRF-STAGING-STATE-PLAYBOOK.md`; cross-repo entry → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md` (full WRF doc set in Doc map below).
+- **WRF-input staging**: stage GRIB → scratch as a `manifest_<case>.json` + `contract_<case>.json` handshake that `brc-wrf` consumes for WPS/WRF. brc-tools owns staging/manifests/contracts/NWP-download + the reusable `visualize/grid.py` quicklook helpers; WPS/`real.exe`/`wrf.exe`/run-Slurm stay in `brc-wrf`. NAM-only proven & merged; GEFS+NAM two-stream optional/unproven; RAP source added (#26: offline plan/contract/tests, NCEI path preflight-confirmed), live staging/WPS pending in brc-wrf. State → `docs/WRF-STAGING-STATE-PLAYBOOK.md`; cross-repo entry → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md` (full WRF doc set in Doc map below).
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -40,6 +40,7 @@ figures/          generated output (gitignored)
 - `docs/ENVIRONMENT-SETUP.md` — conda / venv setup
 - `docs/CROSS-REPO-SYNC.md` — sync protocol with clyfar / ubair-website / preprint
 - `docs/nwp/ROADMAP.md` — HRRR/RRFS strategy and phase tracker
+- `docs/nwp/NWP-SOURCE-MATRIX.md` — per-source download matrix (Herbie vs direct), idiosyncrasies, Herbie currency
 - `docs/WRF-INPUT-STAGING.md` — WRF/WPS GRIB staging: status, microtasks, CHPC DTN + SLURM
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — terse WRF staging state and reading packet
 - `docs/WRF-GEFS-NAM-FIELD-MAP.md` — DRAFT GEFS/NAM two-stream field-map (NOT proven)
@@ -74,6 +75,7 @@ public signatures as load-bearing too.
 - **JSON filenames**: `generate_json_fpath()` → `{prefix}_{YYYYMMDD_HHMM}Z.json`.
 - **API calls**: wrap in try/except; log and continue; retry with backoff at boundaries only.
 - **NWP code** lives in `brc_tools/nwp/`, not `brc_tools/download/`.
+- **Don't reinvent NWP downloads — check Herbie first.** Brian Blaylock's Herbie ([herbie.readthedocs.io](https://herbie.readthedocs.io)) ships hardened, on-rails model templates (`herbie/models/*.py`) for most NOAA/NCEI sources — prefer them over hand-rolled fetches. Record each source's Herbie-native-vs-direct decision in `docs/nwp/NWP-SOURCE-MATRIX.md` (enforced by `tests/test_source_matrix.py`). A hand-rolled GET is the exception and must justify why Herbie doesn't fit (today: only `nam_analysis`/`rap_analysis`, which Herbie can't retrieve for 2013).
 - **Units**: NWP temps in K, MSLP in Pa, wind in m/s. Obs already in C / Pa / m/s (Synoptic returns Pa — `lookups.toml` `synoptic_units`). Convert at the boundary.
 - **Lookups** (`brc_tools/nwp/lookups.toml`) is the source of truth for models, regions, waypoints, waypoint groups, variable aliases. Read it; don't duplicate its contents into docs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,10 @@ skeleton FlightRadar24 client.
 ```
 pytest tests/
 ```
-Local Python work: use a conda env that carries the deps (herbie, polars, pandas,
-matplotlib, requests). On this CHPC checkout `clyfar-nov2025` already has them;
-fresh setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
+Use a conda env with the deps (herbie, polars, pandas, matplotlib, cfgrib, requests).
+Preferred: the dedicated **`brc-tools-2026`** env (`mamba env create -f environment.yml`;
+herbie 2026.3.0 — validated, 107 passed); the shared `clyfar-nov2025` also works. Fresh
+setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
 
 ## Related repos
 - `ubair-website` — Node.js receiver for uploads (data contract).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ public signatures as load-bearing too.
 - **API calls**: wrap in try/except; log and continue; retry with backoff at boundaries only.
 - **NWP code** lives in `brc_tools/nwp/`, not `brc_tools/download/`.
 - **Don't reinvent NWP downloads — check Herbie first.** Brian Blaylock's Herbie ([herbie.readthedocs.io](https://herbie.readthedocs.io)) ships hardened, on-rails model templates (`herbie/models/*.py`) for most NOAA/NCEI sources — prefer them over hand-rolled fetches. Record each source's Herbie-native-vs-direct decision in `docs/nwp/NWP-SOURCE-MATRIX.md` (enforced by `tests/test_source_matrix.py`). A hand-rolled GET is the exception and must justify why Herbie doesn't fit (today: only `nam_analysis`/`rap_analysis`, which Herbie can't retrieve for 2013).
-- **Units**: NWP temps in K, MSLP in Pa, wind in m/s. Obs already in C / Pa / m/s (Synoptic returns Pa — `lookups.toml` `synoptic_units`). Convert at the boundary.
+- **Units**: NWP temps in K, MSLP in Pa, wind in m/s. Obs already in C / Pa / m/s (Synoptic returns Pa for pressure; units are per-alias in `lookups.toml` `synoptic_units`). Convert at the boundary (e.g. Pa→hPa) only for display.
 - **Lookups** (`brc_tools/nwp/lookups.toml`) is the source of truth for models, regions, waypoints, waypoint groups, variable aliases. Read it; don't duplicate its contents into docs.
 
 ## Environment variables
@@ -93,9 +93,9 @@ public signatures as load-bearing too.
 | `BRC_TOOLS_LOCK_DIR` | Parallel-download lock dir | optional |
 | `BRC_TOOLS_HTTP_IPV4_ONLY` | Force IPv4 (CHPC DTN IPv6-hang workaround) | optional |
 
-All `api/` clients resolve keys via `brc_tools.api._auth.load_api_key(VAR)` — env var
-first, then optional `~/.config/<svc>/api_key`; `FR24_API_KEY` is reserved for the
-skeleton FlightRadar24 client.
+All `api/` clients resolve keys via `brc_tools.api._auth.load_api_key(VAR)` — **env var
+only** today (the helper also accepts an optional `~/.config/<svc>/api_key` fallback, but
+no client wires it yet); `FR24_API_KEY` is reserved for the skeleton FlightRadar24 client.
 
 ## Testing
 ```

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -16,6 +16,12 @@ Slurm run profiles stay in `brc-wrf`.
 - The remaining staging-microtask backlog (#4–#13, #31, …) lives in
   `../brc-wrf/doc/BRC_WRF_MICROTASK_HANDOFF.md` — that handoff is the source of truth
   for this lane; not duplicated here.
+- [ ] **RAP analysis source (`rap_analysis`)** — brc-wrf's Pelican RAP rerun
+  (`../brc-wrf/brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md`) wants hourly RAP analysis
+  staging; not yet implemented (only `nam_analysis` + `gefs_reforecast` exist in
+  `lookups.toml` / `brc_tools/nwp/wrf_staging.py`). Needs a lookups model entry,
+  hourly-cadence generalization of the NAM analysis staging path, and a Vtable/soil-field
+  decision.
 
 ## Priority 1: Reliability
 

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -2,6 +2,23 @@
 
 Completed items are removed once merged; git history is the record.
 
+## Session closeout (2026-06-29) — open PRs + next steps
+
+Three PRs from this session's docs/RAP/env work (merge order independent; CODEOWNERS review):
+- **#25** — CLAUDE.md/docs sync + `docs/nwp/NWP-SOURCE-MATRIX.md` + a "check Herbie first" guard.
+- **#26** — `rap_analysis` staging source (offline, NCEI path preflight-confirmed).
+- **#27** — `brc-tools-2026` env + Herbie `2024`→`2026.3.0` bump (validated, 107 passed).
+
+Recommended next steps toward the goals (least-recently-mentioned first):
+1. **Merge #25/#26/#27**, then migrate the obs/HRRR crons to `brc-tools-2026` (re-verify the
+   RRFS path if RRFS ever goes operational — its Herbie template changed at 2026.3.0).
+2. **RAP forcing experiment** — the one approved DTN stage below is the *only* remaining
+   brc-tools step before brc-wrf can run the new ICs/LBCs.
+3. **clyfar `send_json_to_server`→`send_json_to_all`** — long-parked; needs a cross-repo PR
+   (`docs/CROSS-REPO-SYNC.md`) to retire the legacy single-URL path.
+4. **NWPSource/ObsSource integration tests** (Priority 1) — still the highest-leverage
+   reliability work, untouched this session.
+
 ## WRF-input staging (branch `feat/wrf-input-staging`)
 
 A separate active lane: stage GRIB (GEFSv12 reforecast + NAM analysis) to scratch
@@ -16,12 +33,11 @@ Slurm run profiles stay in `brc-wrf`.
 - The remaining staging-microtask backlog (#4–#13, #31, …) lives in
   `../brc-wrf/doc/BRC_WRF_MICROTASK_HANDOFF.md` — that handoff is the source of truth
   for this lane; not duplicated here.
-- [ ] **RAP analysis source (`rap_analysis`)** — brc-wrf's Pelican RAP rerun
-  (`../brc-wrf/brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md`) wants hourly RAP analysis
-  staging; not yet implemented (only `nam_analysis` + `gefs_reforecast` exist in
-  `lookups.toml` / `brc_tools/nwp/wrf_staging.py`). Needs a lookups model entry,
-  hourly-cadence generalization of the NAM analysis staging path, and a Vtable/soil-field
-  decision.
+- [ ] **RAP forcing — DTN stage** — source support landed in #26 (offline plan/contract/
+  tests + source-generic staging); the NCEI path is preflight-confirmed. Remaining brc-tools
+  step: one approved DTN stage of the 7 RAP cycles (2013-02-02 12–18Z) → manifest/contract on
+  scratch; then brc-wrf owns the WPS Vtable choice + metgrid/real/wrf. Memo:
+  `../brc-wrf/brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md`.
 
 ## Priority 1: Reliability
 

--- a/docs/WRF-INPUT-STAGING.md
+++ b/docs/WRF-INPUT-STAGING.md
@@ -27,7 +27,7 @@ manifest**; the sibling **brc-wrf** repo owns **ungrib → metgrid → real** an
 > **Canonical CHPC references (read these for any run decision):**
 > - `~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md` — **single source of truth** for nodes, partitions, storage, DTN, login-node etiquette.
 > - `~/gits/brc-knowledge/scholarium/reference-base/resources/wrf-on-chpc-quickstart.md` — WRF build/run, module stack, scaling table (§8).
-> - `~/gits/brc-knowledge/scholarium/reference-base/resources/run_wrf_feb05.slurm` — **validated** WRF run script for the Feb-2013 Basin case (notch392, 56 tasks). Reuse it; don't reinvent.
+> - `~/gits/brc-knowledge/scholarium/reference-base/resources/run_wrf_feb05.slurm` — **validated** WRF run script for the Feb-2013 Basin case (notch392, 56 tasks). The WRF run is owned by **brc-wrf**; brc-knowledge carries this script as the canonical reference.
 > - `~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-slurm-job-examples.md` — DTN + compute-node proxy examples.
 
 ---

--- a/docs/nwp/NWP-SOURCE-MATRIX.md
+++ b/docs/nwp/NWP-SOURCE-MATRIX.md
@@ -1,0 +1,108 @@
+# NWP source matrix — Herbie vs. direct download
+
+How brc-tools obtains each NWP source, the per-source idiosyncrasies, and where we
+use **Herbie** vs. a **hand-rolled fetch** (and why). This is the answer to the
+recurring "are we reinventing the wheel?" question. Machine-readable companion:
+`brc_tools/nwp/lookups.toml` (the model registry); staging detail in
+`docs/WRF-INPUT-STAGING.md`.
+
+Herbie version evaluated: **2025.11.3** (env `clyfar-nov2025`).
+
+## Matrix
+
+| Source (`lookups` key) | Role | brc-tools entry point | Mechanism | Herbie-native? | Key idiosyncrasies |
+|---|---|---|---|---|---|
+| `hrrr` | operational forecast | `NWPSource.fetch()` | **Herbie** `model="hrrr"` | ✅ yes | `subh` 15-min axis dropped by `NWPSource.normalize_coords` → `aviation.py` calls Herbie directly to keep 15-min |
+| `gefs` | operational ensemble | `NWPSource.fetch()` | **Herbie** `model="gefs"` | ✅ yes | 0–360° lon → shift-then-sel crop; product breakpoint `atmos.25`→`atmos.5` above f240 |
+| `rrfs` | experimental | `NWPSource.fetch()` | **Herbie** `model="rrfs"` | ✅ yes | evolving product names |
+| `gefs_reforecast` | WRF forcing (historical ens) | `wrf_staging.stage_reforecast()` | **Herbie** `Herbie.download()`, `model="gefs_reforecast"` | ✅ yes | per-variable file layout; 700 hPa pressure split (`_pres` / `_pres_abv700mb`); specific humidity only; 10 m winds = `ugrd_hgt`; **no land-sea mask, no snow**; members c00/p01–p04; `Days:1-10`/`10-16` buckets |
+| `nam_analysis` | WRF forcing/filler (2013) | `wrf_staging.stage_nam_analysis()` | **Direct NCEI HTTP GET** (`requests`) | ❌ **no** | Herbie `nam` has only `aws`/`nomads` (operational, recent) — no NCEI-historical `namanl_218`. grib1 `.grb`; 6-hourly; whole file; carries land-mask/SST/skin/4-layer soil/snow |
+| `rap_analysis` | WRF forcing (Pelican hot-swap) | `wrf_staging.stage_rap_analysis()` → shared `stage_nam_analysis` | **Direct NCEI HTTP GET** (`requests`) | ⚠️ **intended but broken upstream** (see below) | grib2 `.grb2`; hourly; whole file; ~12 MB/cycle |
+| _Synoptic obs_ | observations | `ObsSource` | SynopticPy (obs ≠ NWP) | n/a | UTC-strip, alias rename, waypoint injection |
+| _FlightAware_ | aviation | `brc_tools/api/flightaware` | AeroAPI client | n/a | paid API |
+
+## The RAP wheel: Herbie aims at it, but is broken in 2025.11.3
+
+Herbie ships templates pointed at exactly our file:
+- **`rap_historical`** (product `analysis`) builds
+  `…/rapid-refresh/access/historical/analysis/{YYYYMM}/{YYYYMMDD}/rap_130_{YYYYMMDD_HHMM}_{fxx:03d}.grb2`
+  — **byte-identical to our `[models.rap_analysis].url_template`.** It also carries RUC2/RUC
+  fallbacks for pre-2012 dates.
+- **`rap_ncei`** (product `rap-130-13km`) targets the `…/access/rap-130-13km/analysis/…` subdir.
+
+Live resolution test (2026-06-29, Herbie 2025.11.3) for `2013-02-02 12Z`, `fxx=0`:
+
+| Herbie call | Result |
+|---|---|
+| `model="rap_historical", product="analysis"` | **raises `ValueError: Invalid suffix 'grb.inv'`** |
+| `model="rap_ncei", product="rap-130-13km"` | `grib=None` (no 2013 file under `rap-130-13km/`) |
+| `model="nam", product="awphys"` | `grib=None` (operational sources don't reach 2013) |
+
+The `rap_historical` failure is an **upstream typo** in `herbie/models/rap.py`:
+`IDX_SUFFIX = [".inv", ".grb2.inv", "grb.inv"]` — the third entry is missing its leading dot
+(`grb.inv` → should be `.grb.inv`), which Herbie rejects before it probes the file.
+
+**So out of the box Herbie does not retrieve RAP-130 2013 analysis** — our direct GET works where
+Herbie currently fails, and uses the same URL Herbie *intends*. (Independently confirmed by curl:
+all 7 cycles 12–18Z → HTTP 200, ~12 MB; bogus cycle → 404.)
+
+## Why the analysis sources use direct GET (not Herbie)
+
+Beyond the bug, `nam_analysis` + `rap_analysis` deliberately share one **whole-file analysis** path
+(`stage_nam_analysis`, source-generic) because:
+- **One path, one set of guarantees:** per-cycle locking, `BRC_TOOLS_HTTP_IPV4_ONLY` (NCEI IPv6-hang
+  workaround), GRIB validation, manifest/contract — identical for NAM and RAP.
+- **Offline `--plan` is deterministic:** URLs/paths are templated from `lookups.toml`; no Herbie
+  inventory probing.
+- **No byte-range/`.idx` machinery:** WPS wants whole analysis files; we never subset.
+- Herbie genuinely lacks NAM-NCEI-historical, so NAM had to be direct anyway; RAP rides the same path
+  for uniformity.
+
+## Wheel check / recommendations
+
+- **HRRR / GEFS / RRFS / GEFS-reforecast** — correctly on Herbie; no change. ✅
+- **NAM analysis (2013)** — Herbie has no NCEI-historical NAM; direct GET is the only option. ✅
+- **RAP analysis (2013)** — mild reinvention *by necessity*: Herbie's `rap_historical` is the intended
+  wheel but is broken (IDX_SUFFIX typo) in 2025.11.3, and our URL matches its intent. Options:
+  1. **Keep direct GET** (works today; uniform with NAM) — current choice.
+  2. **File an upstream Herbie issue** for the `'.grb.inv'` typo (cheap; helps everyone).
+  3. Revisit a Herbie-backed RAP path once fixed (would gain RUC2 pre-2012 fallback for free).
+
+## Herbie currency (checked 2026-06-29)
+
+| | Version | When |
+|---|---|---|
+| Installed (`clyfar-nov2025`) | **2025.11.3** | Nov 2025 |
+| Latest (conda-forge + PyPI) | **2026.3.0** | Mar 2026 |
+
+What updating `2025.11.3 → 2026.3.0` would buy:
+- **2026.3.0** — RRFS template fixed to the current S3 bucket layout (#511). **We use `rrfs`** — the
+  pinned version may already mis-resolve it.
+- **2026.1.0** — Pandas 3.0 inventory parsing; drops Py3.10 / adds 3.14; new NOAA AIWP models
+  (AIGFS, AIGEFS, HGEFS).
+- **2025.12.0** — full-file downloads moved `urllib` → `requests` (fixes SSL-cert issues, #246).
+- **Does NOT fix** the `rap_historical` `IDX_SUFFIX` typo — still `"grb.inv"` on the default branch at
+  2026.3.0, so a Herbie-backed RAP path stays blocked regardless.
+
+**Recommendation:** update Herbie (ideally in a fresh, lean `brc-tools` env, not the shared
+`clyfar-nov2025`) pinned to `herbie-data>=2026.3.0`; afterward re-run the RRFS path and the RAP probe
+below. File an upstream issue for the `rap_historical` typo. Env recipe → `docs/ENVIRONMENT-SETUP.md`.
+
+## Enforcement
+
+Adding any `[models.*]` to `lookups.toml` **must** add a row here (with its Herbie-vs-direct decision) —
+guarded by `tests/test_source_matrix.py`, which fails if a lookups model is undocumented. This enforces
+the *process* (record the wheel-check), not an automated Herbie lookup: Herbie model names don't map 1:1
+to ours (our `nam_analysis`/`rap_analysis` vs Herbie `nam`/`rap_historical`/`rap_ncei`), so a
+name-collision check would mislead. The human decision lives here.
+
+## Resources — Brian Blaylock's Herbie (check these FIRST)
+
+- **Docs** (extensive: tutorials, gallery, per-model notes, FAQ): https://herbie.readthedocs.io
+- **Source + issues:** https://github.com/blaylockbk/Herbie
+- **Model templates** = the on-rails, hardened access patterns: `herbie/models/*.py` in the installed
+  package — read the relevant one before hand-rolling any NOAA download. Herbie grew from Blaylock's
+  University of Utah HRRR-archive work, so its coverage of NOAA/NCEI archives is deep.
+
+> Maintenance: re-run the live probes in "The RAP wheel" after each Herbie upgrade; if `rap_historical`
+> starts resolving and the RRFS path is confirmed, reconsider the direct-GET choices.

--- a/docs/nwp/NWP-SOURCE-MATRIX.md
+++ b/docs/nwp/NWP-SOURCE-MATRIX.md
@@ -12,7 +12,7 @@ Herbie version evaluated: **2025.11.3** (env `clyfar-nov2025`).
 
 | Source (`lookups` key) | Role | brc-tools entry point | Mechanism | Herbie-native? | Key idiosyncrasies |
 |---|---|---|---|---|---|
-| `hrrr` | operational forecast | `NWPSource.fetch()` | **Herbie** `model="hrrr"` | ✅ yes | `subh` 15-min axis dropped by `NWPSource.normalize_coords` → `aviation.py` calls Herbie directly to keep 15-min |
+| `hrrr` | operational forecast | `NWPSource.fetch()` | **Herbie** `model="hrrr"` | ✅ yes | `subh` (15-min) resolves as hourly through NWPSource — `normalize_coords` drops the GRIB time axis; call Herbie directly if 15-min is needed |
 | `gefs` | operational ensemble | `NWPSource.fetch()` | **Herbie** `model="gefs"` | ✅ yes | 0–360° lon → shift-then-sel crop; product breakpoint `atmos.25`→`atmos.5` above f240 |
 | `rrfs` | experimental | `NWPSource.fetch()` | **Herbie** `model="rrfs"` | ✅ yes | evolving product names |
 | `gefs_reforecast` | WRF forcing (historical ens) | `wrf_staging.stage_reforecast()` | **Herbie** `Herbie.download()`, `model="gefs_reforecast"` | ✅ yes | per-variable file layout; 700 hPa pressure split (`_pres` / `_pres_abv700mb`); specific humidity only; 10 m winds = `ugrd_hgt`; **no land-sea mask, no snow**; members c00/p01–p04; `Days:1-10`/`10-16` buckets |

--- a/tests/test_source_matrix.py
+++ b/tests/test_source_matrix.py
@@ -1,0 +1,28 @@
+"""Guard: every NWP source in lookups.toml must be documented in the source matrix.
+
+Enforces the "don't reinvent the wheel" process — each `[models.*]` added to
+`brc_tools/nwp/lookups.toml` has to gain a row in `docs/nwp/NWP-SOURCE-MATRIX.md`
+recording its Herbie-vs-direct download decision. This guards the *process* (the
+wheel-check is written down), not an automated Herbie lookup: Herbie model names do
+not map 1:1 to ours, so a name-collision check would mislead.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOOKUPS = ROOT / "brc_tools" / "nwp" / "lookups.toml"
+MATRIX = ROOT / "docs" / "nwp" / "NWP-SOURCE-MATRIX.md"
+
+
+def test_every_nwp_model_documented_in_source_matrix():
+    models = tomllib.loads(LOOKUPS.read_text(encoding="utf-8")).get("models", {})
+    assert models, "no [models.*] found in lookups.toml"
+    doc = MATRIX.read_text(encoding="utf-8")
+    missing = [name for name in models if f"`{name}`" not in doc]
+    assert not missing, (
+        f"NWP source(s) missing a row in {MATRIX.relative_to(ROOT)}: {missing}. "
+        "Add each with its Herbie-native-vs-direct-download decision (see the doc header)."
+    )


### PR DESCRIPTION
## What

Resync `CLAUDE.md` (the agent-context file) with recent cross-repo churn in `brc-wrf` and the `aviation/`→`api/` migration here, fix a few factual deviations from single-source-of-truth, and carry two small downstream doc updates.

### CLAUDE.md
- **Repo map**: `aviation/` (retired in `d88d716`) → `api/` (FlightAware, FR24, Perplexity, Mistral via shared `_auth`); note `visualize/grid.py`.
- **Current focus / WRF**: rewritten around the real seam — the `manifest_<case>.json` + `contract_<case>.json` handshake brc-wrf consumes — plus a one-line ownership boundary; de-duplicates the doc links the Doc map already carries.
- **Data-flow anchor**: real server-URL resolution order (`BASINWX_API_URLS` → `website_urls` → `website_url`); flags `brc_tools.visualize.grid` as a 2nd load-bearing cross-repo interface (brc-wrf's `wrf_quicklook.py` imports it).
- **Units**: obs pressure `hPa` → `Pa` (matches `lookups.toml` `synoptic_units`).
- **Env-var table**: add `BASINWX_API_URLS`, `PERPLEXITY_API_KEY`, `MISTRAL_API_KEY`, `BRC_TOOLS_HRRR_CACHE`, `BRC_TOOLS_HTTP_IPV4_ONLY`; `_auth` precedence note.
- **Related repos**: add `brc-wrf`, `brc-knowledge`.

### Downstream
- `WISHLIST-TASKS.md`: add the `rap_analysis` source request (brc-wrf Pelican RAP).
- `docs/WRF-INPUT-STAGING.md`: defer WRF-run ownership to brc-wrf on the `run_wrf_feb05.slurm` reference.

## Verification
- Every new claim cross-checked against source (env vars → code, `api/` tree, `grid.py` functions, `aviation/` removed, `synoptic_units = "Pa"`).
- `pytest` collects all 105 tests (docs-only change; no code touched).

Pre-existing unrelated WIP in the working tree (`.gitignore`, the `o3_concentration` lookups alias, `HANDOFF-TO-BRC-WRF.md`, the basin-floor scripts) was intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
