### PR TITLE
feat(wrf): add rap_analysis whole-file staging source (offline)

### DIFF
--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -124,6 +124,21 @@ grid              = "218"                    # 12 km CONUS Lambert-conformal
 filename_template = "namanl_218_{yyyymmdd}_{hhmm}_000.grb"
 url_template      = "https://www.ncei.noaa.gov/data/north-american-mesoscale-model/access/historical/analysis/{yyyymm}/{yyyymmdd}/{filename}"
 
+[models.rap_analysis]
+# RAP 13 km analysis (grid 130), hourly whole-file forcing for the Pelican
+# 2013-02-02 12-18Z hot-swap. Same shape as nam_analysis: one whole GRIB per
+# analysis cycle, staged by direct HTTP GET (NOT Herbie). PROVISIONAL: the NCEI
+# filename/URL and grib version below are best-guess and must be confirmed by one
+# live availability preflight before staging. The WPS Vtable (Vtable.RAP
+# candidates) is a brc-wrf review item and is NOT proven by this entry.
+description       = "RAP 13 km analysis (grid 130), NCEI historical archive"
+default_product   = "rap_130"
+cadence_hours     = 1                       # hourly analysis cycles
+grid              = "130"                    # 13 km CONUS Lambert-conformal
+wps_fg_name       = "RAP"                    # provisional WPS fg_name token
+filename_template = "rap_130_{yyyymmdd}_{hhmm}_000.grb2"
+url_template      = "https://www.ncei.noaa.gov/data/rapid-refresh/access/historical/analysis/{yyyymm}/{yyyymmdd}/{filename}"
+
 # ── Regions ─────────────────────────────────────────────────────────────────
 
 [regions.uinta_basin]

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -127,17 +127,19 @@ url_template      = "https://www.ncei.noaa.gov/data/north-american-mesoscale-mod
 [models.rap_analysis]
 # RAP 13 km analysis (grid 130), hourly whole-file forcing for the Pelican
 # 2013-02-02 12-18Z hot-swap. Same shape as nam_analysis: one whole GRIB per
-# analysis cycle, staged by direct HTTP GET (NOT Herbie). PROVISIONAL: the NCEI
-# filename/URL and grib version below are best-guess and must be confirmed by one
-# live availability preflight before staging. The WPS Vtable (Vtable.RAP
-# candidates) is a brc-wrf review item and is NOT proven by this entry.
-description       = "RAP 13 km analysis (grid 130), NCEI historical archive"
-default_product   = "rap_130"
-cadence_hours     = 1                       # hourly analysis cycles
-grid              = "130"                    # 13 km CONUS Lambert-conformal
-wps_fg_name       = "RAP"                    # provisional WPS fg_name token
-filename_template = "rap_130_{yyyymmdd}_{hhmm}_000.grb2"
-url_template      = "https://www.ncei.noaa.gov/data/rapid-refresh/access/historical/analysis/{yyyymm}/{yyyymmdd}/{filename}"
+# analysis cycle, staged by direct HTTP GET (NOT Herbie). Path/filename/grib2 and
+# all 7 cycles 12-18Z CONFIRMED by a live NCEI preflight (2026-06-29; ~12 MB/cycle,
+# HTTP 200, bogus cycles 404). Still NOT proven for a run: the WPS Vtable choice
+# (Vtable.RAP candidates) and RAP field-adequacy (land-sea mask / soil / snow /
+# skin-temp / SST) are brc-wrf review items — wps_fg_name is the staging token only.
+description         = "RAP 13 km analysis (grid 130), NCEI historical archive"
+default_product     = "rap_130"
+cadence_hours       = 1                       # hourly analysis cycles
+grid                = "130"                    # 13 km CONUS Lambert-conformal
+wps_fg_name         = "RAP"                    # WPS fg_name token (Vtable = brc-wrf)
+est_bytes_per_cycle = 12_500_000              # ~12 MB/file (NCEI preflight 2026-06-29)
+filename_template   = "rap_130_{yyyymmdd}_{hhmm}_000.grb2"
+url_template        = "https://www.ncei.noaa.gov/data/rapid-refresh/access/historical/analysis/{yyyymm}/{yyyymmdd}/{filename}"
 
 # ── Regions ─────────────────────────────────────────────────────────────────
 

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -589,6 +589,9 @@ def _remote_url(H) -> str | None:
 
 DEFAULT_NAM_SOURCE = "nam_analysis"
 DEFAULT_NAM_CADENCE_HOURS = 6
