### PR TITLE
nwp: GFS analysis as second Pelican WRF forcing (staged + verified)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Current focus
 - HRRR/RRFS → BasinWX operational ingest (GH issue #10). Strategy and status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures). Pattern: `docs/CASE-STUDY-GUIDE.md`.
-- **WRF-input staging**: stage GRIB → scratch as a `manifest_<case>.json` + `contract_<case>.json` handshake that `brc-wrf` consumes for WPS/WRF. brc-tools owns staging/manifests/contracts/NWP-download + the reusable `visualize/grid.py` quicklook helpers; WPS/`real.exe`/`wrf.exe`/run-Slurm stay in `brc-wrf`. NAM-only proven & merged; GEFS+NAM two-stream optional/unproven; RAP source merged (#26) **and staged+verified to scratch** — brc-wrf consumes the contract next (WPS Vtable + metgrid/real/wrf). **Cold-start entry → `docs/WRF-STAGING-STATE-PLAYBOOK.md`** (single source of truth for this lane); proof detail → `docs/WRF-INPUT-STAGING.md`; cross-repo → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
+- **WRF-input staging**: stage GRIB → scratch as a `manifest_<case>.json` + `contract_<case>.json` handshake that `brc-wrf` consumes for WPS/WRF. brc-tools owns staging/manifests/contracts/NWP-download + the reusable `visualize/grid.py` quicklook helpers; WPS/`real.exe`/`wrf.exe`/run-Slurm stay in `brc-wrf`. NAM-only proven & merged (baseline `pelican2013_nam`); RAP staged but **blocked before `real.exe`** (no layered soil); **`gfs_analysis` added + staged+verified** (`pelican2013_gfs`, #33) as the 2nd IC/LBC forcing — brc-wrf consumes the GFS contract next (WPS `Vtable.GFS` → metgrid/real/wrf); GEFS+NAM two-stream optional/unproven. **Cold-start entry → `docs/WRF-STAGING-STATE-PLAYBOOK.md`** (single source of truth for this lane); proof detail → `docs/WRF-INPUT-STAGING.md`; cross-repo → `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
 - Next up: NWPSource / ObsSource integration tests. Backlog: `WISHLIST-TASKS.md`.
 
 ## Repo map
@@ -73,7 +73,7 @@ public signatures as load-bearing too.
 - **JSON filenames**: `generate_json_fpath()` → `{prefix}_{YYYYMMDD_HHMM}Z.json`.
 - **API calls**: wrap in try/except; log and continue; retry with backoff at boundaries only.
 - **NWP code** lives in `brc_tools/nwp/`, not `brc_tools/download/`.
-- **Don't reinvent NWP downloads — check Herbie first.** Brian Blaylock's Herbie ([herbie.readthedocs.io](https://herbie.readthedocs.io)) ships hardened, on-rails model templates (`herbie/models/*.py`) for most NOAA/NCEI sources — prefer them over hand-rolled fetches. Record each source's Herbie-native-vs-direct decision in `docs/nwp/NWP-SOURCE-MATRIX.md` (enforced by `tests/test_source_matrix.py`). A hand-rolled GET is the exception and must justify why Herbie doesn't fit (today: only `nam_analysis`/`rap_analysis`, which Herbie can't retrieve for 2013).
+- **Don't reinvent NWP downloads — check Herbie first.** Brian Blaylock's Herbie ([herbie.readthedocs.io](https://herbie.readthedocs.io)) ships hardened, on-rails model templates (`herbie/models/*.py`) for most NOAA/NCEI sources — prefer them over hand-rolled fetches. Record each source's Herbie-native-vs-direct decision in `docs/nwp/NWP-SOURCE-MATRIX.md` (enforced by `tests/test_source_matrix.py`). A hand-rolled GET is the exception and must justify why Herbie doesn't fit (today: `nam_analysis`/`rap_analysis`/`gfs_analysis`, which Herbie can't retrieve for 2013).
 - **Units**: NWP temps in K, MSLP in Pa, wind in m/s. Obs already in C / Pa / m/s (Synoptic returns Pa for pressure; units are per-alias in `lookups.toml` `synoptic_units`). Convert at the boundary (e.g. Pa→hPa) only for display.
 - **Lookups** (`brc_tools/nwp/lookups.toml`) is the source of truth for models, regions, waypoints, waypoint groups, variable aliases. Read it; don't duplicate its contents into docs.
 
@@ -101,7 +101,7 @@ pytest tests/
 ```
 Use a conda env with the deps (herbie, polars, pandas, matplotlib, cfgrib, requests).
 Preferred: the dedicated **`brc-tools-2026`** env (`mamba env create -f environment.yml`;
-herbie 2026.3.0 — validated, 107 passed); the shared `clyfar-nov2025` also works. Fresh
+herbie 2026.3.0 — validated, 110 passed); the shared `clyfar-nov2025` also works. Fresh
 setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
 
 ## Related repos

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -141,6 +141,27 @@ est_bytes_per_cycle = 12_500_000              # ~12 MB/file (NCEI preflight 2026
 filename_template   = "rap_130_{yyyymmdd}_{hhmm}_000.grb2"
 url_template        = "https://www.ncei.noaa.gov/data/rapid-refresh/access/historical/analysis/{yyyymm}/{yyyymmdd}/{filename}"
 
+[models.gfs_analysis]
+# GFS 0.5° analysis (grid 004) from the NCEI historical archive — an auth-free,
+# field-complete SECOND WRF/WPS forcing for the Pelican 2013-02-02 12-18Z hot-swap
+# ("poor-man's ensemble" beside the proven nam_analysis baseline). Same shape as
+# nam_analysis/rap_analysis: one whole GRIB2 per analysis cycle, staged by direct
+# HTTP GET (NOT Herbie — Herbie's gfs.py has only aws/nomads operational sources,
+# which don't reach 2013). Field adequacy CONFIRMED from the live .inv (2026-06-30):
+# 4-layer TMP/SOILW below-ground, LAND/TMP/ICEC/WEASD at surface, 26-level
+# HGT/TMP/RH/UGRD/VGRD, PRMSL+MSLET, 2 m/10 m — the full set real.exe needs (the
+# layered soil + real-ready 3D atmosphere RAP lacked). Maps to Vtable.GFS (brc-wrf).
+# Only gap vs NAM: no snod (snow depth); weasd (snow water-equiv) -> metgrid SNOW.
+# grid-4 also ships _003/_006 offsets -> optional 3-hourly LBCs (stager change).
+description         = "GFS 0.5° analysis (grid 004), NCEI historical archive"
+default_product     = "gfsanl_4"
+cadence_hours       = 6                       # analysis cycles at 00/06/12/18Z
+grid                = "004"                    # 0.5° global lat-lon
+wps_fg_name         = "GFS"                    # WPS fg_name token; Vtable.GFS (brc-wrf)
+est_bytes_per_cycle = 52_000_000              # ~52 MB/file (NCEI HEAD 2026-06-30)
+filename_template   = "gfsanl_4_{yyyymmdd}_{hhmm}_000.grb2"
+url_template        = "https://www.ncei.noaa.gov/data/global-forecast-system/access/historical/analysis/{yyyymm}/{yyyymmdd}/{filename}"
+
 # ── Regions ─────────────────────────────────────────────────────────────────
 
 [regions.uinta_basin]

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -591,7 +591,7 @@ DEFAULT_NAM_SOURCE = "nam_analysis"
 DEFAULT_NAM_CADENCE_HOURS = 6
 # WPS fg_name token per staging source; build_contract prefers the lookups model's
 # wps_fg_name and falls back to this map so a non-NAM source is never stamped GEFS.
-_FG_NAME_FALLBACK = {"nam_analysis": "NAM", "gefs_reforecast": "GEFS", "rap_analysis": "RAP"}
+_FG_NAME_FALLBACK = {"nam_analysis": "NAM", "gefs_reforecast": "GEFS", "rap_analysis": "RAP", "gfs_analysis": "GFS"}
 
 
 def _snap_down_to_cadence(t: dt.datetime, cadence_hours: int) -> dt.datetime:
@@ -805,6 +805,19 @@ def stage_rap_analysis(**kwargs) -> list[StagedFile]:
     pending one live availability preflight; the WPS Vtable is a brc-wrf decision.
     """
     kwargs["source"] = "rap_analysis"
+    return stage_nam_analysis(**kwargs)
+
+
+def stage_gfs_analysis(**kwargs) -> list[StagedFile]:
+    """Stage GFS 0.5° analysis (NCEI ``gfsanl_4``) — 6-hourly whole-file forcing.
+
+    Thin wrapper over :func:`stage_nam_analysis` (the shared whole-file analysis
+    stager) pinned to ``source="gfs_analysis"``: 6-hourly cadence, NCEI direct GET,
+    no Herbie. Unlike RAP, GFS analysis is field-complete for ``real.exe`` (4-layer
+    soil, land-sea mask, skin temp, snow, full pressure column — confirmed from the
+    NCEI ``.inv``); the WPS Vtable is ``Vtable.GFS`` (a brc-wrf decision).
+    """
+    kwargs["source"] = "gfs_analysis"
     return stage_nam_analysis(**kwargs)
 
 
@@ -1191,7 +1204,7 @@ def stage_case(
 
     ``sources`` (e.g. ``("gefs_reforecast", "nam_analysis")``) overrides the
     singular ``source``; whole-file analysis sources (``nam_analysis``,
-    ``rap_analysis``) are staged via :func:`stage_nam_analysis` (one whole file per
+    ``rap_analysis``, ``gfs_analysis``) are staged via :func:`stage_nam_analysis` (one whole file per
     analysis cycle), any other source via :func:`stage_reforecast` (per member).
     ``interval_hours`` defaults to the forcing source's cadence (NAM-only → 6 h,
     RAP-only → 1 h, reforecast → 3 h) when not given.
@@ -1302,7 +1315,7 @@ def _run_obs_check(*, case: str, init_dt: dt.datetime) -> None:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments for the WRF-input staging script."""
     parser = argparse.ArgumentParser(
-        description="Stage WPS/WRF-ready GRIB inputs (GEFS reforecast or NAM/RAP analysis) to scratch.",
+        description="Stage WPS/WRF-ready GRIB inputs (GEFS reforecast or NAM/RAP/GFS analysis) to scratch.",
     )
     parser.add_argument("--case", default=DEFAULT_CASE, help="Case name (output subdir).")
     parser.add_argument(
@@ -1320,7 +1333,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--source",
         default=DEFAULT_SOURCE,
-        help="Comma list of sources: gefs_reforecast, nam_analysis, rap_analysis (default: gefs_reforecast).",
+        help="Comma list of sources: gefs_reforecast, nam_analysis, rap_analysis, gfs_analysis (default: gefs_reforecast).",
     )
     parser.add_argument(
         "--variable-levels",

--- a/docs/WRF-INPUT-STAGING.md
+++ b/docs/WRF-INPUT-STAGING.md
@@ -1,6 +1,6 @@
 # WRF-Input GRIB Staging — Reference (detail + proof)
 
-> **State:** NAM-only is proven end-to-end (WPS → `real.exe` → `wrf.exe`). GEFS+NAM two-stream is **not** proven.
+> **State:** NAM-only is proven end-to-end (WPS → `real.exe` → `wrf.exe`). GFS 0.5° analysis is a second forcing, **staged + verified** for the Pelican case (awaiting brc-wrf WPS). GEFS+NAM two-stream is **not** proven.
 > **brc-wrf side:** `../brc-wrf/brc-docs/BRC-WRF-STATE-PLAYBOOK.md` · `../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md` (paths from repo root; both repos checked out as siblings).
 
 **Status:** ✅ **end-to-end validated** (2026-06-13). NAM-only staging drove WPS → `real.exe` →
@@ -42,6 +42,18 @@ manifest**; the sibling **brc-wrf** repo owns **ungrib → metgrid → real** an
 | `tests/test_wrf_staging.py` | 13 mocked tests + 1 opt-in live (`RUN_LIVE_HERBIE=1`). |
 | `brc_tools/nwp/lookups.toml` | `[models.gefs_reforecast]` block + S3-confirmed `wps_variable_levels`. |
 
+**Python environment guardrail:** all commands in this repo that run Python,
+Herbie, WRF source planning/staging, manifest verification, or tests must force
+the maintained WRF-staging env:
+
+```bash
+conda run -n brc-tools-2026 python ...
+conda run -n brc-tools-2026 pytest ...
+```
+
+Do not use bare `python`/`pytest` from an inherited Codex shell; it may be an
+unrelated environment such as `clyfar-nov2025`.
+
 **Source mapping (decided, evidence-backed):** operational GEFS (Herbie `gefs`) AWS archive starts
 **2017** — useless for 2013. The only Herbie-native GEFS-family source for historical dates is
 **GEFSv12 Reforecast** (`gefs_reforecast`, 2000–2019, daily 00Z, 5 members c00/p01–p04). It uses a
@@ -51,6 +63,15 @@ humidity is **specific** (`spfh_*`, no `rh_pres`/`rh_2m`), 10 m winds are `ugrd_
 there is **no land-sea mask / no snow depth**. → the gap is filled by an **auth-free NAM 12 km
 analysis** (NCEI `namanl_218`, `stage_nam_analysis`) — used either as a standalone single-stream
 forcing or as a second ungrib stream (multi-`fg_name` metgrid). **No NCAR RDA / ds083.2 / auth.**
+
+**Second independent forcing (GFS analysis, the Pelican hot-swap):** `gfs_analysis` stages the
+auth-free **NCEI GFS 0.5° analysis** (grid-004 GRIB2 `gfsanl_4`, direct GET like NAM/RAP) as a
+standalone single-stream forcing (`Vtable.GFS`, `fg_name=["GFS"]`, humidity = RH). Its `.inv` carries
+the full `real.exe` set — 4-layer soil T/moisture, land-sea mask, skin temp, snow/ice, 26-level
+atmosphere — so unlike RAP it should clear `NUM_METGRID_SOIL_LEVELS > 0`. Staged + `verify_manifest`
+**2/2 OK** for `pelican2013_gfs_3_1_333m_75lev` (12Z+18Z, `interval_seconds=21600`, a structural
+mirror of the NAM baseline); WPS/run is brc-wrf's. Chosen over NCAR-RDA FNL (auth-gated; 0.5° GFS is
+finer than 2013 FNL's 1°). Cross-repo handoff: `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
 
 **Output layout:**
 ```
@@ -63,13 +84,18 @@ forcing or as a second ungrib stream (multi-`fg_name` metgrid). **No NCAR RDA / 
 **Quick start (small smoke; see §5 for where to run big stages):**
 ```bash
 # NAM analysis — the validated single-stream forcing (auth-free NCEI, no RDA):
-python scripts/stage_wrf_inputs.py --case jan2013_basin_gefs \
+conda run -n brc-tools-2026 python -m brc_tools.nwp.wrf_staging --case jan2013_basin_gefs \
   --init-time "2013-01-31 00Z" --source nam_analysis --fxx-window 12,48
 
 # GEFS reforecast smoke (2 vars, control member, lead-subset to f12..f48):
-python scripts/stage_wrf_inputs.py --case jan2013_basin_gefs \
+conda run -n brc-tools-2026 python -m brc_tools.nwp.wrf_staging --case jan2013_basin_gefs \
   --init-time "2013-01-31 00Z" --members 0 --variable-levels tmp_2m,weasd_sfc \
   --fxx-window 12,48 --lead-subset      # --lead-subset = only f12..f48, ~6x smaller
+
+# GFS 0.5° analysis — Pelican hot-swap second forcing (auth-free NCEI grid-4; 2x52 MB,
+# staged + verified 2026-06-30; field-complete; maps to Vtable.GFS). 12Z+18Z mirror the NAM baseline:
+conda run -n brc-tools-2026 python -m brc_tools.nwp.wrf_staging --case pelican2013_gfs_3_1_333m_75lev \
+  --init-time "2013-02-02 12Z" --source gfs_analysis --fxx-window 0,6 --http-ipv4-only --no-quicklook
 ```
 
 ---

--- a/docs/WRF-STAGING-STATE-PLAYBOOK.md
+++ b/docs/WRF-STAGING-STATE-PLAYBOOK.md
@@ -7,50 +7,81 @@ lane** — start here; the detail/proof lives in `docs/WRF-INPUT-STAGING.md`.
 
 ## Cold-start handoff (for the next Claude Code session)
 
-**You are in `brc-tools`. The RAP forcing experiment's brc-tools half is DONE — the next
-move is in `brc-wrf`.**
+**You are in `brc-tools`. GFS analysis is now a supported second forcing source,
+staged + verified for the Pelican hot-swap lane. The ball is in `brc-wrf`'s court:
+run WPS (`Vtable.GFS`) → metgrid → `real.exe` → `wrf.exe` on the staged contract.**
 
-State (2026-06-29):
-- **RAP staged + verified on scratch:** `/scratch/general/vast/$USER/wrf_inputs/pelican2013_rap_3_1_333m_75lev/`
-  holds 7 hourly RAP-130 GRIB (2013-02-02 12–18Z, ~85 MB), `manifest_*.json` (`verify_manifest` 7/7 OK),
-  and `contract_*.json` (`wps_fg_name:["RAP"]`, `interval_seconds:3600`, hourly).
-- **`rap_analysis` source merged to `main`** (offline plan/contract/tests + source-generic whole-file
-  staging); the NCEI path is live-preflight-confirmed. Env: **`brc-tools-2026`** (herbie 2026.3.0;
-  `mamba env create -f environment.yml`).
-- **Session PRs merged:** #25 (docs + `docs/nwp/NWP-SOURCE-MATRIX.md` + Herbie guard), #26 (RAP), #27 (env).
+State (2026-06-30):
+- **NAM baseline complete:** `brc-wrf` has the successful
+  `pelican2013_nam_3_1_333m_75lev` 3/1/0.333 km, 75-level, six-hour run.
+- **RAP staged + verified, but blocked in WRF:** the RAP bundle under
+  `/scratch/general/vast/$USER/wrf_inputs/pelican2013_rap_3_1_333m_75lev/`
+  has 7 hourly RAP-130 GRIB files and a valid contract, but two WPS-only
+  `brc-wrf` proofs blocked before `real.exe`: hybrid RAP lacked a real-ready
+  3D atmosphere, and pressure RAP lacked layered soil temperature/moisture.
+- **ERA5 blocked locally:** no `era5` WRF-staging source exists here,
+  `brc-tools-2026` lacks `cdsapi`/`ecmwfapi`, and CDS credentials were not
+  configured. `brc-wrf` has a plausible WPS-side `Vtable.ECMWF`, but staging is
+  not ready.
+- **GFS analysis SUPPORTED + STAGED + VERIFIED (2026-06-30):** added
+  `[models.gfs_analysis]` (NCEI grid-004 0.5° GRIB2, auth-free direct GET — same
+  lane as NAM/RAP) + `stage_gfs_analysis()` + matrix row + tests. Field adequacy
+  CONFIRMED from the live `.inv` (4-layer soil T/moisture, land-sea mask, skin
+  temp, snow/ice, 26-level atmosphere — the soil + real-ready 3D atmosphere RAP
+  lacked). Staged + `verify_manifest` 2/2 OK to
+  `/scratch/general/vast/$USER/wrf_inputs/pelican2013_gfs_3_1_333m_75lev/`
+  (12Z+18Z, `wps_fg_name=["GFS"]`, `interval_seconds=21600` — an exact structural
+  mirror of the NAM baseline). Chosen over NCAR-RDA FNL (auth-gated; 0.5° GFS is
+  finer than 2013 FNL's 1°). NCEI product:
+  https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast
+- **Environment guardrail:** every brc-tools Python, Herbie, WRF
+  source-planning, staging, manifest-verification, or pytest command must use
+  `conda run -n brc-tools-2026 ...` or
+  `/uufs/chpc.utah.edu/common/home/u0737349/software/pkg/miniforge3/envs/brc-tools-2026/bin/python`.
+  Do not rely on inherited shells; Codex has inherited `clyfar-nov2025` in this
+  lane.
 
-Next move — **switch to `brc-wrf`** and consume the contract:
-1. Point the brc-wrf case at the contract/manifest above; choose the WPS **Vtable.RAP** (candidates in the
-   memo — none generic) and run ungrib → metgrid → real → wrf.
-2. ⚠️ **Open risk — verify first:** RAP field-adequacy is UNPROVEN (land-sea mask / soil / snow / skin-temp /
-   SST). If RAP alone is short at metgrid, add a NAM filler stream (the parked GEFS+NAM two-stream pattern).
+Next move (now in `brc-wrf`):
+1. Consume the staged GFS contract
+   `contract_pelican2013_gfs_3_1_333m_75lev.json`: ungrib with `Vtable.GFS`
+   (humidity = RH) → metgrid → `real.exe` → `wrf.exe`. **Watch
+   `NUM_METGRID_SOIL_LEVELS > 0`** — that is the exact RAP failure mode this
+   source is expected to clear.
+2. Note `SNOWH` may be absent (GFS ships `weasd` snow water-equiv, no `snod`);
+   metgrid yields `SNOW`, and Noah can derive depth — not a `real.exe` blocker.
+3. Handoff packet for `brc-wrf`: `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.
 
-If you instead need a **different NWP model** for ICs/LBCs: the pattern is now small — add `[models.<src>]`
-to `lookups.toml` (mirror `nam_analysis`/`rap_analysis`); a whole-file analysis source rides the existing
-generic path (zero new code); then `--plan` → one live preflight → one DTN stage → add a source-matrix row
-(the `tests/test_source_matrix.py` guard enforces it).
+Optional brc-tools fast-follow (only if `brc-wrf` wants finer LBCs): grid-4 ships
+`_003`/`_006` offsets, so 3-hourly boundaries (`interval_seconds=10800`) are
+available from the 12Z+18Z cycles with a small stager change (forecast-offset
+enumeration; the analysis filename template currently hardcodes `_000`).
 
 Read for full context:
-- `docs/WRF-INPUT-STAGING.md` — NAM-only end-to-end proof detail.
-- `docs/nwp/NWP-SOURCE-MATRIX.md` — per-source Herbie-vs-direct decisions + Herbie currency.
-- `../brc-wrf/brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md` — RAP Vtable candidates + field gaps.
-- `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md` — brc-wrf's side of the seam.
-- Caretaker: when a brc-tools path moves, re-check that `../brc-tools`↔`../brc-wrf` doc links still resolve
-  (a manual pass — keep it true). brc-wrf consumes the **contract sidecar**, not `staged_files`.
+- `docs/WRF-INPUT-STAGING.md` - NAM-only end-to-end proof detail.
+- `docs/nwp/NWP-SOURCE-MATRIX.md` - per-source Herbie-vs-direct decisions and
+  Herbie currency.
+- `../brc-wrf/brc-docs/BRC-WRF-PELICAN-NWP-HOTSWAP-HANDOFF.md` - active
+  cross-repo handoff and paste prompts.
+- `../brc-wrf/brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md` - RAP Vtable
+  candidates and field gaps, only if RAP is explicitly revived.
+- Caretaker: when a brc-tools path moves, re-check that
+  `../brc-tools` <-> `../brc-wrf` doc links still resolve. `brc-wrf` consumes
+  the contract sidecar, not `staged_files`.
 
-brc-wrf session paste-prompt (start a Claude Code session in `~/gits/brc-wrf`):
-- **Read:** `brc-docs/BRC-WRF-STATE-PLAYBOOK.md`, `brc-docs/BRC-WRF-PELICAN-RAP-FEASIBILITY.md`, `../brc-tools/docs/WRF-INPUT-STAGING.md`.
-- **Login-safe:** `git status --short`; `python brc-cases/wrf_case.py validate <case>.yaml`.
-- **Off-login (approved compute/DTN):** `python ../brc-tools/scripts/stage_wrf_inputs.py --verify-manifest /scratch/general/vast/$USER/wrf_inputs/pelican2013_rap_3_1_333m_75lev/manifest_pelican2013_rap_3_1_333m_75lev.json`; point the case `contract_path` at the RAP `contract_*.json`; then `wrf_case.py validate <case>.yaml --strict-files`.
-- **Stop points:** no `sbatch`/WPS/`real.exe`/`wrf.exe` without explicit human approval; absolute `/scratch` paths are CHPC-local — never hand one to another machine.
+Stop points (still `brc-wrf`/human-owned): WPS, `real.exe`, `wrf.exe`, `sbatch`,
+NetCDF-heavy reads, archive inventories, and quicklooks. brc-tools staging for the
+GFS hot-swap is done (John-authorized 2026-06-30); any *further new-source*
+downloads/staging still warrant a heads-up first.
 
 Remaining brc-tools backlog (not blocking brc-wrf): `WISHLIST-TASKS.md` → "Session closeout" section.
 
 ## One-Sentence State
 
-`brc-tools` can stage WRF-ready GRIB inputs for the Jan-2013 Basin case, verify
-their integrity, and hand `brc-wrf` a manifest/contract boundary; the NAM-only
-single-stream path is proven through WPS, `real.exe`, and `wrf.exe`.
+`brc-tools` can stage WRF-ready GRIB inputs (NAM, RAP, and now GFS analysis; GEFS
+reforecast partial), verify their integrity, and hand `brc-wrf` a manifest/contract
+boundary; the NAM-only single-stream path is proven through WPS, `real.exe`, and
+`wrf.exe`, and GFS analysis is staged + verified for the same Pelican window,
+awaiting `brc-wrf` WPS.
 
 ## What This Repo Owns
 
@@ -70,6 +101,7 @@ Those belong in `brc-wrf`, using CHPC settings from `brc-knowledge`.
 | Item | Status |
 | --- | --- |
 | NAM analysis staging | Proven and used in the successful Jan-2013 WRF proof. |
+| GFS analysis staging | Supported (`gfs_analysis`) + staged + `verify_manifest` 2/2 OK for `pelican2013_gfs_3_1_333m_75lev` (12Z+18Z); field-complete per the `.inv`; WPS/run is `brc-wrf`'s to prove. |
 | Manifest verification | Proven: the existing proof manifest verifies `28/28 OK`. |
 | Contract sidecar | Implemented for fresh stages; old proof scratch predates this sidecar. |
 | Lead-time subsetting | Implemented for GEFS reforecast to reduce unnecessary download volume. |
@@ -92,8 +124,8 @@ Those belong in `brc-wrf`, using CHPC settings from `brc-knowledge`.
 | --- | --- | --- |
 | 1 | ✅ Done — `feat/wrf-input-staging` merged to `main` (PR #22 NAM-only, PR #23 hygiene batch). | `main` now contains the proven staging boundary. |
 | 2 | Keep NAM-only as the baseline proof. | Do not rename it as GEFS+NAM. |
-| 3 | Decide whether GEFS+NAM is needed for the next science question. | If yes, design the WPS two-stream proof with `brc-wrf`; if no, improve NAM repeatability. |
-| 4 | If GEFS+NAM is pursued, run a no-download design pass first. | Confirm Vtable, source split, and expected missing fields before WPS. |
+| 3 | ✅ Done — `gfs_analysis` source support added; GFS grid-4 staged + verified for `pelican2013_gfs_3_1_333m_75lev` (branch `nwp/gfs-analysis-source`). | Contract handed to `brc-wrf` via `BRC-TOOLS-LINK-HANDOFF.md`. |
+| 4 | `brc-wrf`: run WPS `Vtable.GFS` → metgrid → `real.exe` → `wrf.exe`; confirm `NUM_METGRID_SOIL_LEVELS > 0`. | brc-tools side complete; WPS/run stays in `brc-wrf`. |
 | 5 | Keep every full-stage or full-run step behind CHPC ownership boundaries. | DTN for downloads, `brc-wrf` for WPS/WRF, `brc-knowledge` for Slurm truth. |
 
 ## Reading Packet
@@ -102,7 +134,7 @@ Read these with the matching `brc-wrf` packet:
 
 1. `docs/WRF-INPUT-STAGING.md`
 2. `docs/WRF-STAGING-STATE-PLAYBOOK.md`
-3. `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`
+3. `../brc-wrf/brc-docs/BRC-WRF-PELICAN-NWP-HOTSWAP-HANDOFF.md`
 4. `../brc-wrf/brc-docs/BRC-WRF-STATE-PLAYBOOK.md`
 5. `../brc-wrf/brc-docs/BRC-WRF-FIRST-CASE.md`
 6. `../brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md` sections 1-3 and Q1

--- a/docs/nwp/NWP-SOURCE-MATRIX.md
+++ b/docs/nwp/NWP-SOURCE-MATRIX.md
@@ -6,7 +6,17 @@ recurring "are we reinventing the wheel?" question. Machine-readable companion:
 `brc_tools/nwp/lookups.toml` (the model registry); staging detail in
 `docs/WRF-INPUT-STAGING.md`.
 
-Herbie version evaluated: **2025.11.3** (env `clyfar-nov2025`).
+Herbie version evaluated for current WRF-staging work: **2026.3.0** (env
+`brc-tools-2026`). Do not run this lane from an inherited shell env; force:
+
+```bash
+conda run -n brc-tools-2026 python ...
+conda run -n brc-tools-2026 pytest ...
+```
+
+Earlier RAP wheel checks used `clyfar-nov2025` / Herbie **2025.11.3**; keep
+those results as historical evidence only unless they are refreshed under
+`brc-tools-2026`.
 
 ## Matrix
 
@@ -18,6 +28,8 @@ Herbie version evaluated: **2025.11.3** (env `clyfar-nov2025`).
 | `gefs_reforecast` | WRF forcing (historical ens) | `wrf_staging.stage_reforecast()` | **Herbie** `Herbie.download()`, `model="gefs_reforecast"` | ✅ yes | per-variable file layout; 700 hPa pressure split (`_pres` / `_pres_abv700mb`); specific humidity only; 10 m winds = `ugrd_hgt`; **no land-sea mask, no snow**; members c00/p01–p04; `Days:1-10`/`10-16` buckets |
 | `nam_analysis` | WRF forcing/filler (2013) | `wrf_staging.stage_nam_analysis()` | **Direct NCEI HTTP GET** (`requests`) | ❌ **no** | Herbie `nam` has only `aws`/`nomads` (operational, recent) — no NCEI-historical `namanl_218`. grib1 `.grb`; 6-hourly; whole file; carries land-mask/SST/skin/4-layer soil/snow |
 | `rap_analysis` | WRF forcing (Pelican hot-swap) | `wrf_staging.stage_rap_analysis()` → shared `stage_nam_analysis` | **Direct NCEI HTTP GET** (`requests`) | ⚠️ **intended but broken upstream** (see below) | grib2 `.grb2`; hourly; whole file; ~12 MB/cycle |
+| `era5` | WRF forcing candidate | _not implemented_ | Would require CDS/Copernicus tooling or another reviewed source path | n/a locally | Blocked locally: no `era5` model in `lookups.toml`, no `cdsapi`/`ecmwfapi` in `brc-tools-2026`, and no CDS credentials configured; WPS-side `Vtable.ECMWF` exists in brc-wrf |
+| `gfs_analysis` | WRF forcing (Pelican hot-swap, 2nd source) | `wrf_staging.stage_gfs_analysis()` → shared `stage_nam_analysis` | **Direct NCEI HTTP GET** (`requests`) | ❌ **no** | Herbie `gfs` has only `aws`/`nomads` (operational, recent) — no NCEI-historical `gfsanl_4`. grib2 `.grb2`; grid-004 0.5°; 6-hourly `_000` (grid-4 also ships `_003`/`_006` → optional 3-hourly LBCs); whole file ~52 MB/cycle; **field-complete for `real.exe`** (4-layer soil T/moisture, land-sea mask, skin temp, snow/ice, 26-level HGT/TMP/RH/UGRD/VGRD — confirmed from the live `.inv` 2026-06-30; the layered soil + real-ready 3D atmosphere RAP lacked); `Vtable.GFS`, humidity = RH; only gap vs NAM is `snod` (snow depth). NCEI product: https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast |
 | _Synoptic obs_ | observations | `ObsSource` | SynopticPy (obs ≠ NWP) | n/a | UTC-strip, alias rename, waypoint injection |
 | _FlightAware_ | aviation | `brc_tools/api/flightaware` | AeroAPI client | n/a | paid API |
 
@@ -48,15 +60,19 @@ all 7 cycles 12–18Z → HTTP 200, ~12 MB; bogus cycle → 404.)
 
 ## Why the analysis sources use direct GET (not Herbie)
 
-Beyond the bug, `nam_analysis` + `rap_analysis` deliberately share one **whole-file analysis** path
-(`stage_nam_analysis`, source-generic) because:
+Beyond the bug, `nam_analysis`, `rap_analysis`, and `gfs_analysis` deliberately share one
+**whole-file analysis** path (`stage_nam_analysis`, source-generic) because:
 - **One path, one set of guarantees:** per-cycle locking, `BRC_TOOLS_HTTP_IPV4_ONLY` (NCEI IPv6-hang
-  workaround), GRIB validation, manifest/contract — identical for NAM and RAP.
+  workaround), GRIB validation, manifest/contract — identical for NAM, RAP, and GFS.
 - **Offline `--plan` is deterministic:** URLs/paths are templated from `lookups.toml`; no Herbie
   inventory probing.
 - **No byte-range/`.idx` machinery:** WPS wants whole analysis files; we never subset.
-- Herbie genuinely lacks NAM-NCEI-historical, so NAM had to be direct anyway; RAP rides the same path
-  for uniformity.
+- Herbie genuinely lacks NAM-NCEI-historical, so NAM had to be direct anyway; RAP and GFS ride the same
+  path for uniformity.
+- **GFS analysis chosen over NCAR-RDA FNL (`ds083.2`):** the auth-free NCEI archive needs no RDA
+  account/`cdsapi`, and grid-004 (0.5°) is *finer* than 2013 FNL (1°). Field adequacy and `Vtable.GFS`
+  were confirmed from the live `.inv` (no GRIB body downloaded) — it carries the 4-layer soil + full 3D
+  atmosphere RAP lacked, so it should clear the `NUM_METGRID_SOIL_LEVELS=0` block that stopped RAP.
 
 ## Wheel check / recommendations
 
@@ -68,11 +84,12 @@ Beyond the bug, `nam_analysis` + `rap_analysis` deliberately share one **whole-f
   2. **File an upstream Herbie issue** for the `'.grb.inv'` typo (cheap; helps everyone).
   3. Revisit a Herbie-backed RAP path once fixed (would gain RUC2 pre-2012 fallback for free).
 
-## Herbie currency (checked 2026-06-29)
+## Herbie currency (checked 2026-06-30)
 
 | | Version | When |
 |---|---|---|
-| Installed (`clyfar-nov2025`) | **2025.11.3** | Nov 2025 |
+| Required WRF-staging env (`brc-tools-2026`) | **2026.3.0** | Mar 2026 |
+| Inherited env observed in Codex (`clyfar-nov2025`) | **2025.11.3** | Nov 2025 |
 | Latest (conda-forge + PyPI) | **2026.3.0** | Mar 2026 |
 
 What updating `2025.11.3 → 2026.3.0` would buy:
@@ -84,9 +101,9 @@ What updating `2025.11.3 → 2026.3.0` would buy:
 - **Does NOT fix** the `rap_historical` `IDX_SUFFIX` typo — still `"grb.inv"` on the default branch at
   2026.3.0, so a Herbie-backed RAP path stays blocked regardless.
 
-**Recommendation:** update Herbie (ideally in a fresh, lean `brc-tools` env, not the shared
-`clyfar-nov2025`) pinned to `herbie-data>=2026.3.0`; afterward re-run the RRFS path and the RAP probe
-below. File an upstream issue for the `rap_historical` typo. Env recipe → `docs/ENVIRONMENT-SETUP.md`.
+**Recommendation:** use `brc-tools-2026` for all WRF-staging work. File an upstream issue
+for the `rap_historical` typo if RAP Herbie support matters later. Env recipe →
+`docs/ENVIRONMENT-SETUP.md`.
 
 ## Enforcement
 

--- a/docs/walkthroughs/wrf-staging.md
+++ b/docs/walkthroughs/wrf-staging.md
@@ -5,17 +5,18 @@ scratch with provenance sidecars. This is **only the input-prep half**. brc-tool
 stops once the files + sidecars exist; running the model is the `brc-wrf` repo's
 job.
 
-> **State:** NAM-only single-stream is proven end-to-end. GEFS+NAM two-stream is
-> **not** proven — see [../WRF-GEFS-NAM-FIELD-MAP.md](../WRF-GEFS-NAM-FIELD-MAP.md).
+> **State:** NAM-only single-stream is proven end-to-end. GFS 0.5° analysis is a
+> second forcing, **staged + verified** for the Pelican case (awaiting brc-wrf WPS).
+> GEFS+NAM two-stream is **not** proven — see [../WRF-GEFS-NAM-FIELD-MAP.md](../WRF-GEFS-NAM-FIELD-MAP.md).
 
-**Needs:** DTN access for real downloads · conda env `brc-tools`
+**Needs:** DTN access for real downloads · conda env `brc-tools-2026`
 
 ## Look before you download (cheap, no network)
 
 `--plan` lists the files, URLs, and total bytes, then exits:
 
 ```bash
-python scripts/stage_wrf_inputs.py --plan \
+conda run -n brc-tools-2026 python -m brc_tools.nwp.wrf_staging --plan \
     --case jan2013_basin_gefs --init-time "2013-01-31 12Z" --source nam_analysis
 ```
 
@@ -30,7 +31,7 @@ sbatch scripts/stage_inputs.dtn.slurm        # brc-tools' own staging job
 ## Check what was staged
 
 ```bash
-python scripts/stage_wrf_inputs.py --verify-manifest \
+conda run -n brc-tools-2026 python -m brc_tools.nwp.wrf_staging --verify-manifest \
     /scratch/general/vast/$USER/wrf_inputs/jan2013_basin_gefs/manifest_jan2013_basin_gefs.json
 ```
 

--- a/tests/test_wrf_staging.py
+++ b/tests/test_wrf_staging.py
@@ -32,6 +32,7 @@ from brc_tools.nwp.wrf_staging import (
     build_contract,
     build_manifest,
     plan_case,
+    stage_gfs_analysis,
     stage_nam_analysis,
     stage_rap_analysis,
     stage_reforecast,
@@ -464,6 +465,31 @@ def test_stage_rap_analysis_layout_and_manifest(tmp_path, fake_nam_http):
     assert len(fake_nam_http.urls) == 7  # one whole-file GET per cycle
 
 
+def test_stage_gfs_analysis_layout_and_manifest(tmp_path, fake_nam_http):
+    # GFS analysis rides the shared whole-file analysis stager (mocked HTTP) at
+    # 6-hourly cadence -> 12Z + 18Z bracket the Pelican 2013-02-02 12-18Z window.
+    staged = stage_gfs_analysis(
+        init_time="2013-02-02 12Z",
+        fxx_window=(0, 6),
+        output_root=tmp_path,
+        case="pelican2013_gfs",
+    )
+    assert len(staged) == 2  # one whole file per 6-hourly analysis cycle (12Z, 18Z)
+    for sf in staged:
+        dest = Path(sf.local_path)
+        assert dest.exists() and validate_cached_grib(dest)
+        assert dest.parent == tmp_path / "pelican2013_gfs" / "gfs_analysis"  # no member dir
+        assert dest.name.startswith("gfsanl_4_") and dest.name.endswith("_000.grb2")
+        assert sf.source == "gfs_analysis" and sf.member == "" and sf.member_int == 0
+        assert sf.variable_level == "all" and sf.lead_times == [0]
+        assert sf.product == "gfsanl_4"
+        assert sf.remote_url.startswith("https://www.ncei.noaa.gov/")
+    assert {Path(sf.local_path).name for sf in staged} == {
+        "gfsanl_4_20130202_1200_000.grb2", "gfsanl_4_20130202_1800_000.grb2",
+    }
+    assert len(fake_nam_http.urls) == 2  # one whole-file GET per cycle
+
+
 # ── manifest ─────────────────────────────────────────────────────────────────
 
 
@@ -756,6 +782,7 @@ def test_interval_hours_for_sources():
     assert _interval_hours_for_sources(("gefs_reforecast",), lu) == 3
     assert _interval_hours_for_sources(("gefs_reforecast", "nam_analysis"), lu) == 3
     assert _interval_hours_for_sources(("rap_analysis",), lu) == 1  # hourly RAP analysis
+    assert _interval_hours_for_sources(("gfs_analysis",), lu) == 6  # 6-hourly GFS analysis
 
 
 def test_build_contract_nam_only():
@@ -797,6 +824,20 @@ def test_build_contract_rap_only():
     assert c["interval_seconds"] == 3600 and c["interval_hours"] == 1
     assert c["cadence_hours"]["rap_analysis"] == 1
     assert c["source_file_counts"] == {"rap_analysis": 1}
+
+
+def test_build_contract_gfs_only():
+    m = build_manifest(
+        case="pelican2013_gfs", region="uinta_basin_wide",
+        requested_window=("2013-02-02T12:00:00Z", "2013-02-02T18:00:00Z"),
+        interval_hours=6, sources=["gfs_analysis"],
+        staged=[_nam_staged_stub("gfs_analysis")],
+    )
+    c = build_contract(m)
+    assert c["wps_fg_name"] == ["GFS"]  # metadata-driven (Vtable.GFS), not mis-stamped
+    assert c["interval_seconds"] == 21600 and c["interval_hours"] == 6
+    assert c["cadence_hours"]["gfs_analysis"] == 6
+    assert c["source_file_counts"] == {"gfs_analysis": 1}
 
 
 def test_stage_case_writes_contract_and_derived_interval(tmp_path, fake_nam_http):


### PR DESCRIPTION
Adds `gfs_analysis` — auth-free **NCEI GFS grid-4 (0.5° GRIB2)** as a second, independent IC/LBC source for the Pelican WRF case (poor-man's ensemble beside the proven NAM baseline). RAP was blocked before `real.exe` (no layered soil); ERA5 is blocked locally (no CDS). GFS clears both failure modes — the live `.inv` confirms 4-layer soil T/moisture, land mask, skin temp, snow/ice, and a 26-level atmosphere.

## What's here
- `[models.gfs_analysis]` + `stage_gfs_analysis()` — auto-routes through the existing direct-GET `stage_nam_analysis` lane (no new routing code).
- Source-matrix row + staging/contract tests (full suite: **110 passed, 2 skipped**).
- Staged + `verify_manifest` **2/2 OK** to `pelican2013_gfs_3_1_333m_75lev` (12Z+18Z, `wps_fg_name=["GFS"]`, `interval_seconds=21600` — structural mirror of the NAM baseline).

## brc-wrf next (its lane)
Ungrib `Vtable.GFS` → metgrid → `real.exe` → `wrf.exe`; watch `NUM_METGRID_SOIL_LEVELS > 0`. Handoff packet: `../brc-wrf/brc-docs/BRC-TOOLS-LINK-HANDOFF.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)