### PR TITLE
docs: freshen CLAUDE.md + plain-language README for junior devs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ brc_tools/        installable package
   nwp/            NWPSource (Herbie), lookups.toml, derived, alignment, case_study, wrf_staging (WRF/WPS GRIB)
   obs/            ObsSource (SynopticPy wrapper), scanner (event detection)
   verify/         deterministic metrics (paired_scores, RMSE/bias/MAE)
-  visualize/      planview maps, timeseries panels, grid.py (reusable field/section plots; consumed by brc-wrf); figure-engine render modules (surface/crosssection/upperair/profile/domains/basemap/style)
+  visualize/      planview + timeseries panels; grid.py (field/section plots — brc-wrf seam); figure-engine modules (surface/section/upperair/profile/domains/basemap/style)
   download/       Synoptic obs script, push_data uploader, HRRR helpers
   api/            external API clients: FlightAware, FR24, Perplexity, Mistral (shared _auth); soundings (IGRA2/Wyoming RAOB, auth-free)
   utils/          lookups, small helpers
@@ -97,7 +97,7 @@ pytest tests/
 ```
 Use a conda env with the deps (herbie, polars, pandas, matplotlib, cfgrib, requests).
 Preferred: the dedicated **`brc-tools-2026`** env (`mamba env create -f environment.yml`;
-herbie 2026.3.0 — validated, 110 passed); the shared `clyfar-nov2025` also works. Fresh
+herbie 2026.3.0 — validated, 174 passed / 2 skipped); the shared `clyfar-nov2025` also works. Fresh
 setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
 
 ## Related repos

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### `brc-tools` - Bingham Research Center (python) Tools
+# `brc-tools` — Bingham Research Center Python tools
 
 > AI agents: see [`CLAUDE.md`](CLAUDE.md) for project context.
 > Documentation index: [`docs/`](docs/). Current focus: HRRR/RRFS ingest in [`docs/nwp/`](docs/nwp/).
@@ -8,6 +8,11 @@ Shared Python utilities for atmospheric data operations at the Bingham
 Research Center. Pulls weather observations (SynopticPy) and NWP model
 data (Herbie/HRRR) and pushes JSON to the [BasinWX](https://www.basinwx.com)
 website.
+
+**Mental model (new here?):** fetch weather data (station observations + model
+forecasts) → tidy it into a common shape → ship small JSON files to the website that
+draws the Uinta Basin's air-quality dashboards. Almost everything in the package hangs
+off that one flow. Not a meteorologist? Start with [`docs/walkthroughs/`](docs/walkthroughs/).
 
 Package name: `brc_tools` (underscore). Repo name: `brc-tools` (hyphen).
 
@@ -51,6 +56,8 @@ Repo-local skills (slash commands) live in `.claude/skills/`:
   live in the study repo, e.g. `../wrf-nudge-ozone-air2026/cases/pelican2013.toml`).
 
 ## CHPC Deployment
+
+*Operations reference — a junior dev can skip this on day one and come back when you actually deploy.*
 
 This package is deployed on CHPC to push weather data to BasinWX.
 


### PR DESCRIPTION
## Summary
Small, surgical docs pass — no load-bearing pointers removed (both files were already lean; cutting context would hurt AI devs more than help).

**CLAUDE.md (AI-dev context):**
- Fix stale test count: `110 passed` → `174 passed / 2 skipped` (current `brc-tools-2026` result).
- Tighten the `visualize/` repo-map line.

**README.md (plain language for junior devs):**
- `h3` → `h1` title.
- Add a plain-language **"Mental model (new here?)"** — fetch obs + forecasts → tidy → ship JSON to the website; with a not-a-meteorologist pointer to `docs/walkthroughs/`.
- Signpost `## CHPC Deployment` as ops reference a junior can skip on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113AAeE9jtsfYgv7TLp6Dtr
