### PR TITLE
docs: retitle WRF-INPUT-STAGING as Reference + purge dead handoff refs

### DIFF
--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -27,7 +27,7 @@ proven end-to-end** (WPS → `real.exe` → `wrf.exe`); the **GEFS+NAM two-strea
 not** proven. brc-tools owns download/staging/manifest only — WPS/`real.exe`/`wrf.exe`/
 Slurm run profiles stay in `brc-wrf`.
 
-- Canonical docs: `docs/WRF-INPUT-STAGING.md` (full handoff) and
+- Canonical docs: `docs/WRF-INPUT-STAGING.md` (full reference) and
   `docs/WRF-STAGING-STATE-PLAYBOOK.md` (terse state).
 - Cross-repo entry point: `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
 - The remaining staging-microtask backlog (#4–#13, #31, …) lives in

--- a/docs/CROSS-REPO-SYNC.md
+++ b/docs/CROSS-REPO-SYNC.md
@@ -71,9 +71,9 @@ These files must stay aligned across repos:
 > **Note (2026-06-16, brc-tools-local):** brc-tools also has a separate seam to
 > **brc-wrf** (the WRF model fork) for WRF-input GRIB staging — *not* one of the 4
 > repos above. Its contract is the manifest/contract sidecar boundary; the protocol
-> lives in `docs/WRF-INPUT-STAGING.md`, `docs/HANDOFF-TO-BRC-WRF.md`, and
-> `docs/HANDOFF-TO-BRC-WRF-HYGIENE.md` (cross-repo wiring + caretaker). Keep that
-> seam's docs in sync there, not here.
+> lives in `docs/WRF-STAGING-STATE-PLAYBOOK.md` (the single cold-start handoff) and
+> `docs/WRF-INPUT-STAGING.md` (detail/proof). Keep that seam's docs in sync there,
+> not here.
 
 ## Workflow for Making Changes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,8 @@ Project documentation. Topical files only — agent context lives in
 - **CROSS-REPO-SYNC.md** — protocol for keeping the four sibling repos aligned.
 - **WEBSITE-INTEGRATION.md** — BasinWX upload contract (endpoint, auth, dataTypes, schemas).
 - **ENVIRONMENT-SETUP.md** — venv/conda setup for new team members.
-- **WRF-INPUT-STAGING.md** — WRF/WPS GRIB staging handoff, proof evidence, and microtasks.
-- **WRF-STAGING-STATE-PLAYBOOK.md** — plain-language milestone/state packet for the WRF staging side.
-- **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (not proven).
-- **HANDOFF-TO-BRC-WRF.md** — paste-prompt to hand the WRF run side to a brc-wrf session.
+- **WRF-INPUT-STAGING.md** — WRF/WPS GRIB staging reference: status, proof evidence, and microtasks (the playbook is the handoff).
+- **WRF-STAGING-STATE-PLAYBOOK.md** — the single WRF cold-start handoff + state packet (start here for the WRF lane).
+- **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (parked, not proven).
+- **nwp/NWP-SOURCE-MATRIX.md** — per-source download matrix (Herbie vs direct) + Herbie currency.
 - **nwp/** — HRRR/RRFS roadmap (current operational focus).

--- a/docs/WRF-INPUT-STAGING.md
+++ b/docs/WRF-INPUT-STAGING.md
@@ -1,4 +1,4 @@
-# WRF-Input GRIB Staging — Handoff
+# WRF-Input GRIB Staging — Reference (detail + proof)
 
 > **State:** NAM-only is proven end-to-end (WPS → `real.exe` → `wrf.exe`). GEFS+NAM two-stream is **not** proven.
 > **brc-wrf side:** `../brc-wrf/brc-docs/BRC-WRF-STATE-PLAYBOOK.md` · `../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md` (paths from repo root; both repos checked out as siblings).


### PR DESCRIPTION
Retitles `WRF-INPUT-STAGING.md` H1 to **Reference (detail + proof)** — it's the detail doc the playbook points to, not a handoff. Fixes every description to match: `docs/README.md` index (drops the deleted `HANDOFF-TO-BRC-WRF.md` entry, adds `NWP-SOURCE-MATRIX.md`, marks field-map parked), WISHLIST 'full handoff'→'full reference', and `CROSS-REPO-SYNC.md` (repoints the two deleted HANDOFF docs to the playbook). Sweep confirms **no dead `HANDOFF-TO-BRC-WRF*` references remain**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)