### PR TITLE
wrf-figures: X8 deficit-transport diagnostics + budget/provenance fixes

### DIFF
--- a/brc_tools/nwp/wrf_figures.py
+++ b/brc_tools/nwp/wrf_figures.py
@@ -26,6 +26,7 @@ dataset-agnostic and are reused unchanged; nothing here touches the brc-wrf-faci
 
 from __future__ import annotations
 
+import csv
 import os
 import re
 from dataclasses import dataclass, field
@@ -40,6 +41,8 @@ from brc_tools.visualize.crosssection import (
     plot_wrf_section_difference,
 )
 from brc_tools.visualize.deficitflux import (
+    plot_deficit_budget,
+    plot_deficit_bulk_diagnostics,
     plot_deficitflux_divergence,
     plot_deficitflux_map,
 )
@@ -70,6 +73,7 @@ FAMILIES = [
     "domains", "section", "upperair", "surface",
     "difference", "profile", "skewt", "thetaz", "heatdeficit", "heatdeficit_map",
     "deficitflux_map", "deficitflux_div", "deficitflux_transect",
+    "deficitbulk_map", "deficit_budget",
 ]
 
 # Vertical extent for the theta(z) profile plot (m MSL); a generic default.
@@ -190,6 +194,10 @@ class CaseConfig:
     heatdeficit_domain: str = "inner"     # nest for the heatdeficit_map field: "inner"|"outer"|"dNN"
     deficitflux_domain: str = "inner"     # nest for the deficitflux families: "inner"|"outer"|"dNN"
     deficitflux_smooth_km: float = 1.0    # display smoothing scale for -div(F), km (0 = raw)
+    deficit_active_min_k: float = 0.25    # minimum deficit defining the diagnosed active layer
+    deficit_min_heat_mj_m2: float = 0.1   # H threshold for F/H and bulk diagnostics
+    deficit_budget_margin_cells: int = 0  # symmetric edge crop for area-mean storage/convergence
+    deficit_spinup_hours: float = 0.0     # shaded context interval from the first valid time
     transects: list[TransectSpec] = field(default_factory=list)  # deficitflux_transect lines
     # Nests that ALSO get free-standing single-domain surface figures (the multidomain
     # panel squeezes 4 nests into one row, so an innermost-only version reads better
@@ -278,6 +286,10 @@ class CaseConfig:
             heatdeficit_domain=str(case.get("heatdeficit_domain", "inner")),
             deficitflux_domain=str(case.get("deficitflux_domain", "inner")),
             deficitflux_smooth_km=float(case.get("deficitflux_smooth_km", 1.0)),
+            deficit_active_min_k=float(case.get("deficit_active_min_k", 0.25)),
+            deficit_min_heat_mj_m2=float(case.get("deficit_min_heat_mj_m2", 0.1)),
+            deficit_budget_margin_cells=int(case.get("deficit_budget_margin_cells", 0)),
+            deficit_spinup_hours=float(case.get("deficit_spinup_hours", 0.0)),
             transects=transects,
             surface_single_domains=tuple(str(s) for s in case.get("surface_single_domains", [])),
             map_overlays=map_overlays,
@@ -336,6 +348,22 @@ def _slug(text: str) -> str:
 
 def _focus_slug(cfg: CaseConfig) -> str:
     return _slug(cfg.focus_point.name) or "focus"
+
+
+def _valid_tag(valid: datetime) -> str:
+    """Collision-safe compact valid-time tag, preserving legacy hourly names."""
+    if valid.second:
+        return valid.strftime("%H%M%Sz")
+    if valid.minute:
+        return valid.strftime("%H%Mz")
+    return valid.strftime("%Hz")
+
+
+def _valid_label(valid: datetime, *, include_date: bool = False) -> str:
+    """Human-readable valid time with minute/second precision only when needed."""
+    clock = "%H:%M:%S" if valid.second else ("%H:%M" if valid.minute else "%H")
+    prefix = "%Y-%m-%d " if include_date else ""
+    return valid.strftime(prefix + clock) + "Z"
 
 
 def _resolve_domain(spec: str, rep: PreflightReport) -> int | None:
@@ -415,8 +443,8 @@ def _skip_existing(out_png: Path, srcs: list[Path], enabled: bool) -> bool:
     True only when ``enabled`` and the figure already exists and is at least as new
     as every source wrfout it derives from (mtime).  A source rewritten by a later
     WRF run is thus newer than the figure, so the figure regenerates ("move to newer
-    output").  Keyed on the hour-only filename, so it is safe for hourly (or coarser)
-    output; sub-hourly cadence would collide (see docs/WRF-FIGURE-ENGINE.md).
+    output"). Per-valid-time callers use :func:`_valid_tag`, so sub-hourly products
+    remain distinct while historical hourly names are unchanged.
     """
     if not enabled or not out_png.exists():
         return False
@@ -464,7 +492,7 @@ def task_section(cfg, run, dom, case, label, valid, orient, out, skip_existing=F
     # ``domain_tag`` is "" for the default innermost nest (legacy filename) and "_dNN"
     # when --section-domain targets a coarser nest, so the override coexists with the
     # default set instead of clobbering it.
-    out_png = out / f"section_{orient.lower()}_{case}{domain_tag}_{valid:%H}z.png"
+    out_png = out / f"section_{orient.lower()}_{case}{domain_tag}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, dom, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -474,14 +502,14 @@ def task_section(cfg, run, dom, case, label, valid, orient, out, skip_existing=F
     plot_wrf_section(
         sec, out_png,
         locator_terrain=wo.surface_field(ds, "HGT"),
-        title=f"{label} | d{dom:02d} {orient} section | {valid:%Y-%m-%d %H}Z",
+        title=f"{label} | d{dom:02d} {orient} section | {_valid_label(valid, include_date=True)}",
         annotation=cfg.annotation, waypoints=cfg.waypoints,
     )
 
 
 def task_upperair(cfg, run, innermost, case, label, valid, out, skip_existing=False):
     crest = cfg.crest_m
-    out_png = out / f"crest{int(crest)}_{case}_{valid:%H}z.png"
+    out_png = out / f"crest{int(crest)}_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, innermost, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -505,7 +533,7 @@ def task_upperair(cfg, run, innermost, case, label, valid, out, skip_existing=Fa
         style=resolve_style("theta_crest", overrides=cfg.style.overrides,
                             autoscale=cfg.style.autoscale),
         waypoints=cfg.waypoints, overlays=cfg.map_overlays,
-        title=f"{label} | crest theta + wind + T-adv | {valid:%H}Z", annotation=cfg.annotation,
+        title=f"{label} | crest theta + wind + T-adv | {_valid_label(valid)}", annotation=cfg.annotation,
     )
 
 
@@ -518,7 +546,7 @@ def task_upperair_pressure(cfg, run, domain, case, label, valid, out, skip_exist
     the cold pool.
     """
     p_hpa = float(cfg.upper_pressure_hpa)
-    out_png = out / f"p{int(p_hpa)}_advection_{case}_{valid:%H}z.png"
+    out_png = out / f"p{int(p_hpa)}_advection_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, domain, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -546,13 +574,13 @@ def task_upperair_pressure(cfg, run, domain, case, label, valid, out, skip_exist
         style=resolve_style("temp_upper", overrides=cfg.style.overrides,
                             autoscale=cfg.style.autoscale),
         waypoints=cfg.waypoints, overlays=cfg.map_overlays,
-        title=f"{label} | d{domain:02d} {int(p_hpa)} hPa T + wind + T-adv | {valid:%H}Z",
+        title=f"{label} | d{domain:02d} {int(p_hpa)} hPa T + wind + T-adv | {_valid_label(valid)}",
         annotation=cfg.annotation,
     )
 
 
 def task_surface(cfg, run, domains, case, label, valid, sv, out, skip_existing=False):