+# WPS fg_name token per staging source; build_contract prefers the lookups model's
+# wps_fg_name and falls back to this map so a non-NAM source is never stamped GEFS.
+_FG_NAME_FALLBACK = {"nam_analysis": "NAM", "gefs_reforecast": "GEFS", "rap_analysis": "RAP"}
 
 
 def _snap_down_to_cadence(t: dt.datetime, cadence_hours: int) -> dt.datetime:
@@ -781,16 +784,28 @@ def stage_nam_analysis(
 
     if not staged:
         raise RuntimeError(
-            f"NAM staging produced no files for init {init_dt:%Y-%m-%d %HZ} window "
+            f"{source} staging produced no files for init {init_dt:%Y-%m-%d %HZ} window "
             f"{fxx_window}: all {len(cycles)} cycle(s) were missing/unreachable. Check the "
-            "NCEI URL template ([models.nam_analysis] in lookups.toml)."
+            f"NCEI URL template ([models.{source}] in lookups.toml)."
         )
     if len(staged) < len(cycles):
         LOG.warning(
-            "NAM: staged %d of %d cycles (%d missing gap(s)).",
-            len(staged), len(cycles), len(cycles) - len(staged),
+            "%s: staged %d of %d cycles (%d missing gap(s)).",
+            source, len(staged), len(cycles), len(cycles) - len(staged),
         )
     return staged
+
+
+def stage_rap_analysis(**kwargs) -> list[StagedFile]:
+    """Stage RAP 13 km analysis (NCEI ``rap_130``) — hourly whole-file forcing.
+
+    Thin wrapper over :func:`stage_nam_analysis` (the shared whole-file analysis
+    stager) pinned to ``source="rap_analysis"``: hourly cadence, NCEI direct GET,
+    no Herbie. The NCEI URL/filename in ``[models.rap_analysis]`` are PROVISIONAL
+    pending one live availability preflight; the WPS Vtable is a brc-wrf decision.
+    """
+    kwargs["source"] = "rap_analysis"
+    return stage_nam_analysis(**kwargs)
 
 
 # ── manifest ────────────────────────────────────────────────────────────────
@@ -873,16 +888,18 @@ def write_manifest(manifest: dict, output_dir: str | Path) -> Path:
 def _interval_hours_for_sources(sources, lu: dict) -> int:
     """Metgrid/WRF LBC interval (hours) implied by the forcing source(s).
 
-    NAM-only forcing runs at the NAM analysis cadence (6 h — the validated
-    Feb-2013 recipe). If a reforecast-family source is present it forces the LBCs
-    at the finer reforecast lead cadence (3 h), with NAM as filler. This replaces
-    the blind ``DEFAULT_INTERVAL_HOURS`` that wrongly stamped a NAM-only run as 3 h.
+    The interval is the **finest native cadence** among the staged sources:
+    analysis sources carry ``cadence_hours`` (NAM 6 h, RAP 1 h); the reforecast has
+    none and forces LBCs at the 3-hourly lead cadence (``DEFAULT_INTERVAL_HOURS``),
+    with NAM as filler. So NAM-only → 6 h, RAP-only → 1 h, reforecast(+NAM) → 3 h.
     """
-    non_nam = [s for s in sources if s != DEFAULT_NAM_SOURCE]
-    if non_nam:
-        return DEFAULT_INTERVAL_HOURS  # reforecast 3-hourly LBC cadence
-    cfg = lu["models"].get(DEFAULT_NAM_SOURCE, {})
-    return int(cfg.get("cadence_hours", DEFAULT_NAM_CADENCE_HOURS))
+    intervals = []
+    for src in sources:
+        cfg = lu["models"].get(src, {})
+        intervals.append(
+            int(cfg["cadence_hours"]) if "cadence_hours" in cfg else DEFAULT_INTERVAL_HOURS
+        )
+    return min(intervals) if intervals else DEFAULT_INTERVAL_HOURS
 
 
 def build_contract(manifest: dict, lu: dict | None = None) -> dict:
@@ -907,20 +924,22 @@ def build_contract(manifest: dict, lu: dict | None = None) -> dict:
     cadence_hours = {}
     for src in sources:
         cfg = lu["models"].get(src, {})
+        # Per-source native cadence: analysis sources (NAM 6 h, RAP 1 h) carry
+        # cadence_hours; the reforecast falls back to the 3-hourly LBC cadence.
         cadence_hours[src] = (
-            int(cfg.get("cadence_hours", DEFAULT_NAM_CADENCE_HOURS))
-            if src == DEFAULT_NAM_SOURCE
-            else DEFAULT_INTERVAL_HOURS
+            int(cfg["cadence_hours"]) if "cadence_hours" in cfg else DEFAULT_INTERVAL_HOURS
         )
 
-    nam = DEFAULT_NAM_SOURCE in sources
-    other = [s for s in sources if s != DEFAULT_NAM_SOURCE]
-    if other and nam:
-        fg_name = ["GEFS", "NAM"]  # two-stream: reforecast forcing + NAM filler
-    elif other:
-        fg_name = ["GEFS"]
-    else:
-        fg_name = ["NAM"]  # validated single-stream forcing
+    # WPS fg_name token per source (filler/forcing order follows ``sources``), from the
+    # lookups model's ``wps_fg_name`` with a fallback map for the legacy sources — so a
+    # non-NAM source (e.g. rap_analysis) is never mis-stamped as GEFS.
+    fg_name: list[str] = []
+    for src in sources:
+        token = lu["models"].get(src, {}).get("wps_fg_name") or _FG_NAME_FALLBACK.get(src)
+        if token and token not in fg_name:
+            fg_name.append(token)
+    if not fg_name:
+        fg_name = ["NAM"]
 
     interval_hours = _interval_hours_for_sources(sources, lu)
     name = case.get("name")
@@ -977,7 +996,7 @@ def plan_case(
     plan: list[dict] = []
     for src in sources:
         cfg = lu["models"].get(src, {})
-        if src == DEFAULT_NAM_SOURCE:
+        if cfg.get("filename_template"):  # whole-file analysis source (NAM, RAP)
             cadence = int(cfg.get("cadence_hours", DEFAULT_NAM_CADENCE_HOURS))
             url_template = cfg.get("url_template")
             filename_template = cfg.get("filename_template")
@@ -1169,10 +1188,11 @@ def stage_case(
     """Stage every requested source/member, write the manifest, optional quicklook/obs.
 
     ``sources`` (e.g. ``("gefs_reforecast", "nam_analysis")``) overrides the
-    singular ``source``; ``nam_analysis`` is staged via :func:`stage_nam_analysis`
-    (one whole file per analysis cycle), any other source via
-    :func:`stage_reforecast` (per member). ``interval_hours`` defaults to the
-    forcing source's cadence (NAM-only → 6 h, reforecast → 3 h) when not given.
+    singular ``source``; whole-file analysis sources (``nam_analysis``,
+    ``rap_analysis``) are staged via :func:`stage_nam_analysis` (one whole file per
+    analysis cycle), any other source via :func:`stage_reforecast` (per member).
+    ``interval_hours`` defaults to the forcing source's cadence (NAM-only → 6 h,
+    RAP-only → 1 h, reforecast → 3 h) when not given.
     Also writes a ``contract_<case>.json`` sidecar. Returns the manifest path.
     """
     init_dt = _parse_init_time(init_time)
@@ -1189,7 +1209,7 @@ def stage_case(
     staged: list[StagedFile] = []
     t0 = time.perf_counter()  # end-to-end staging wall-time (incl. sha256 + move)
     for src in src_list:
-        if src == DEFAULT_NAM_SOURCE:
+        if lu["models"].get(src, {}).get("filename_template"):  # whole-file analysis (NAM, RAP)
             staged.extend(
                 stage_nam_analysis(
                     init_time=init_dt,
@@ -1298,7 +1318,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--source",
         default=DEFAULT_SOURCE,
-        help="Comma list of sources: gefs_reforecast, nam_analysis (default: gefs_reforecast).",
+        help="Comma list of sources: gefs_reforecast, nam_analysis, rap_analysis (default: gefs_reforecast).",
     )
     parser.add_argument(
         "--variable-levels",

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -1016,7 +1016,7 @@ def plan_case(
                 plan.append({
                     "source": src, "member": "", "filename": filename,
                     "url": url, "local_path": str(dest),
-                    "est_bytes": NAM_EST_BYTES_PER_CYCLE,
+                    "est_bytes": int(cfg.get("est_bytes_per_cycle", NAM_EST_BYTES_PER_CYCLE)),
                 })
         else:
             breakpoint_fxx = int(cfg.get("fxx_bucket_breakpoint", 240))

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -621,7 +621,7 @@ def test_plan_case_rap_offline(tmp_path):
     assert len(plan) == 7  # hourly cycles 12Z..18Z (analysis path, not reforecast)
     assert all(e["source"] == "rap_analysis" and e["member"] == "" for e in plan)
     assert all(e["url"].startswith("https://www.ncei.noaa.gov/") for e in plan)
-    assert all(e["est_bytes"] for e in plan)  # rough offline estimate present
+    assert all(e["est_bytes"] == 12_500_000 for e in plan)  # per-source estimate (NCEI preflight)
     names = [Path(e["local_path"]).name for e in plan]
     assert names[0] == "rap_130_20130202_1200_000.grb2"
     assert names[-1] == "rap_130_20130202_1800_000.grb2"

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -33,6 +33,7 @@ from brc_tools.nwp.wrf_staging import (
     build_manifest,
     plan_case,
     stage_nam_analysis,
+    stage_rap_analysis,
     stage_reforecast,
     verify_manifest,
     write_manifest,
@@ -186,6 +187,14 @@ def test_lookups_nam_analysis_parses():
     cfg = wrf_staging.load_lookups()["models"]["nam_analysis"]
     assert cfg["cadence_hours"] == 6
     assert "{yyyymmdd}" in cfg["filename_template"]
+    assert cfg["url_template"].startswith("https://www.ncei.noaa.gov/")
+
+
+def test_lookups_rap_analysis_parses():
+    cfg = wrf_staging.load_lookups()["models"]["rap_analysis"]
+    assert cfg["cadence_hours"] == 1                    # hourly analysis
+    assert cfg["wps_fg_name"] == "RAP"
+    assert cfg["filename_template"] == "rap_130_{yyyymmdd}_{hhmm}_000.grb2"
     assert cfg["url_template"].startswith("https://www.ncei.noaa.gov/")
 
 
@@ -433,6 +442,28 @@ def test_stage_nam_skips_existing(tmp_path, fake_nam_http):
     assert fake_nam_http.urls == []  # already staged -> no HTTP call
 
 
+def test_stage_rap_analysis_layout_and_manifest(tmp_path, fake_nam_http):
+    # RAP rides the shared whole-file analysis stager (mocked HTTP) at hourly cadence.
+    staged = stage_rap_analysis(
+        init_time="2013-02-02 00Z",
+        fxx_window=(12, 18),  # hourly 12Z..18Z on 2013-02-02 (Pelican window)
+        output_root=tmp_path,
+        case="pelican",
+    )
+    assert len(staged) == 7  # one whole file per hourly analysis cycle
+    for sf in staged:
+        dest = Path(sf.local_path)
+        assert dest.exists() and validate_cached_grib(dest)
+        assert dest.parent == tmp_path / "pelican" / "rap_analysis"  # no member dir
+        assert dest.name.startswith("rap_130_") and dest.name.endswith("_000.grb2")
+        assert sf.source == "rap_analysis" and sf.member == "" and sf.member_int == 0
+        assert sf.remote_url.startswith("https://www.ncei.noaa.gov/")
+    assert {Path(sf.local_path).name for sf in staged} == {
+        f"rap_130_20130202_{h:02d}00_000.grb2" for h in range(12, 19)
+    }
+    assert len(fake_nam_http.urls) == 7  # one whole-file GET per cycle
+
+
 # ── manifest ─────────────────────────────────────────────────────────────────
 
 
@@ -582,6 +613,21 @@ def test_plan_case_reforecast_offline(tmp_path):
     assert all(e["est_bytes"] is None for e in plan)  # reforecast size unknown offline
 
 
+def test_plan_case_rap_offline(tmp_path):
+    plan = plan_case(
+        case="pelican2013_rap", init_time="2013-02-02 00Z", output_root=tmp_path,
+        fxx_window=(12, 18), sources=("rap_analysis",),
+    )
+    assert len(plan) == 7  # hourly cycles 12Z..18Z (analysis path, not reforecast)
+    assert all(e["source"] == "rap_analysis" and e["member"] == "" for e in plan)
+    assert all(e["url"].startswith("https://www.ncei.noaa.gov/") for e in plan)
+    assert all(e["est_bytes"] for e in plan)  # rough offline estimate present
+    names = [Path(e["local_path"]).name for e in plan]
+    assert names[0] == "rap_130_20130202_1200_000.grb2"
+    assert names[-1] == "rap_130_20130202_1800_000.grb2"
+    assert all(Path(e["local_path"]).parent.name == "rap_analysis" for e in plan)
+
+
 # ── manifest integrity ───────────────────────────────────────────────────────
 
 
@@ -709,6 +755,7 @@ def test_interval_hours_for_sources():
     assert _interval_hours_for_sources(("nam_analysis",), lu) == 6
     assert _interval_hours_for_sources(("gefs_reforecast",), lu) == 3
     assert _interval_hours_for_sources(("gefs_reforecast", "nam_analysis"), lu) == 3
+    assert _interval_hours_for_sources(("rap_analysis",), lu) == 1  # hourly RAP analysis
 
 
 def test_build_contract_nam_only():
@@ -736,6 +783,20 @@ def test_build_contract_two_stream():
     assert c["wps_fg_name"] == ["GEFS", "NAM"]
     assert c["interval_seconds"] == 10800
     assert c["source_file_counts"] == {"gefs_reforecast": 1, "nam_analysis": 1}
+
+
+def test_build_contract_rap_only():
+    m = build_manifest(
+        case="pelican2013_rap", region="uinta_basin_wide",
+        requested_window=("2013-02-02T12:00:00Z", "2013-02-02T18:00:00Z"),
+        interval_hours=1, sources=["rap_analysis"],
+        staged=[_nam_staged_stub("rap_analysis")],
+    )
+    c = build_contract(m)
+    assert c["wps_fg_name"] == ["RAP"]  # metadata-driven, NOT mis-stamped as GEFS
+    assert c["interval_seconds"] == 3600 and c["interval_hours"] == 1
+    assert c["cadence_hours"]["rap_analysis"] == 1
+    assert c["source_file_counts"] == {"rap_analysis": 1}
 
 
 def test_stage_case_writes_contract_and_derived_interval(tmp_path, fake_nam_http):


### PR DESCRIPTION
## What

Adds `rap_analysis` as a first-class WRF-input staging source so brc-wrf can hot-swap RAP forcing for the **Pelican 2013-02-02 12–18Z** case (3/1/0.333 km, 75 lev) — the smallest **offline, no-download** patch per the brc-wrf RAP feasibility memo (`../brc-wrf/brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md`).

## Changes
- **`lookups.toml`** — `[models.rap_analysis]`: hourly grid-130 NCEI analysis, `wps_fg_name="RAP"`, filename/URL templates. ⚠️ NCEI filename/URL + grib version are **PROVISIONAL** pending one live preflight.
- **`wrf_staging.py`** — generalize the whole-file-analysis path so it is source-driven, not NAM-hardcoded:
  - `plan_case` / `stage_case` branch on `filename_template` (covers NAM **and** RAP) instead of `src == nam_analysis`.
  - `build_contract` + `_interval_hours_for_sources` derive cadence and `fg_name` from per-source metadata (lookups `wps_fg_name` / `cadence_hours`, with a fallback map) — so RAP yields `wps_fg_name=["RAP"]`, `interval_seconds=3600`, `interval_hours=1` instead of being **mis-stamped GEFS**.
  - Add `stage_rap_analysis()` wrapper; refresh CLI `--source` help.
- **`tests`** — +4 RAP tests (lookups parse, mocked hourly staging, offline plan, contract) + a RAP assertion in the interval test.

## Validation (offline; conda env `clyfar-nov2025`)
- `pytest tests/test_wrf_staging.py` → **40 passed, 2 skipped**; full suite **107 passed, 2 skipped**. NAM/GEFS/two-stream regressions intact.
- `git diff --check` clean.
- Offline CLI `--plan` enumerates 7 hourly files for 2013-02-02 12–18Z under `…/rap_analysis/rap_130_*_000.grb2`, no network.

## Scope / boundaries (carried forward from the memo)
- **Offline only**: no download, DTN, WPS, `real.exe`, `wrf.exe`, or `sbatch`.
- **Out of scope (brc-wrf review items):** RAP WPS field-adequacy (land-sea mask / soil / snow / skin-temp / SST) and the Vtable choice (4 candidates, none generic). A green suite proves plan/contract **shape** only; `fg_name="RAP"` is a provisional token.
- brc-tools keeps owning staging/manifest/contract; WPS/run-Slurm stay in brc-wrf.

## Next step (separate approval)
One **live RAP availability/metadata preflight** for 2013-02-02 12Z to confirm-or-correct the NCEI path/filename/grib-extension and per-cycle availability — then a separate staging approval. (Preflight result will be posted here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