-    out_png = out / f"{sv.key}_{case}_multidomain_{valid:%H}z.png"
+    out_png = out / f"{sv.key}_{case}_multidomain_{_valid_tag(valid)}.png"
     srcs = [wo.wrfout_path(run, dom, valid) for dom in domains]
     if _skip_existing(out_png, srcs, skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -577,13 +605,13 @@ def task_surface(cfg, run, domains, case, label, valid, sv, out, skip_existing=F
     plot_domain_panels(
         panels, out_png, style=style,
         wind=sv.wind, extent=extent, waypoints=cfg.waypoints, overlays=cfg.map_overlays,
-        suptitle=f"{label} | {sv.style} | d{innermost:02d} area | {valid:%H}Z",
+        suptitle=f"{label} | {sv.style} | d{innermost:02d} area | {_valid_label(valid)}",
     )
 
 
 def task_surface_single(cfg, run, dom, case, label, valid, sv, out, skip_existing=False):
     """Free-standing single-nest surface figure (companion to the multidomain panel)."""
-    out_png = out / f"{sv.key}_{case}_d{dom:02d}_{valid:%H}z.png"
+    out_png = out / f"{sv.key}_{case}_d{dom:02d}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, dom, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -601,13 +629,13 @@ def task_surface_single(cfg, run, dom, case, label, valid, sv, out, skip_existin
     plot_domain_panels(
         [panel], out_png, style=style,
         wind=sv.wind, waypoints=cfg.waypoints, overlays=cfg.map_overlays,
-        suptitle=f"{label} | {sv.style} | d{dom:02d} | {valid:%H}Z",
+        suptitle=f"{label} | {sv.style} | d{dom:02d} | {_valid_label(valid)}",
     )
 
 
 def task_diff_map(cfg, run_a, run_b, innermost, tag, valid, out, feedback, limit=None,
                   skip_existing=False):
-    out_png = out / f"theta2m_{tag}_{valid:%H}z.png"
+    out_png = out / f"theta2m_{tag}_{_valid_tag(valid)}.png"
     srcs = [wo.wrfout_path(run_a, innermost, valid), wo.wrfout_path(run_b, innermost, valid)]
     if _skip_existing(out_png, srcs, skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -619,14 +647,14 @@ def task_diff_map(cfg, run_a, run_b, innermost, tag, valid, out, feedback, limit
         wo.surface_field(da, "XLONG"), wo.surface_field(da, "XLAT"),
         wo.theta_2m(da), wo.theta_2m(db), out_png,
         var="theta", limit=lim,
-        title=f"{tag} | 2 m theta | d{innermost:02d} | {valid:%H}Z",
+        title=f"{tag} | 2 m theta | d{innermost:02d} | {_valid_label(valid)}",
         terrain=wo.surface_field(da, "HGT"), annotation=cfg.annotation,
     )
 
 
 def task_diff_section(cfg, run_a, run_b, innermost, tag, valid, orient, out, limit=None,
                       skip_existing=False):
-    out_png = out / f"section_{orient.lower()}_{tag}_{valid:%H}z.png"
+    out_png = out / f"section_{orient.lower()}_{tag}_{_valid_tag(valid)}.png"
     src_a = wo.wrfout_path(run_a, innermost, valid)
     src_b = wo.wrfout_path(run_b, innermost, valid)
     if _skip_existing(out_png, [src_a, src_b], skip_existing):
@@ -638,7 +666,7 @@ def task_diff_section(cfg, run_a, run_b, innermost, tag, valid, orient, out, lim
     plot_wrf_section_difference(
         sec_a, sec_b, out_png,
         var="theta", limit=limit,
-        title=f"{tag} | d{innermost:02d} {orient} theta | {valid:%H}Z",
+        title=f"{tag} | d{innermost:02d} {orient} theta | {_valid_label(valid)}",
         locator_terrain=wo.surface_field(db, "HGT"), annotation=cfg.annotation,
         waypoints=cfg.waypoints,
     )
@@ -668,7 +696,7 @@ def task_domains(cfg, run, domains, out, skip_existing=False):
 
 
 def task_profiles(cfg, case_runs, valid, out, skip_existing=False):
-    out_png = out / f"theta_profiles_{_focus_slug(cfg)}_{valid:%H}z.png"
+    out_png = out / f"theta_profiles_{_focus_slug(cfg)}_{_valid_tag(valid)}.png"
     srcs = [wo.wrfout_path(run, innermost, valid) for _case, _label, run, innermost in case_runs]
     if _skip_existing(out_png, srcs, skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -681,14 +709,14 @@ def task_profiles(cfg, case_runs, valid, out, skip_existing=False):
     plot_theta_profiles(
         cols, out_png,
         terrain_m=ref_terrain, crest_m=cfg.crest_m, y_max_m=_PROFILE_Y_MAX_M,
-        title=rf"$\theta(z)$ at {cfg.focus_point.name} | {valid:%Y-%m-%d %H}Z",
+        title=rf"$\theta(z)$ at {cfg.focus_point.name} | {_valid_label(valid, include_date=True)}",
         annotation=cfg.annotation,
     )
 
 
 def task_skewt(cfg, run, innermost, case, label, valid, out, skip_existing=False):
     """Focus-point (innermost) model skew-T -- the cold-pool structure (model-only)."""
-    out_png = out / f"skewt_{_focus_slug(cfg)}_{case}_{valid:%H}z.png"
+    out_png = out / f"skewt_{_focus_slug(cfg)}_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, innermost, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -700,7 +728,7 @@ def task_skewt(cfg, run, innermost, case, label, valid, out, skip_existing=False
     )
     plot_skewt(
         model, out_png,
-        title=f"{label} skew-T | {cfg.focus_point.name} (d{innermost:02d}) | {valid:%Y-%m-%d %H}Z",
+        title=f"{label} skew-T | {cfg.focus_point.name} (d{innermost:02d}) | {_valid_label(valid, include_date=True)}",
         annotation=cfg.annotation,
     )
 
@@ -711,7 +739,7 @@ def task_skewt_station(
     """Model outermost-domain column at a RAOB proxy site, overlaid on that sounding."""
     from brc_tools.api.soundings import STATIONS
 
-    out_png = out / f"skewt_{station_name}_{case}_{valid:%H}z.png"
+    out_png = out / f"skewt_{station_name}_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, outermost, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -725,7 +753,7 @@ def task_skewt_station(
     obs = CachedSounding(sounding_cache).get(station_name, valid) if sounding_cache else None
     plot_skewt(
         model, out_png, obs=obs,
-        title=f"{label} vs RAOB | {station_name} ({st.location}) d{outermost:02d} | {valid:%H}Z",
+        title=f"{label} vs RAOB | {station_name} ({st.location}) d{outermost:02d} | {_valid_label(valid)}",
         annotation=cfg.annotation,
     )
 
@@ -753,12 +781,12 @@ def task_thetaz_station(
     models = {}
     for t in model_valids:
         ds = wo.open_wrfout(wo.wrfout_path(run, outermost, t))
-        models[f"{t:%H}Z"] = sounding_from_column(
+        models[_valid_label(t)] = sounding_from_column(
             wo.extract_column(ds, st.lat, st.lon),
             source=label, station=station_name, valid_time=t,
         )
     obs = CachedSounding(sounding_cache).get(station_name, obs_valid) if sounding_cache else None
-    hours = ", ".join(f"{t:%H}Z" for t in model_valids)
+    hours = ", ".join(_valid_label(t) for t in model_valids)
     plot_theta_wind_profile(
         models, out_png, obs=obs, crest_m=cfg.crest_m,
         title=(f"{label} — θ(z) spin-up at {station_name} ({st.location}) d{outermost:02d}\n"
@@ -802,7 +830,7 @@ def task_heatdeficit(cfg, case_runs, out, skip_existing=False):
 
 def task_heatdeficit_map(cfg, run, dom, case, label, valid, out, skip_existing=False):
     """Per-case plan-view of the cold-pool heat-deficit field (MJ m-2) on nest ``dom``."""
-    out_png = out / f"heatdeficit_{case}_{valid:%H}z.png"
+    out_png = out / f"heatdeficit_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, dom, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -813,7 +841,7 @@ def task_heatdeficit_map(cfg, run, dom, case, label, valid, out, skip_existing=F
     plot_heatdeficit_field(
         wo.surface_field(ds, "XLONG"), wo.surface_field(ds, "XLAT"), field_mj, out_png,
         style=style, crest_terrain=wo.surface_field(ds, "HGT"), crest_m=cfg.crest_m,
-        title=f"{label} | cold-pool heat deficit | d{dom:02d} | {valid:%Y-%m-%d %H}Z",
+        title=f"{label} | cold-pool heat deficit | d{dom:02d} | {_valid_label(valid, include_date=True)}",
         annotation=cfg.annotation, waypoints=cfg.waypoints, overlays=cfg.map_overlays,
     )
 
@@ -821,7 +849,7 @@ def task_heatdeficit_map(cfg, run, dom, case, label, valid, out, skip_existing=F
 def task_heatdeficit_map_diff(cfg, run_a, run_b, dom, tag, valid, out, hd_limit=None,
                               skip_existing=False):
     """Paired heat-deficit difference map (case a minus case b, MJ m-2) on nest ``dom``."""
-    out_png = out / f"heatdeficit_{tag}_{valid:%H}z.png"
+    out_png = out / f"heatdeficit_{tag}_{_valid_tag(valid)}.png"
     srcs = [wo.wrfout_path(run_a, dom, valid), wo.wrfout_path(run_b, dom, valid)]
     if _skip_existing(out_png, srcs, skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -833,14 +861,14 @@ def task_heatdeficit_map_diff(cfg, run_a, run_b, dom, tag, valid, out, hd_limit=
     plot_heatdeficit_difference(
         wo.surface_field(da, "XLONG"), wo.surface_field(da, "XLAT"), fa, fb, out_png,
         limit=hd_limit, crest_terrain=wo.surface_field(da, "HGT"), crest_m=cfg.crest_m,
-        title=f"{tag} | Δ cold-pool heat deficit | d{dom:02d} | {valid:%H}Z",
+        title=f"{tag} | Δ cold-pool heat deficit | d{dom:02d} | {_valid_label(valid)}",
         annotation=cfg.annotation, waypoints=cfg.waypoints, overlays=cfg.map_overlays,
     )
 
 
 def task_deficitflux_map(cfg, run, dom, case, label, valid, out, skip_existing=False):
     """Deficit transport F (quivers) over the heat-deficit field on nest ``dom``."""
-    out_png = out / f"deficitflux_{case}_{valid:%H}z.png"
+    out_png = out / f"deficitflux_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, dom, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -852,15 +880,15 @@ def task_deficitflux_map(cfg, run, dom, case, label, valid, out, skip_existing=F
     plot_deficitflux_map(
         wo.surface_field(ds, "XLONG"), wo.surface_field(ds, "XLAT"), h_mj, fx, fy, out_png,
         style=style, crest_terrain=wo.surface_field(ds, "HGT"), crest_m=cfg.crest_m,
-        title=f"{label} | deficit transport F over H | d{dom:02d} | {valid:%Y-%m-%d %H}Z",
+        title=f"{label} | deficit transport F over H | d{dom:02d} | {_valid_label(valid, include_date=True)}",
         annotation=cfg.annotation, waypoints=cfg.waypoints, overlays=cfg.map_overlays,
         transects=cfg.transects,
     )
 
 
 def task_deficitflux_div(cfg, run, dom, case, label, valid, out, skip_existing=False):
-    """Advective heat-deficit tendency ``-div(F)`` (MJ m-2 h-1) on nest ``dom``."""
-    out_png = out / f"deficitflux_div_{case}_{valid:%H}z.png"
+    """Horizontal heat-deficit flux convergence ``-div(F)`` on nest ``dom``."""
+    out_png = out / f"deficitflux_div_{case}_{_valid_tag(valid)}.png"
     src = wo.wrfout_path(run, dom, valid)
     if _skip_existing(out_png, [src], skip_existing):
         print(f"  [skip] {out_png.name} up to date")
@@ -877,13 +905,155 @@ def task_deficitflux_div(cfg, run, dom, case, label, valid, out, skip_existing=F
         wo.surface_field(ds, "XLONG"), wo.surface_field(ds, "XLAT"), adv_mj_h, out_png,
         style=style, smooth_sigma=sigma,
         crest_terrain=wo.surface_field(ds, "HGT"), crest_m=cfg.crest_m,
-        title=f"{label} | advective dH/dt | d{dom:02d} | {valid:%Y-%m-%d %H}Z",
+        title=f"{label} | horizontal deficit-flux convergence | d{dom:02d} | {_valid_label(valid, include_date=True)}",
         annotation=cfg.annotation, waypoints=cfg.waypoints, overlays=cfg.map_overlays,
     )
 
 
+def task_deficitbulk_map(cfg, run, dom, case, label, valid, out, skip_existing=False):
+    """Exploratory layer depth, deficit-weighted speed, and bulk-Froude maps."""
+    out_png = out / f"deficitbulk_{case}_{_valid_tag(valid)}.png"
+    src = wo.wrfout_path(run, dom, valid)
+    if _skip_existing(out_png, [src], skip_existing):
+        print(f"  [skip] {out_png.name} up to date")
+        return
+    ds = wo.open_wrfout(src)
+    try:
+        bulk = wo.deficit_bulk_fields(
+            ds,
+            cfg.crest_m,
+            min_deficit_k=cfg.deficit_active_min_k,
+            min_heat_deficit_j_m2=cfg.deficit_min_heat_mj_m2 * 1e6,
+        )
+        styles = tuple(
+            resolve_style(key, overrides=cfg.style.overrides, autoscale=cfg.style.autoscale)
+            for key in ("deficit_depth", "deficit_speed", "deficit_froude")
+        )
+        plot_deficit_bulk_diagnostics(
+            wo.surface_field(ds, "XLONG"),
+            wo.surface_field(ds, "XLAT"),
+            bulk.depth_m,
+            np.hypot(bulk.velocity_x_m_s, bulk.velocity_y_m_s),
+            bulk.froude,
+            out_png,
+            styles=styles,
+            crest_terrain=wo.surface_field(ds, "HGT"),
+            crest_m=cfg.crest_m,
+            title=(f"{label} | exploratory deficit-layer diagnostics | d{dom:02d} | "
+                   f"{_valid_label(valid, include_date=True)}"),
+            annotation=(f"{cfg.annotation} | active deficit >= {cfg.deficit_active_min_k:g} K; "
+                        f"F/H masked below H={cfg.deficit_min_heat_mj_m2:g} MJ m-2"),
+            waypoints=cfg.waypoints,
+            overlays=cfg.map_overlays,
+        )
+    finally:
+        ds.close()
+
+
+def _area_weighted_interior_mean(field, area, margin_cells: int) -> float:
+    """Area-weighted finite mean after a symmetric grid-cell edge crop."""
+    field = np.asarray(field, dtype=float)
+    area = np.asarray(area, dtype=float)
+    margin = max(int(margin_cells), 0)
+    if margin and (2 * margin >= field.shape[0] or 2 * margin >= field.shape[1]):
+        raise ValueError(
+            f"deficit_budget_margin_cells={margin} removes the full {field.shape} grid"
+        )
+    view = (slice(margin, -margin), slice(margin, -margin)) if margin else (...,)
+    values = field[view]
+    weights = area[view]
+    finite = np.isfinite(values) & np.isfinite(weights) & (weights > 0.0)
+    if not finite.any():
+        return float("nan")
+    return float(np.average(values[finite], weights=weights[finite]))
+
+
+def task_deficit_budget(cfg, run, dom, case, label, out, skip_existing=False):
+    """Area-mean H storage, horizontal convergence, and unresolved tendency."""
+    out_png = out / f"deficit_budget_{case}.png"
+    out_csv = out / f"deficit_budget_{case}.csv"
+    times = wo.list_valid_times(run, dom)
+    srcs = [wo.wrfout_path(run, dom, valid) for valid in times]
+    if (_skip_existing(out_png, srcs, skip_existing)
+            and _skip_existing(out_csv, srcs, skip_existing)):
+        print(f"  [skip] {out_png.name} and {out_csv.name} up to date")
+        return
+    if len(times) < 2:
+        print(f"  [SKIP] {label}: deficit budget requires at least two valid times")
+        return
+
+    heat: list[float] = []
+    convergence: list[float] = []
+    for src in srcs:
+        ds = wo.open_wrfout(src)
+        try:
+            area = wo.grid_cell_area_m2(ds)
+            heat.append(
+                _area_weighted_interior_mean(
+                    wo.heat_deficit_field(ds, cfg.crest_m) / 1e6,
+                    area,
+                    cfg.deficit_budget_margin_cells,
+                )
+            )
+            convergence.append(
+                _area_weighted_interior_mean(
+                    -wo.deficit_flux_divergence(ds, cfg.crest_m) * 3600.0 / 1e6,
+                    area,
+                    cfg.deficit_budget_margin_cells,
+                )
+            )
+        finally:
+            ds.close()
+
+    heat_arr = np.asarray(heat, dtype=float)
+    convergence_arr = np.asarray(convergence, dtype=float)
+    dt_hours = np.asarray(
+        [(b - a).total_seconds() / 3600.0 for a, b in zip(times[:-1], times[1:])],
+        dtype=float,
+    )
+    interval_times = [a + (b - a) / 2 for a, b in zip(times[:-1], times[1:])]
+    storage = np.diff(heat_arr) / dt_hours
+    interval_convergence = 0.5 * (convergence_arr[:-1] + convergence_arr[1:])
+    unresolved = storage - interval_convergence
+
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_csv, "w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow([
+            "interval_start_utc", "interval_end_utc", "interval_midpoint_utc",
+            "heat_start_mj_m2", "heat_end_mj_m2", "storage_mj_m2_h",
+            "horizontal_convergence_mj_m2_h", "unresolved_mj_m2_h",
+            "edge_margin_cells",
+        ])
+        for i, midpoint in enumerate(interval_times):
+            writer.writerow([
+                times[i].isoformat(), times[i + 1].isoformat(), midpoint.isoformat(),
+                f"{heat_arr[i]:.9g}", f"{heat_arr[i + 1]:.9g}", f"{storage[i]:.9g}",
+                f"{interval_convergence[i]:.9g}", f"{unresolved[i]:.9g}",
+                cfg.deficit_budget_margin_cells,
+            ])
+
+    spinup_end = (
+        times[0] + timedelta(hours=cfg.deficit_spinup_hours)
+        if cfg.deficit_spinup_hours > 0.0 else None
+    )
+    plot_deficit_budget(
+        times,
+        heat_arr,
+        interval_times,
+        storage,
+        interval_convergence,
+        unresolved,
+        out_png,
+        title=(f"{label} | crest-referenced heat-deficit tendency diagnostic | d{dom:02d}"),
+        spinup_end=spinup_end,
+        annotation=(f"{cfg.annotation} | {cfg.deficit_budget_margin_cells}-cell edge crop; "
+                    "unresolved = storage - horizontal convergence"),
+    )
+
+
 def task_deficitflux_transect(cfg, dfx_runs, tr, out, skip_existing=False):
-    """Deficit export Phi(t) through one configured transect, a line per case (GW)."""
+    """Deficit transport Phi(t) through one configured transect, a line per case (GW)."""
     out_png = out / f"deficitflux_transect_{tr.name}.png"
     times_by_case = {
         label: wo.list_valid_times(run, dom) for _case, label, run, dom in dfx_runs
@@ -919,9 +1089,9 @@ def task_deficitflux_transect(cfg, dfx_runs, tr, out, skip_existing=False):
         return
     plot_scalar_timeseries(
         series, out_png,
-        ylabel=r"deficit export $\Phi$ (GW)",
-        title=(f"Cold-pool deficit export — {tr.label} (crest {int(cfg.crest_m)} m)\n"
-               "positive = export to the right of A$\\rightarrow$B"),
+        ylabel=r"deficit transport $\Phi$ (GW)",
+        title=(f"Crest-referenced deficit transport — {tr.label} (crest {int(cfg.crest_m)} m)\n"
+               "positive = transport to the right of A$\\rightarrow$B"),
     )
 
 
@@ -1129,7 +1299,9 @@ def build_tasks(cfg: CaseConfig, selection: Selection) -> list[tuple]:
         hd_dom = _resolve_domain(cfg.heatdeficit_domain, rep) if "heatdeficit_map" in fams else None
         if "heatdeficit_map" in fams and hd_dom is None:
             print(f"  [SKIP] {case}: heatdeficit_map — domain {cfg.heatdeficit_domain} not present")
-        dfx_fams = {"deficitflux_map", "deficitflux_div"} & set(fams)
+        dfx_fams = {
+            "deficitflux_map", "deficitflux_div", "deficitbulk_map", "deficit_budget"
+        } & set(fams)
         dfx_dom = _resolve_domain(cfg.deficitflux_domain, rep) if dfx_fams else None
         if dfx_fams and dfx_dom is None:
             print(f"  [SKIP] {case}: deficitflux — domain {cfg.deficitflux_domain} not present")
@@ -1141,6 +1313,10 @@ def build_tasks(cfg: CaseConfig, selection: Selection) -> list[tuple]:
                     print(f"  [SKIP] {case}: surface single-domain {spec} not present")
                 elif d not in ss_doms:
                     ss_doms.append(d)
+        if "deficit_budget" in fams and dfx_dom is not None:
+            tasks.append((f"{label} deficit budget", task_deficit_budget,
+                          (cfg, run, dfx_dom, case, label,
+                           out_dir(cfg, selection, "deficit_budget", case), skip)))
         for t in sel_times:
             if "section" in fams and sec_dom is not None:
                 for orient in ("EW", "NS"):
@@ -1178,6 +1354,10 @@ def build_tasks(cfg: CaseConfig, selection: Selection) -> list[tuple]:
                 tasks.append((f"{label} deficit flux div {t:%H}Z", task_deficitflux_div,
                               (cfg, run, dfx_dom, case, label, t,
                                out_dir(cfg, selection, "deficitflux_div", case), skip)))
+            if "deficitbulk_map" in fams and dfx_dom is not None:
+                tasks.append((f"{label} deficit bulk {_valid_label(t)}", task_deficitbulk_map,
+                              (cfg, run, dfx_dom, case, label, t,
+                               out_dir(cfg, selection, "deficitbulk_map", case), skip)))
             if "skewt" in fams and rep.point_ok:
                 tasks.append((f"{label} skewt {cfg.focus_point.name} {t:%H}Z", task_skewt,
                               (cfg, run, innermost, case, label, t,

--- a/brc_tools/nwp/wrf_output.py
+++ b/brc_tools/nwp/wrf_output.py
@@ -707,7 +707,7 @@ def deficit_bulk_fields(
 
 @dataclass
 class TransectFlux:
-    """Deficit transport through a vertical plane along a lat/lon line (canyon export)."""
+    """Signed horizontal transport through a vertical plane along a lat/lon line."""
 
     lats: np.ndarray  # (n,) sample latitudes along a->b
     lons: np.ndarray  # (n,) sample longitudes
@@ -720,9 +720,10 @@ class TransectFlux:
     label: str = ""
 
 
-def transect_deficit_flux(
+def integrate_flux_transect(
     ds,
-    crest_m: float,
+    flux_x_w_m: np.ndarray,
+    flux_y_w_m: np.ndarray,
     lat_a: float,
     lon_a: float,
     lat_b: float,
@@ -731,13 +732,13 @@ def transect_deficit_flux(
     spacing_m: float | None = None,
     label: str = "",
 ) -> TransectFlux:
-    """Deficit transport through the vertical plane over the a->b line (W).
+    """Integrate an earth-relative horizontal flux field across an a->b line.
 
-    Samples earth-relative ``F`` at the nearest column every ``spacing_m`` (default:
-    grid ``min(dx, dy)``) and integrates the normal component,
+    ``flux_x_w_m`` and ``flux_y_w_m`` are eastward and northward components on the
+    WRF mass grid. The function samples the nearest column every ``spacing_m``
+    (default: grid ``min(dx, dy)``) and integrates the normal component,
     ``Phi = integral F . n_hat ds``, with ``n_hat`` the rightward normal walking
-    a->b — positive ``Phi`` exports cold-pool air to the walker's right.  Flat-earth
-    metric, fine for basin-scale (< ~100 km) transects.
+    a->b. Flat-earth metric, fine for basin-scale (< ~100 km) transects.
     """
     from scipy.integrate import trapezoid
     from scipy.spatial import cKDTree
@@ -766,7 +767,12 @@ def transect_deficit_flux(
     _, idx = tree.query(np.column_stack([lats, lons]))
     jj, ii = np.unravel_index(np.asarray(idx, dtype=int), xlat.shape)
 
-    fx, fy = deficit_flux_field(ds, crest_m)  # earth-relative
+    fx = np.asarray(flux_x_w_m)
+    fy = np.asarray(flux_y_w_m)
+    if fx.shape != xlat.shape or fy.shape != xlat.shape:
+        raise ValueError(
+            f"flux fields must match mass-grid shape {xlat.shape}; got {fx.shape}, {fy.shape}"
+        )
     f_normal = fx[jj, ii] * nx_e + fy[jj, ii] * ny_n
     dist = frac * length
     return TransectFlux(
@@ -778,5 +784,37 @@ def transect_deficit_flux(
         f_normal=f_normal,
         total_w=float(trapezoid(f_normal, dist)),
         normal_en=(nx_e, ny_n),
+        label=label,
+    )
+
+
+def transect_deficit_flux(
+    ds,
+    crest_m: float,
+    lat_a: float,
+    lon_a: float,
+    lat_b: float,
+    lon_b: float,
+    *,
+    spacing_m: float | None = None,
+    label: str = "",
+) -> TransectFlux:
+    """Deficit transport through the vertical plane over the a->b line (W).
+
+    Positive ``Phi`` transports cold-pool heat deficit to the walker's right.
+    Use :func:`integrate_flux_transect` when a caller already has the earth-relative
+    deficit-flux fields and needs several transects without recomputing the column
+    integral.
+    """
+    fx, fy = deficit_flux_field(ds, crest_m)
+    return integrate_flux_transect(
+        ds,
+        fx,
+        fy,
+        lat_a,
+        lon_a,
+        lat_b,
+        lon_b,
+        spacing_m=spacing_m,
         label=label,
     )

--- a/brc_tools/nwp/wrf_output.py
+++ b/brc_tools/nwp/wrf_output.py
@@ -596,21 +596,47 @@ def deficit_flux_field(
     return fx, fy
 
 
+def horizontal_flux_divergence(
+    ds,
+    flux_x_w_m: np.ndarray,
+    flux_y_w_m: np.ndarray,
+    *,
+    earth_relative: bool = False,
+) -> np.ndarray:
+    """Horizontal divergence of a mass-grid flux field (W m-2).
+
+    Inputs are grid-relative by default. Set ``earth_relative=True`` for eastward /
+    northward components; they are rotated back to the WRF grid before applying the
+    map-factor divergence.
+
+    Uses the WRF map-factor form ``m^2 * [d(Fx/m)/dx + d(Fy/m)/dy]`` and central
+    differences via ``np.gradient``.
+    """
+    fx = np.asarray(flux_x_w_m, dtype=float)
+    fy = np.asarray(flux_y_w_m, dtype=float)
+    shape = surface_field(ds, "XLAT").shape
+    if fx.shape != shape or fy.shape != shape:
+        raise ValueError(f"flux fields must match mass-grid shape {shape}; got {fx.shape}, {fy.shape}")
+    if earth_relative:
+        cosa = surface_field(ds, "COSALPHA") if "COSALPHA" in ds else np.ones(shape)
+        sina = surface_field(ds, "SINALPHA") if "SINALPHA" in ds else np.zeros(shape)
+        fx, fy = fx * cosa + fy * sina, fy * cosa - fx * sina
+    m = surface_field(ds, "MAPFAC_M") if "MAPFAC_M" in ds else np.ones_like(fx)
+    dx, dy = dx_dy(ds)
+    return m * m * (np.gradient(fx / m, dx, axis=1) + np.gradient(fy / m, dy, axis=0))
+
+
 def deficit_flux_divergence(ds, crest_m: float) -> np.ndarray:
     """Horizontal ``div(F)`` of the deficit transport (W m-2).
 
     ``-div(F)`` is the horizontal flux-convergence contribution to ``dH/dt``, not a
     closed thermodynamic tendency or a uniquely diabatic/advective partition.
 
-    Uses grid-relative components on the mass grid with the WRF map-factor form
-    ``m^2 * [d(Fx/m)/dx + d(Fy/m)/dy]`` (``MAPFAC_M`` ~ 1.0004 over the Uinta Basin,
-    but the form is exact; identity when the field is absent).  Central differences
-    via ``np.gradient``.
+    Uses grid-relative components on the mass grid; see
+    :func:`horizontal_flux_divergence` for the map-factor operator.
     """
     fx, fy = deficit_flux_field(ds, crest_m, earth_relative=False)
-    m = surface_field(ds, "MAPFAC_M") if "MAPFAC_M" in ds else np.ones_like(fx)
-    dx, dy = dx_dy(ds)
-    return m * m * (np.gradient(fx / m, dx, axis=1) + np.gradient(fy / m, dy, axis=0))
+    return horizontal_flux_divergence(ds, fx, fy)
 
 
 def cold_pool_depth_field(ds, crest_m: float, *, min_deficit_k: float = 0.0) -> np.ndarray:

--- a/brc_tools/nwp/wrf_output.py
+++ b/brc_tools/nwp/wrf_output.py
@@ -245,6 +245,22 @@ def dx_dy(ds) -> tuple[float, float]:
     return float(ds.attrs["DX"]), float(ds.attrs["DY"])
 
 
+def grid_cell_area_m2(ds) -> np.ndarray:
+    """Projected mass-grid cell area (m2), including the WRF map factor.
+
+    WRF's ``DX`` and ``DY`` are distances on the computational grid.  Physical
+    cell area is therefore ``DX * DY / MAPFAC_M**2``; when ``MAPFAC_M`` is not
+    present (including small synthetic fixtures), the identity map factor is
+    used.
+    """
+    dx, dy = dx_dy(ds)
+    if "MAPFAC_M" not in ds:
+        shape = surface_field(ds, "XLAT").shape
+        return np.full(shape, dx * dy, dtype=float)
+    mapfac = surface_field(ds, "MAPFAC_M")
+    return (dx * dy) / np.square(mapfac)
+
+
 def grid_spacing_label(ds) -> str:
     """Human-readable grid spacing from the ``DX`` global attr (e.g. ``3 km``, ``333 m``).
 
@@ -477,6 +493,26 @@ class _DeficitKernel:
     theta_crest: np.ndarray  # (ny, nx) K, theta interpolated to crest_m per column
 
 
+@dataclass
+class DeficitBulkFields:
+    """Bulk fields derived from one crest-referenced deficit kernel.
+
+    ``transport_velocity`` is the deficit-weighted horizontal wind ``F/H``.
+    ``froude`` is an exploratory reduced-gravity proxy based on the diagnosed
+    mean deficit and layer depth; it is not a hydraulic-control diagnosis.
+    """
+
+    heat_deficit_j_m2: np.ndarray
+    flux_x_w_m: np.ndarray
+    flux_y_w_m: np.ndarray
+    velocity_x_m_s: np.ndarray
+    velocity_y_m_s: np.ndarray
+    depth_m: np.ndarray
+    mean_deficit_k: np.ndarray
+    froude: np.ndarray
+    theta_crest_k: np.ndarray
+
+
 def _deficit_kernel(ds, crest_m: float) -> _DeficitKernel:
     """Crest-referenced deficit integrand, factored out so :func:`heat_deficit_field`,
     :func:`deficit_flux_field` and :func:`cold_pool_depth_field` share one convention
@@ -537,13 +573,17 @@ def deficit_flux_field(
 
         F = (c_p / g) * integral_{p_sfc}^{p_crest} max(theta_crest - theta, 0) * u_h dp
 
-    The wind-weighted companion of :func:`heat_deficit_field` (same kernel, so the pair
-    closes a budget: dH/dt = -div(F) + diabatic residual; the vertical boundary term
-    vanishes because the integrand -> 0 at the crest).  Clipping the deficit at zero
-    confines the transport to cold-pool air — an unclipped integral would be dominated
-    by the free troposphere.  Returns ``(Fx, Fy)`` in W per metre of transect width:
-    earth-relative for maps (default), grid-relative for divergence / along-grid
-    sections.  The deficit-weighted transport velocity is ``F / H`` (mask small H).
+    The wind-weighted companion of :func:`heat_deficit_field`.  Clipping the deficit at
+    zero confines the transport to the diagnosed cold layer — an unclipped integral
+    would be dominated by the free troposphere.  Returns ``(Fx, Fy)`` in W per metre of
+    transect width: earth-relative for maps (default), grid-relative for divergence /
+    along-grid sections.
+
+    ``-div(F)`` is the horizontal flux-convergence contribution to heat-deficit
+    tendency.  Combining it with finite-difference storage leaves an *unresolved*
+    tendency that can include diabatic physics, the time-varying local crest reference,
+    movement of the clipped layer, vertical/boundary terms, and numerical error; it is
+    not by itself a diabatic-heating diagnosis.
     """
     from scipy.integrate import trapezoid
 
@@ -557,7 +597,10 @@ def deficit_flux_field(
 
 
 def deficit_flux_divergence(ds, crest_m: float) -> np.ndarray:
-    """div(F) of the deficit transport (W m-2); ``-div(F)`` is the advective dH/dt.
+    """Horizontal ``div(F)`` of the deficit transport (W m-2).
+
+    ``-div(F)`` is the horizontal flux-convergence contribution to ``dH/dt``, not a
+    closed thermodynamic tendency or a uniquely diabatic/advective partition.
 
     Uses grid-relative components on the mass grid with the WRF map-factor form
     ``m^2 * [d(Fx/m)/dx + d(Fy/m)/dy]`` (``MAPFAC_M`` ~ 1.0004 over the Uinta Basin,
@@ -583,6 +626,83 @@ def cold_pool_depth_field(ds, crest_m: float, *, min_deficit_k: float = 0.0) -> 
     z_agl = kern.height_asl - surface_field(ds, "HGT")[np.newaxis]
     depth = np.take_along_axis(z_agl, top[np.newaxis], axis=0)[0]
     return np.where(pos.any(axis=0), depth, 0.0)
+
+
+def deficit_bulk_fields(
+    ds,
+    crest_m: float,
+    *,
+    min_deficit_k: float = 0.25,
+    min_heat_deficit_j_m2: float = 1.0e5,
+) -> DeficitBulkFields:
+    """Return H, F/H, depth, mean deficit, and an exploratory bulk Froude proxy.
+
+    The active layer contains levels whose crest-relative potential-temperature
+    deficit exceeds ``min_deficit_k``.  Transport velocity is masked where ``H`` is
+    below ``min_heat_deficit_j_m2``.  The bulk Froude proxy is
+
+    ``|F/H| / sqrt(g * mean_deficit/theta_crest * depth)``.
+
+    It is useful for exploratory maps, but does not establish hydraulic control: the
+    diagnosed layer may be disconnected, the reference is local and time varying, and
+    no along-canyon control section or observed layer depth is imposed.
+    """
+    from scipy.integrate import trapezoid
+
+    kern = _deficit_kernel(ds, crest_m)
+    u, v = earth_relative_winds(ds)
+    pressure = kern.pressure_pa
+
+    deficit_dp = -trapezoid(kern.integrand, x=pressure, axis=0)
+    heat = (CP / G) * deficit_dp
+    flux_x = -(CP / G) * trapezoid(kern.integrand * u, x=pressure, axis=0)
+    flux_y = -(CP / G) * trapezoid(kern.integrand * v, x=pressure, axis=0)
+
+    valid_h = heat >= float(min_heat_deficit_j_m2)
+    velocity_x = np.divide(
+        flux_x, heat, out=np.full_like(heat, np.nan, dtype=float), where=valid_h
+    )
+    velocity_y = np.divide(
+        flux_y, heat, out=np.full_like(heat, np.nan, dtype=float), where=valid_h
+    )
+
+    active = kern.integrand > float(min_deficit_k)
+    active_dp = -trapezoid(active.astype(float), x=pressure, axis=0)
+    active_deficit_dp = -trapezoid(
+        np.where(active, kern.integrand, 0.0), x=pressure, axis=0
+    )
+    mean_deficit = np.divide(
+        active_deficit_dp,
+        active_dp,
+        out=np.full_like(heat, np.nan, dtype=float),
+        where=active_dp > 0.0,
+    )
+    pos = active
+    top = pos.shape[0] - 1 - np.argmax(pos[::-1], axis=0)
+    z_agl = kern.height_asl - surface_field(ds, "HGT")[np.newaxis]
+    depth = np.take_along_axis(z_agl, top[np.newaxis], axis=0)[0]
+    depth = np.where(pos.any(axis=0), depth, 0.0)
+
+    speed = np.hypot(velocity_x, velocity_y)
+    reduced_gravity_depth = G * mean_deficit / kern.theta_crest * depth
+    wave_speed = np.sqrt(np.clip(reduced_gravity_depth, 0.0, None))
+    froude = np.divide(
+        speed,
+        wave_speed,
+        out=np.full_like(speed, np.nan, dtype=float),
+        where=valid_h & np.isfinite(wave_speed) & (wave_speed > 0.0),
+    )
+    return DeficitBulkFields(
+        heat_deficit_j_m2=heat,
+        flux_x_w_m=flux_x,
+        flux_y_w_m=flux_y,
+        velocity_x_m_s=velocity_x,
+        velocity_y_m_s=velocity_y,
+        depth_m=depth,
+        mean_deficit_k=mean_deficit,
+        froude=froude,
+        theta_crest_k=kern.theta_crest,
+    )
 
 
 @dataclass

--- a/brc_tools/visualize/deficitflux.py
+++ b/brc_tools/visualize/deficitflux.py
@@ -1,11 +1,11 @@
-"""Cold-pool deficit-transport plan-view maps (flux vectors + advective tendency).
+"""Cold-pool deficit-transport maps and time-series diagnostics.
 
 The advection companion to ``visualize/heatdeficit.py``: integrated deficit transport
 (:func:`brc_tools.nwp.wrf_output.deficit_flux_field`, W m^-1 — the IVT analogue of the
 Whiteman heat deficit) rendered as quivers over the heat-deficit field, plus the
-advective tendency ``-div(F)`` (MJ m^-2 h^-1) as a symmetric diverging map.  The pair
-closes a budget with the heat-deficit map (dH/dt = -div F + diabatic), so the two
-families share the crest convention and the ``heat_deficit`` colour scale.
+horizontal flux-convergence contribution ``-div(F)`` (MJ m^-2 h^-1) as a symmetric
+diverging map.  Finite-difference storage minus that contribution is retained as an
+*unresolved* tendency rather than attributed uniquely to diabatic physics.
 
 Same offline-robust dressing as the heat-deficit maps (plain lon/lat matplotlib,
 fail-soft Natural-Earth overlays, decluttered waypoints, crest terrain contour).
@@ -115,7 +115,7 @@ def plot_deficitflux_divergence(
     overlays: dict | None = None,
     dpi: int = 300,
 ) -> Path:
-    """Advective heat-deficit tendency ``-div(F)`` (MJ m^-2 h^-1), diverging map.
+    """Horizontal heat-deficit flux convergence ``-div(F)`` (MJ m^-2 h^-1).
 
     Red = advection deepening the pool (matching the heat-deficit difference maps,
     where red = deeper).  ``smooth_sigma`` (grid cells) is display-only smoothing;
@@ -147,8 +147,154 @@ def plot_deficitflux_divergence(
     _decorate(ax, lon, lat, crest_terrain=crest_terrain, crest_m=crest_m,
               waypoints=waypoints, overlays=overlays)
     fig.colorbar(mesh, ax=ax, shrink=0.9, extend="both", label=style.label)
-    ax.set_title(f"{title}\n(red = advection deepening the pool)")
+    ax.set_title(f"{title}\n(red = horizontal convergence increasing deficit)")
     _annotate(ax, annotation)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi)
+    plt.close(fig)
+    return out
+
+
+def plot_deficit_bulk_diagnostics(
+    lon,
+    lat,
+    depth_m,
+    speed_m_s,
+    froude,
+    out_path: str | Path,
+    *,
+    styles,
+    crest_terrain=None,
+    crest_m=None,
+    title: str,
+    annotation: str | None = None,
+    waypoints: dict | None = None,
+    overlays: dict | None = None,
+    dpi: int = 300,
+) -> Path:
+    """Render exploratory depth, deficit-weighted speed, and bulk Froude maps.
+
+    These fields share the same crest-referenced active layer.  The Froude panel is a
+    reduced-gravity proxy only; the renderer deliberately labels it as exploratory and
+    does not imply a hydraulic-control diagnosis.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    out = Path(out_path)
+    fields = (np.asarray(depth_m), np.asarray(speed_m_s), np.asarray(froude))
+    labels = ("diagnosed layer depth", "deficit-weighted speed |F|/H", "exploratory bulk Froude proxy")
+    fig, axes = plt.subplots(1, 3, figsize=(14.2, 4.6), constrained_layout=True)
+    for ax, field, style, subtitle in zip(axes, fields, styles, labels):
+        mesh = ax.pcolormesh(
+            lon, lat, field, shading="auto", cmap=style.cmap,
+            vmin=style.vmin, vmax=style.vmax,
+        )
+        _decorate(
+            ax, lon, lat, crest_terrain=crest_terrain, crest_m=crest_m,
+            waypoints=waypoints, overlays=overlays,
+        )
+        fig.colorbar(mesh, ax=ax, shrink=0.82, extend=style.extend, label=style.label)
+        ax.set_title(subtitle, fontsize=9)
+    fig.suptitle(title)
+    if annotation:
+        fig.text(0.01, 0.005, annotation, fontsize=6, color="0.4", ha="left", va="bottom")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi)
+    plt.close(fig)
+    return out
+
+
+def plot_deficit_budget(
+    times,
+    heat_mj_m2,
+    interval_times,
+    storage_tendency,
+    convergence_tendency,
+    unresolved_tendency,
+    out_path: str | Path,
+    *,
+    title: str,
+    spinup_end=None,
+    annotation: str | None = None,
+    dpi: int = 300,
+) -> Path:
+    """Plot area-mean storage, horizontal convergence, and unresolved tendency.
+
+    ``storage_tendency`` and ``convergence_tendency`` must already use a common time
+    interval and spatial mask.  This function does not label their difference as
+    diabatic because reference-state, clipped-layer, vertical/boundary, and numerical
+    terms may also contribute.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.dates as mdates
+    import matplotlib.pyplot as plt
+
+    out = Path(out_path)
+    times = list(times)
+    interval_times = list(interval_times)
+    heat = np.asarray(heat_mj_m2, dtype=float)
+    storage = np.asarray(storage_tendency, dtype=float)
+    convergence = np.asarray(convergence_tendency, dtype=float)
+    unresolved = np.asarray(unresolved_tendency, dtype=float)
+
+    fig = plt.figure(figsize=(10.6, 6.2), constrained_layout=True)
+    gs = fig.add_gridspec(2, 2, width_ratios=(1.45, 1.0))
+    ax_h = fig.add_subplot(gs[0, 0])
+    ax_t = fig.add_subplot(gs[1, 0], sharex=ax_h)
+    ax_s = fig.add_subplot(gs[:, 1])
+
+    ax_h.plot(times, heat, color="black", marker="o", ms=2.8, lw=1.2)
+    ax_h.set_ylabel(r"area-mean $H$ (MJ m$^{-2}$)")
+    ax_h.grid(True, alpha=0.25)
+
+    ax_t.plot(interval_times, storage, label=r"storage $\partial H/\partial t$", lw=1.3)
+    ax_t.plot(interval_times, convergence, label=r"horizontal convergence $-\nabla_h\cdot F$", lw=1.3)
+    ax_t.plot(interval_times, unresolved, label="unresolved tendency", lw=1.1, color="0.35")
+    ax_t.axhline(0.0, color="0.5", lw=0.7)
+    ax_t.set_ylabel(r"MJ m$^{-2}$ h$^{-1}$")
+    ax_t.set_xlabel("valid time (UTC)")
+    ax_t.grid(True, alpha=0.25)
+    ax_t.legend(fontsize=7, ncol=1)
+
+    if spinup_end is not None and times:
+        for ax in (ax_h, ax_t):
+            ax.axvspan(times[0], spinup_end, color="0.75", alpha=0.35, lw=0)
+        ax_h.text(0.02, 0.92, "spin-up context", transform=ax_h.transAxes,
+                  fontsize=7, color="0.35", ha="left", va="top")
+
+    finite = np.isfinite(storage) & np.isfinite(convergence)
+    if finite.any():
+        color = mdates.date2num(np.asarray(interval_times, dtype=object)[finite])
+        scat = ax_s.scatter(convergence[finite], storage[finite], c=color, cmap="viridis", s=28)
+        lo = float(min(np.nanmin(storage[finite]), np.nanmin(convergence[finite])))
+        hi = float(max(np.nanmax(storage[finite]), np.nanmax(convergence[finite])))
+        pad = 0.08 * max(hi - lo, 1.0)
+        ax_s.plot([lo - pad, hi + pad], [lo - pad, hi + pad], color="0.35", ls="--", lw=0.8)
+        ax_s.set_xlim(lo - pad, hi + pad)
+        ax_s.set_ylim(lo - pad, hi + pad)
+        if (finite.sum() >= 2 and np.nanstd(storage[finite]) > 0.0
+                and np.nanstd(convergence[finite]) > 0.0):
+            corr = float(np.corrcoef(storage[finite], convergence[finite])[0, 1])
+        else:
+            corr = float("nan")
+        rmse = float(np.sqrt(np.mean(np.square(unresolved[finite]))))
+        ax_s.set_title(f"10-min interval comparison\nr={corr:.2f}; residual RMSE={rmse:.2f}")
+        cb = fig.colorbar(scat, ax=ax_s, shrink=0.72)
+        cb.set_label("interval midpoint (UTC)")
+        cb.ax.yaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+    ax_s.set_xlabel(r"$-\nabla_h\cdot F$ (MJ m$^{-2}$ h$^{-1}$)")
+    ax_s.set_ylabel(r"$\partial H/\partial t$ (MJ m$^{-2}$ h$^{-1}$)")
+    ax_s.grid(True, alpha=0.25)
+
+    fig.suptitle(title)
+    if annotation:
+        fig.text(0.01, 0.005, annotation, fontsize=6, color="0.4", ha="left", va="bottom")
+    fig.autofmt_xdate(rotation=25)
     out.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(out, dpi=dpi)
     plt.close(fig)

--- a/brc_tools/visualize/deficitflux.py
+++ b/brc_tools/visualize/deficitflux.py
@@ -268,6 +268,8 @@ def plot_deficit_budget(
                   fontsize=7, color="0.35", ha="left", va="top")
 
     finite = np.isfinite(storage) & np.isfinite(convergence)
+    if spinup_end is not None:
+        finite &= np.asarray([valid >= spinup_end for valid in interval_times])
     if finite.any():
         color = mdates.date2num(np.asarray(interval_times, dtype=object)[finite])
         scat = ax_s.scatter(convergence[finite], storage[finite], c=color, cmap="viridis", s=28)
@@ -283,7 +285,11 @@ def plot_deficit_budget(
         else:
             corr = float("nan")
         rmse = float(np.sqrt(np.mean(np.square(unresolved[finite]))))
-        ax_s.set_title(f"10-min interval comparison\nr={corr:.2f}; residual RMSE={rmse:.2f}")
+        comparison_label = "retained 10-min" if spinup_end is not None else "10-min"
+        ax_s.set_title(
+            f"{comparison_label} interval comparison\n"
+            f"r={corr:.2f}; residual RMSE={rmse:.2f}"
+        )
         cb = fig.colorbar(scat, ax=ax_s, shrink=0.72)
         cb.set_label("interval midpoint (UTC)")
         cb.ax.yaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))

--- a/brc_tools/visualize/deficitflux.py
+++ b/brc_tools/visualize/deficitflux.py
@@ -299,7 +299,10 @@ def plot_deficit_budget(
 
     fig.suptitle(title)
     if annotation:
-        fig.text(0.01, 0.005, annotation, fontsize=6, color="0.4", ha="left", va="bottom")
+        # Reserve a footer strip so provenance text cannot collide with the shared
+        # time-axis label when constrained layout tightens the two-row left column.
+        fig.get_layout_engine().set(rect=(0.0, 0.05, 1.0, 0.93))
+        fig.text(0.01, 0.012, annotation, fontsize=6, color="0.4", ha="left", va="bottom")
     fig.autofmt_xdate(rotation=25)
     out.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(out, dpi=dpi)

--- a/brc_tools/visualize/style.py
+++ b/brc_tools/visualize/style.py
@@ -54,11 +54,17 @@ VAR_STYLES: dict[str, VarStyle] = {
     # spatial pool is directly comparable across cases and forecast hours; the pelican2013
     # control peaks near 8 MJ m^-2.
     "heat_deficit":   VarStyle("viridis", r"cold-pool heat deficit (MJ m$^{-2}$)", 0.0, 8.0, extend="max"),
-    # Advective heat-deficit tendency -div(F) (deficitflux_div family).  Symmetric,
+    # Horizontal heat-deficit flux convergence -div(F) (deficitflux_div family). Symmetric,
     # fixed +-2 MJ m^-2 h^-1: the 111 m pelican2013 d04 run has hour-mean magnitudes
     # ~0.2-0.5 with smoothed local extremes near +-2.
-    "deficit_advection": VarStyle("RdBu_r", r"advective $\partial H/\partial t$ (MJ m$^{-2}$ h$^{-1}$)",
+    "deficit_advection": VarStyle("RdBu_r", r"horizontal $-\nabla_h\!\cdot F$ (MJ m$^{-2}$ h$^{-1}$)",
                                   -2.0, 2.0, diverging=True),
+    "deficit_depth": VarStyle("cividis", "diagnosed layer depth (m AGL)",
+                               0.0, 700.0, extend="max"),
+    "deficit_speed": VarStyle("magma", r"deficit-weighted speed $|F|/H$ (m s$^{-1}$)",
+                               0.0, 5.0, extend="max"),
+    "deficit_froude": VarStyle("plasma", "exploratory bulk Froude proxy",
+                                0.0, 2.0, extend="max"),
 }
 
 # Symmetric diverging limits for difference figures (case A minus case B).

--- a/docs/WRF-FIGURE-ENGINE.md
+++ b/docs/WRF-FIGURE-ENGINE.md
@@ -37,8 +37,9 @@ PY=~/software/pkg/miniforge3/envs/brc-tools-2026/bin/python
 "$PY" scripts/wrf_figures.py --config <case.toml> --case nam --figure surface --lead 1 --skip-existing
 ```
 
-Families: `domains, section, upperair, surface, difference, profile, skewt, thetaz,
-heatdeficit, heatdeficit_map, deficitflux_map, deficitflux_div, deficitflux_transect`
+Families are `domains`, `section`, `upperair`, `surface`, `difference`, `profile`,
+`skewt`, `thetaz`, `heatdeficit`, `heatdeficit_map`, `deficitflux_map`,
+`deficitflux_div`, `deficitflux_transect`, `deficitbulk_map`, and `deficit_budget`
 (or `all`). Heavy batches run on SLURM (per `docs/CHPC-REFERENCE.md`);
 the case's own repo owns the sbatch wrapper. Soundings need a network node — run
 `scripts/fetch_soundings.py` first and pass `--sounding-cache`.
@@ -79,23 +80,37 @@ percentile of that figure. The crest is an approximate upper integration boundar
 integrand → 0 there, so the error sits where the signal is smallest). This is the
 productized form of the mechanism-decomposition heat-deficit prototype.
 
-The **`deficitflux_*` families** are the *advection* companions of `heatdeficit_map`,
+The **deficit-transport families** are horizontal-transport companions of
+`heatdeficit_map`,
 built on the integrated deficit transport `F = (c_p/g)∫max(θ_crest−θ,0)·u_h dp`
-(`deficit_flux_field`, W m⁻¹ — the IVT analogue of the heat deficit; same kernel, so
-`dH/dt = −∇·F + diabatic` closes as a budget):
+(`deficit_flux_field`, W m⁻¹ — the IVT analogue of the heat deficit). `−∇h·F` is the
+horizontal flux-convergence contribution to storage. The remainder after subtracting
+that term from finite-difference `dH/dt` is deliberately labelled **unresolved**, not
+diabatic: the local time-varying crest reference, clipped-layer motion, vertical and
+boundary terms, and numerical error can also contribute.
 
 - `deficitflux_map` — F quivers (MW m⁻¹, fixed 5 MW quiver key) over the heat-deficit
   field → per-case `full-figures/deficitflux_map/deficitflux_<case>_<HH>z.png`. Any
   configured `[[transects]]` lines are drawn for context.
-- `deficitflux_div` — advective tendency `−∇·F` (MJ m⁻² h⁻¹, `deficit_advection` style,
-  fixed ±2, red = advection deepening the pool; display-only Gaussian smoothing) →
+- `deficitflux_div` — horizontal convergence `−∇h·F` (MJ m⁻² h⁻¹,
+  `deficit_advection` style, fixed ±2, red = convergence increasing deficit;
+  display-only Gaussian smoothing) →
   per-case `full-figures/deficitflux_div/deficitflux_div_<case>_<HH>z.png`.
-- `deficitflux_transect` — deficit export Φ(t) = ∫F·n̂ ds (GW) through each named
-  `[[transects]]` A→B line (canyon gates), one line per case, positive = export to the
+- `deficitflux_transect` — signed deficit transport Φ(t) = ∫F·n̂ ds (GW) through each
+  named `[[transects]]` A→B line, one line per case, positive = transport to the
   right walking A→B → shared `compare/deficitflux_transect/deficitflux_transect_<name>.png`.
+- `deficitbulk_map` — a three-panel exploratory diagnostic of active-layer depth,
+  deficit-weighted speed `|F|/H`, and a reduced-gravity bulk Froude proxy. The Froude
+  panel is not a hydraulic-control diagnosis → per-case
+  `full-figures/deficitbulk_map/deficitbulk_<case>_<HH>z.png`.
+- `deficit_budget` — area-mean `H`, interval storage, horizontal convergence, and the
+  unresolved remainder, plus a CSV with the exact interval values → per-case
+  `full-figures/deficit_budget/deficit_budget_<case>.{png,csv}`.
 
-All three render on the nest named by `deficitflux_domain` (`inner`/`outer`/`dNN`;
+All five render on the nest named by `deficitflux_domain` (`inner`/`outer`/`dNN`;
 default `inner`). Transect endpoints outside the nest are a named `[SKIP]` per case.
+Per-valid-time filenames retain the legacy `<HH>z` tag for exact-hour output and use
+`<HHMM>z` (or `<HHMMSS>z`) when needed, so sub-hourly runs never overwrite products.
 
 **Map reference overlays** (US highways, rivers incl. the Green River, lakes/reservoirs,
 state borders) are opt-in per case via the `[map]` table and drawn on the surface /
@@ -188,6 +203,10 @@ upper_pressure_hpa = 600.0           # pressure surface for the synoptic T-advec
 upper_adv_domain = "outer"           # compute that map on "outer" (clean) | "inner" nest
 heatdeficit_domain = "d02"           # nest for the heatdeficit_map field: "inner"|"outer"|"dNN" (default inner)
 deficitflux_domain = "inner"         # nest for the deficitflux_* families (default inner)
+deficit_active_min_k = 0.25          # active-layer deficit threshold for bulk maps
+deficit_min_heat_mj_m2 = 0.1         # mask F/H below this H threshold
+deficit_budget_margin_cells = 15     # symmetric edge crop for budget spatial means
+deficit_spinup_hours = 2.0           # context interval shaded from first valid time
 surface_single_domains = ["inner"]   # nests that ALSO get free-standing single-nest surface
                                      # figures ({key}_{case}_dNN_{HH}z.png) beside the
                                      # multidomain panel; default [] = panels only

--- a/tests/test_wrf_figures.py
+++ b/tests/test_wrf_figures.py
@@ -205,6 +205,36 @@ def test_deficitflux_families_emit_and_render(tmp_path, monkeypatch):
         assert pngs and pngs[0].stat().st_size > 0
 
 
+def test_subhourly_valid_tags_are_collision_safe():
+    assert wf._valid_tag(datetime(2013, 2, 2, 12)) == "12z"
+    assert wf._valid_tag(datetime(2013, 2, 2, 12, 10)) == "1210z"
+    assert wf._valid_tag(datetime(2013, 2, 2, 12, 10, 30)) == "121030z"
+    assert wf._valid_label(datetime(2013, 2, 2, 12, 10)) == "12:10Z"
+
+
+def test_deficitbulk_and_budget_emit_and_render(tmp_path, monkeypatch):
+    monkeypatch.setenv("MPLCONFIGDIR", str(tmp_path / "mpl"))
+    cfg = _make_case(tmp_path, monkeypatch)
+    sel = wf.Selection(
+        cases=["main"], families=["deficitbulk_map", "deficit_budget"],
+        time="12", output_dir=str(tmp_path / "out"),
+    )
+    tasks = wf.build_tasks(cfg, sel)
+    bulk = [t for t in tasks if t[1] is wf.task_deficitbulk_map]
+    budget = [t for t in tasks if t[1] is wf.task_deficit_budget]
+    assert bulk and len(budget) == 1
+
+    use_publication_style()
+    _name, fn, args = bulk[0]
+    fn(*args)
+    assert list(Path(args[6]).glob("deficitbulk_main_12z.png"))
+
+    _name, fn, args = budget[0]
+    fn(*args)
+    assert list(Path(args[5]).glob("deficit_budget_main.png"))
+    assert list(Path(args[5]).glob("deficit_budget_main.csv"))
+
+
 def test_deficitflux_transect_emits_and_renders(tmp_path, monkeypatch):
     monkeypatch.setenv("MPLCONFIGDIR", str(tmp_path / "mpl"))
     cfg = _make_case(tmp_path, monkeypatch)

--- a/tests/test_wrf_output.py
+++ b/tests/test_wrf_output.py
@@ -180,6 +180,9 @@ def test_deficit_flux_divergence_uniform_wind_is_advection_of_H():
     expected = 5.0 * np.gradient(H, dx, axis=1) + 2.0 * np.gradient(H, dy, axis=0)
     div = wo.deficit_flux_divergence(ds, crest)
     np.testing.assert_allclose(div, expected, rtol=1e-9, atol=1e-6)
+    fx, fy = wo.deficit_flux_field(ds, crest)
+    reused = wo.horizontal_flux_divergence(ds, fx, fy, earth_relative=True)
+    np.testing.assert_allclose(reused, div, rtol=1e-12, atol=1e-12)
 
 
 def test_cold_pool_depth_field():

--- a/tests/test_wrf_output.py
+++ b/tests/test_wrf_output.py
@@ -153,6 +153,24 @@ def test_deficit_flux_uniform_wind_equals_u_times_H():
     np.testing.assert_allclose(gy, fy)
 
 
+def test_grid_cell_area_and_deficit_bulk_fields():
+    """Bulk fields retain the analytic uniform-wind velocity and finite geometry."""
+    ds = make_synthetic_wrf(nz=8, ny=6, nx=6)
+    area = wo.grid_cell_area_m2(ds)
+    dx, dy = wo.dx_dy(ds)
+    np.testing.assert_allclose(area, dx * dy)  # fixture omits MAPFAC_M: identity fallback
+
+    bulk = wo.deficit_bulk_fields(
+        ds, 1900.0, min_deficit_k=0.25, min_heat_deficit_j_m2=0.0
+    )
+    valid = np.isfinite(bulk.velocity_x_m_s) & (bulk.heat_deficit_j_m2 > 0.0)
+    assert valid.any()
+    np.testing.assert_allclose(bulk.velocity_x_m_s[valid], 5.0, rtol=1e-12)
+    np.testing.assert_allclose(bulk.velocity_y_m_s[valid], 2.0, rtol=1e-12)
+    assert np.nanmin(bulk.depth_m) >= 0.0
+    assert np.isfinite(bulk.froude[valid]).any()
+
+
 def test_deficit_flux_divergence_uniform_wind_is_advection_of_H():
     """Uniform wind: div(uH, vH) = u*dH/dx + v*dH/dy under the same discrete operator."""
     ds = make_synthetic_wrf(nz=8, ny=6, nx=6)

--- a/tests/test_wrf_output.py
+++ b/tests/test_wrf_output.py
@@ -204,6 +204,16 @@ def test_transect_deficit_flux_normal_convention():
     np.testing.assert_allclose(tf.f_normal, -2.0 * H[tf.j, tf.i], rtol=1e-12)
     assert tf.total_w < 0.0  # deficit moves north (V > 0): leftward across an EW walk
 
+    # Reusing an already-computed field is exactly equivalent and avoids repeating
+    # the vertical column integral when several transects share one valid time.
+    fx, fy = wo.deficit_flux_field(ds, crest)
+    reused = wo.integrate_flux_transect(
+        ds, fx, fy, 40.0, -110.0, 40.0, -109.5, label="EW"
+    )
+    assert reused.total_w == pytest.approx(tf.total_w)
+    np.testing.assert_array_equal(reused.j, tf.j)
+    np.testing.assert_array_equal(reused.i, tf.i)
+
 
 def test_transect_deficit_flux_zero_length_raises():
     ds = make_synthetic_wrf()


### PR DESCRIPTION
Five commits produced on the X8 run today (2026-07-15) beyond the deficitflux batch already on main:

- integrated deficit-transport diagnostics for the figure engine (`wrf_output.py` + `wrf_figures.py`)
- reusable flux-divergence helper; flux fields reused across transects (perf)
- budget stats aligned with the retained window; provenance footer reserved on budget figures

**Merge with a merge commit, not squash.** `latex-jrl-mjd-mdpiair-2026` pins `EXPECTED_BRC_TOOLS_REF=548fee49aaa2376f7212ca6646f561d7c31ad8a2` (this branch's tip) in `verification/slurm/run_x8_deficit_transport.slurm`; a merge commit keeps that SHA reachable from main so the frozen evidence packet stays reproducible.

Tests: `tests/test_wrf_output.py` + `tests/test_wrf_figures.py` — 41 passed locally at 548fee4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)