### PR TITLE
MODIS context renderer + EPA AQS AirData client (+ repo housekeeping)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ CLAUDE.local.md
 .coverage
 .pytest_cache/
 htmlcov/
+# BasinWX export staging (legacy repo-local default; now ~/.cache/brc-tools/basinwx)
+data/basinwx/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ JSON to the BasinWX website. Package: **`brc_tools`** (underscore).
 Repo: **`brc-tools`** (hyphen).
 
 ## Current focus
+- **pelican2013 manuscript support** (final-draft push lives in `latex-jrl-mjd-mdpiair-2026`): figure engine + X8 deficit-transport diagnostics merged; the study's evidence packet pins an exact brc-tools SHA — treat `wrf_figures.py`/`wrf_output.py`/`visualize/*` as frozen unless the study repo asks.
 - HRRR/RRFS → BasinWX operational ingest (GH #10). Strategy/status: `docs/nwp/ROADMAP.md`.
 - Case-study pipeline (natural language → script → figures): `docs/CASE-STUDY-GUIDE.md`.
 - **WRF-input staging**: stage GRIB → scratch as `manifest_<case>.json` + `contract_<case>.json` for `brc-wrf` (brc-tools owns staging/download + `visualize/grid.py`; WPS/`real.exe`/`wrf.exe`/run-Slurm stay in `brc-wrf`). NAM-only & GFS proven/merged; RAP blocked pre-`real.exe` (no layered soil); GEFS+NAM two-stream unproven. Cold-start SSOT: `docs/WRF-STAGING-STATE-PLAYBOOK.md`.
@@ -19,7 +20,8 @@ brc_tools/        installable package
   verify/         deterministic metrics (paired_scores, RMSE/bias/MAE)
   visualize/      planview + timeseries panels; grid.py (field/section plots — brc-wrf seam); figure-engine modules (surface/section/upperair/profile/domains/heatdeficit/deficitflux/basemap/style)
   download/       Synoptic obs script, push_data uploader, HRRR helpers
-  api/            external API clients: FlightAware, FR24, Perplexity, Mistral (shared _auth); soundings (IGRA2/Wyoming RAOB, auth-free)
+  api/            external API clients: FlightAware, FR24, Perplexity, Mistral (shared _auth); soundings (IGRA2/Wyoming RAOB) + aqs (EPA AQS AirData bulk), both auth-free
+  satellite/      MODIS context imagery (NASA CMR timing + GIBS corrected reflectance, cached, provenance sidecars)
   utils/          lookups, small helpers
 scripts/          operational scripts + case studies
 docs/             canonical project docs (see Doc map below)
@@ -87,6 +89,7 @@ load-bearing. The publication figure engine built on it (`wrf_figures.py` over
 | `BRC_TOOLS_HERBIE_CACHE` / `BRC_TOOLS_HRRR_CACHE` | NWP / HRRR GRIB cache dir override | optional |
 | `BRC_TOOLS_BASEMAP_DIR` | persistent Natural-Earth cache for figure map overlays (else `CARTOPY_DATA_DIR` → scratch); stage once via `scripts/fetch_basemap.dtn.slurm` | optional |
 | `BRC_TOOLS_MODIS_CACHE` | host-local NASA CMR metadata and GIBS corrected-reflectance PNG cache; supports offline rerendering | optional |
+| `BRC_TOOLS_AQS_CACHE` | EPA AQS AirData bulk-file cache (default `~/.cache/brc-tools/aqs`) with provenance sidecars | optional |
 | `BRC_TOOLS_LOCK_DIR` / `BRC_TOOLS_HTTP_IPV4_ONLY` | parallel-download lock dir / force IPv4 (CHPC DTN IPv6 workaround) | optional |
 
 All `api/` clients resolve keys via `brc_tools.api._auth.load_api_key(VAR)` — **env var

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ figures/          generated output (gitignored)
 - `docs/CHPC-REFERENCE.md` — CHPC account, partitions, salloc, cron (incl. HRRR upload)
 - `docs/WEBSITE-INTEGRATION.md` — BasinWX upload contract (endpoint, auth, dataTypes, schemas, fan-out)
 - `docs/ENVIRONMENT-SETUP.md` — conda/venv setup · `docs/CROSS-REPO-SYNC.md` — sibling-repo sync protocol
+- `docs/MODIS-CONTEXT-RENDERER.md` — portable NASA CMR/GIBS MODIS timing, rendering, cache, and provenance workflow
 - `docs/nwp/ROADMAP.md` — HRRR/RRFS strategy · `docs/nwp/NWP-SOURCE-MATRIX.md` — per-source download matrix
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — **WRF-staging cold-start SSOT**; detail in `docs/WRF-INPUT-STAGING.md`; two-stream draft `docs/WRF-GEFS-NAM-FIELD-MAP.md` (parked)
 - `docs/WRF-FIGURE-ENGINE.md` — dataset-agnostic figure engine (`brc_tools/nwp/wrf_figures.py` + `scripts/wrf_figures.py --config <case.toml>`). Per-study case TOMLs + the run/figure inventory live in the active study repo; SSOT index → `../latex-jrl-mjd-mdpiair-2026/verification/figures/archive-inventory.md`
@@ -85,6 +86,7 @@ load-bearing. The publication figure engine built on it (`wrf_figures.py` over
 | `MISTRAL_API_KEY` | Mistral client + `.mcp.json` MCP server | optional |
 | `BRC_TOOLS_HERBIE_CACHE` / `BRC_TOOLS_HRRR_CACHE` | NWP / HRRR GRIB cache dir override | optional |
 | `BRC_TOOLS_BASEMAP_DIR` | persistent Natural-Earth cache for figure map overlays (else `CARTOPY_DATA_DIR` → scratch); stage once via `scripts/fetch_basemap.dtn.slurm` | optional |
+| `BRC_TOOLS_MODIS_CACHE` | host-local NASA CMR metadata and GIBS corrected-reflectance PNG cache; supports offline rerendering | optional |
 | `BRC_TOOLS_LOCK_DIR` / `BRC_TOOLS_HTTP_IPV4_ONLY` | parallel-download lock dir / force IPv4 (CHPC DTN IPv6 workaround) | optional |
 
 All `api/` clients resolve keys via `brc_tools.api._auth.load_api_key(VAR)` — **env var

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ fig = plot_planview_evolution(ds, "wind_speed_10m", cmap="YlOrRd")
 
 See `scripts/` for full case study examples.
 
+Historical satellite context uses the portable NASA CMR/GIBS renderer documented in
+[`docs/MODIS-CONTEXT-RENDERER.md`](docs/MODIS-CONTEXT-RENDERER.md); it does not require
+WRF, Slurm, GDAL, or an Earthdata login.
+
 ## Claude Code skills
 
 Repo-local skills (slash commands) live in `.claude/skills/`:

--- a/brc_tools/api/aqs/__init__.py
+++ b/brc_tools/api/aqs/__init__.py
@@ -1,0 +1,21 @@
+"""EPA AQS AirData bulk-file client (anonymous, quality-assured AQ + met obs)."""
+
+from brc_tools.api.aqs.client import (
+    AQSSite,
+    PARAMS,
+    UINTA_BASIN_SITES,
+    airdata_url,
+    basin_site_ids,
+    download_airdata,
+    load_airdata,
+)
+
+__all__ = [
+    "AQSSite",
+    "PARAMS",
+    "UINTA_BASIN_SITES",
+    "airdata_url",
+    "basin_site_ids",
+    "download_airdata",
+    "load_airdata",
+]

--- a/brc_tools/api/aqs/client.py
+++ b/brc_tools/api/aqs/client.py
@@ -1,0 +1,277 @@
+"""EPA AQS "AirData" bulk-file client: quality-assured AQ + met observations.
+
+Mechanical API layer.  Downloads EPA's pre-generated annual AirData files
+(``https://aqs.epa.gov/aqsweb/airdata/``) and loads them filtered to sites,
+counties, a bbox, and/or a date window as a Polars frame.  The files are
+**anonymous** (no key, no registration) and are the citable, quality-assured
+record for regulatory and tribal monitors -- unlike Synoptic, which returns no
+ozone/PM for the Uinta Basin before ~2014.  Like ``api/soundings``, this source
+is open, so there is no ``_auth`` wiring.
+
+Scope notes
+-----------
+* One file = one parameter x one year x one cadence (``hourly``/``daily``),
+  covering the whole US (hourly ozone is ~66 MB zipped / ~2 GB CSV; the daily
+  file is ~5 MB).  Download once into the cache, filter locally.
+* **Do not recompute regulatory MDA8 from the hourly file** -- the ``daily``
+  file already carries EPA's own daily max 8-hour value per ``Pollutant
+  Standard`` row (``"1st Max Value"``), with the 75%-completeness and
+  day-assignment rules applied.  Use hourly for diurnal structure, daily for
+  MDA8 series.
+* EPA regenerates these files as QA flows in (the ``Last-Modified`` header
+  moves).  ``download_airdata`` stores a ``*.meta.json`` sidecar (URL,
+  retrieval time, Last-Modified, size) next to the zip so a study can record
+  exactly which vintage it used.
+* Tribal monitors (e.g. Ute Indian Tribe) appear under normal state/county
+  FIPS codes in these files, not under AQS "TT" tribal codes.
+
+Cache: ``BRC_TOOLS_AQS_CACHE`` env var, else ``~/.cache/brc-tools/aqs``.
+Times: hourly rows gain a tz-naive UTC ``valid_time`` (house convention);
+daily rows gain a ``date_local`` Date column.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+AIRDATA_BASE = "https://aqs.epa.gov/aqsweb/airdata"
+
+# AirData filename "parameter" segments.  Criteria gases use the AQS parameter
+# code; the met/derived files use literal words.
+PARAMS: dict[str, str] = {
+    "ozone": "44201",
+    "pm25_frm": "88101",       # FRM/FEM PM2.5
+    "pm25_nonfrm": "88502",    # non-FRM "Acceptable PM2.5" (tribal sites live here)
+    "pm10": "81102",
+    "no2": "42602",
+    "so2": "42401",
+    "co": "42101",
+    "wind": "WIND",
+    "temp": "TEMP",
+    "rh_dp": "RH_DP",
+    "pressure": "PRESS",
+}
+
+# Columns that trip Polars' integer inference partway through a file.
+_FLOAT_OVERRIDES = (
+    "MDL", "Uncertainty", "Sample Measurement", "1st Max Value",
+    "Arithmetic Mean", "Observation Percent", "AQI",
+)
+
+
+@dataclass(frozen=True)
+class AQSSite:
+    """One AQS monitor: zero-padded ``SS-CCC-NNNN`` id + identity notes."""
+
+    aqs_id: str        # e.g. "49-047-2003"
+    name: str
+    operator: str
+    lat: float
+    lon: float
+    note: str = ""
+
+
+# Uinta Basin area monitors verified to report ozone through winter 2012-13
+# (AQS site registry + annual_conc_by_monitor_2013; identities cross-checked
+# against coordinates, 2026-07-15).  Extend freely; ``load_airdata`` also
+# accepts raw ids for any site.
+UINTA_BASIN_SITES: dict[str, AQSSite] = {
+    "ouray": AQSSite("49-047-2003", "Ouray", "Ute Indian Tribe", 40.057, -109.688,
+                     "basin floor; also PM2.5 (88502); est. 2008-12"),
+    "redwash": AQSSite("49-047-2002", "Redwash", "Ute Indian Tribe", 40.206, -109.354,
+                       "Deadman's Bench; also PM2.5 (88502); est. 2008-12"),
+    "whiterocks": AQSSite("49-047-7022", "Whiterocks", "Ute Indian Tribe", 40.484, -109.907,
+                          "est. 1985"),
+    "myton": AQSSite("49-013-7011", "Myton", "Ute Indian Tribe", 40.217, -110.183,
+                     "est. 1985"),
+    "roosevelt": AQSSite("49-013-0002", "Roosevelt", "Utah DEQ", 40.294, -110.010,
+                         "also PM2.5 (88502, POC 3); est. 2011-10"),
+    "vernal": AQSSite("49-047-1003", "Vernal", "Utah DEQ", 40.452, -109.510,
+                      "est. 2012-01"),
+    "dinosaur_nm": AQSSite("49-047-1002", "Dinosaur NM - West Entrance", "NPS",
+                           40.437, -109.305, "Jensen, UT side; est. 2005-05"),
+    "little_mountain": AQSSite("49-047-0014", "Little Mountain", "USFS",
+                               40.538, -109.700, "north-rim control site; est. 2010-05"),
+    "fruitland": AQSSite("49-013-1001", "Fruitland", "Utah DEQ", 40.209, -110.841,
+                         "west-margin control; 2011-04 to 2014-03"),
+    "rangely": AQSSite("08-103-0006", "Rangely, Golf Course", "NPS", 40.087, -108.761,
+                       "CO side of basin; also PM2.5 (88101); est. 2010-08"),
+    "enefit": AQSSite("49-047-5632", "Enefit (Dragon Rd)", "Enefit (industry)",
+                      39.869, -109.097,
+                      "2012 to 2013-12; 2013 data flagged incomplete -- exclude by default"),
+}
+
+
+def basin_site_ids(*, include_flagged: bool = False) -> list[str]:
+    """AQS ids of the registry sites, dropping incomplete-flagged ones by default."""
+    return [s.aqs_id for k, s in UINTA_BASIN_SITES.items()
+            if include_flagged or k != "enefit"]
+
+
+def airdata_url(kind: str, param: str, year: int) -> str:
+    """URL of one pre-generated AirData file.
+
+    ``kind`` is ``"hourly"`` or ``"daily"``; ``param`` is a ``PARAMS`` key or a
+    raw AirData segment (e.g. ``"44201"``, ``"WIND"``).
+    """
+    if kind not in ("hourly", "daily"):
+        raise ValueError(f"kind must be 'hourly' or 'daily', got {kind!r}")
+    seg = PARAMS.get(param, param)
+    return f"{AIRDATA_BASE}/{kind}_{seg}_{year}.zip"
+
+
+def _cache_dir(cache_dir: Path | str | None = None) -> Path:
+    if cache_dir is not None:
+        p = Path(cache_dir)
+    else:
+        p = Path(os.getenv("BRC_TOOLS_AQS_CACHE",
+                           Path.home() / ".cache" / "brc-tools" / "aqs"))
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def download_airdata(kind: str, param: str, year: int, *,
+                     cache_dir: Path | str | None = None,
+                     force: bool = False) -> Path:
+    """Download (or reuse) one AirData zip; return its path.
+
+    Writes a ``<name>.zip.meta.json`` provenance sidecar (URL, retrieval time,
+    server ``Last-Modified``, size).  Raises ``requests.HTTPError`` on failure.
+    """
+    import requests
+
+    url = airdata_url(kind, param, year)
+    out = _cache_dir(cache_dir) / url.rsplit("/", 1)[1]
+    if out.exists() and not force:
+        return out
+
+    resp = requests.get(url, stream=True, timeout=120)
+    resp.raise_for_status()
+    part = out.with_suffix(out.suffix + ".part")
+    with open(part, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=1 << 20):
+            f.write(chunk)
+    part.rename(out)
+
+    meta = {
+        "url": url,
+        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+        "last_modified": resp.headers.get("Last-Modified"),
+        "content_length": out.stat().st_size,
+    }
+    with open(out.parent / (out.name + ".meta.json"), "w") as f:
+        json.dump(meta, f, indent=1)
+    return out
+
+
+def _extract_csv(zip_path: Path) -> Path:
+    """Extract the single CSV member next to the zip (idempotent)."""
+    import zipfile
+
+    with zipfile.ZipFile(zip_path) as zf:
+        members = [m for m in zf.namelist() if m.lower().endswith(".csv")]
+        if len(members) != 1:
+            raise ValueError(f"{zip_path.name}: expected one CSV member, got {members}")
+        target = zip_path.parent / members[0]
+        if not target.exists():
+            zf.extract(members[0], zip_path.parent)
+    return target
+
+
+def _read_header(csv_path: Path) -> list[str]:
+    with open(csv_path, newline="") as f:
+        return next(csv.reader(f))
+
+
+def _norm_code(value: str) -> str:
+    """Normalise an AQS code for comparison: '047' == '47', '0002' == '2'."""
+    s = str(value).strip()
+    stripped = s.lstrip("0")
+    return stripped if stripped else "0"
+
+
+def _site_tuple(site) -> tuple[str, str, str]:
+    """Accept '49-047-2003' or (49, 47, 2003); return normalised strings."""
+    if isinstance(site, str):
+        parts = site.split("-")
+        if len(parts) != 3:
+            raise ValueError(f"site id must be 'SS-CCC-NNNN', got {site!r}")
+    else:
+        parts = list(site)
+    return tuple(_norm_code(p) for p in parts)  # type: ignore[return-value]
+
+
+def _to_date(d) -> date:
+    if isinstance(d, datetime):
+        return d.date()
+    if isinstance(d, date):
+        return d
+    return date.fromisoformat(str(d))
+
+
+def load_airdata(source: Path | str, *,
+                 sites=None, bbox=None, start=None, end=None):
+    """Load one AirData zip/CSV filtered to sites/bbox/dates; return a Polars frame.
+
+    Parameters
+    ----------
+    source : Path or str
+        An AirData ``.zip`` (extracted on demand, cached) or ``.csv``.
+    sites : iterable, optional
+        AQS ids as ``"SS-CCC-NNNN"`` strings or ``(state, county, site)``
+        tuples.  Zero-padding-insensitive.
+    bbox : tuple, optional
+        ``(lon_min, lat_min, lon_max, lat_max)`` on the Latitude/Longitude
+        columns (same order as ``regions`` in ``lookups.toml``).
+    start, end : date/datetime/ISO str, optional
+        Inclusive window on ``Date GMT`` (hourly files) or ``Date Local``
+        (daily files).
+    """
+    import polars as pl
+
+    src = Path(source)
+    csv_path = _extract_csv(src) if src.suffix.lower() == ".zip" else src
+    header = _read_header(csv_path)
+    overrides = {c: pl.Float64 for c in _FLOAT_OVERRIDES if c in header}
+
+    lf = pl.scan_csv(csv_path, infer_schema_length=10000, schema_overrides=overrides)
+
+    hourly = "Date GMT" in header
+    date_col = "Date GMT" if hourly else "Date Local"
+    lf = lf.with_columns(pl.col(date_col).cast(pl.Utf8).str.to_date().alias("_date"))
+
+    if start is not None:
+        lf = lf.filter(pl.col("_date") >= _to_date(start))
+    if end is not None:
+        lf = lf.filter(pl.col("_date") <= _to_date(end))
+
+    if sites is not None:
+        norm = [_site_tuple(s) for s in sites]
+        code = {c: pl.col(c).cast(pl.Utf8).str.strip_chars_start("0").replace("", "0")
+                for c in ("State Code", "County Code", "Site Num")}
+        preds = [(code["State Code"] == st) & (code["County Code"] == co)
+                 & (code["Site Num"] == si) for st, co, si in norm]
+        combined = preds[0]
+        for p in preds[1:]:
+            combined = combined | p
+        lf = lf.filter(combined)
+
+    if bbox is not None:
+        lon_min, lat_min, lon_max, lat_max = bbox
+        lf = lf.filter(pl.col("Longitude").is_between(lon_min, lon_max)
+                       & pl.col("Latitude").is_between(lat_min, lat_max))
+
+    df = lf.collect()
+
+    if hourly:
+        df = df.with_columns(
+            (pl.col("Date GMT").cast(pl.Utf8) + " " + pl.col("Time GMT").cast(pl.Utf8))
+            .str.to_datetime("%Y-%m-%d %H:%M").alias("valid_time"))
+    else:
+        df = df.rename({"_date": "date_local"})
+    return df.drop("_date") if "_date" in df.columns else df

--- a/brc_tools/nwp/basinwx.py
+++ b/brc_tools/nwp/basinwx.py
@@ -23,7 +23,8 @@ DEFAULT_MAX_FXX = 18
 DEFAULT_RUN_COUNT = 3
 DEFAULT_STRIDE = 2
 DEFAULT_UPLOAD_BUCKET = "forecasts"
-DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parents[2] / "data" / "basinwx"
+# staging dir for generated JSON — runtime output stays out of the repo checkout
+DEFAULT_OUTPUT_DIR = Path("~/.cache/brc-tools/basinwx").expanduser()
 
 SURFACE_EXPORT_VARIABLES = [
     "temp_2m",

--- a/brc_tools/satellite/__init__.py
+++ b/brc_tools/satellite/__init__.py
@@ -1,0 +1,9 @@
+"""Satellite-imagery discovery and rendering helpers."""
+
+from brc_tools.satellite.modis import (
+    Granule,
+    find_closest_granule,
+    render_context,
+)
+
+__all__ = ["Granule", "find_closest_granule", "render_context"]

--- a/brc_tools/satellite/modis.py
+++ b/brc_tools/satellite/modis.py
@@ -1,0 +1,907 @@
+"""Portable MODIS context imagery from NASA CMR metadata and GIBS maps.
+
+The renderer deliberately does not download or decode the original HDF-EOS swath.
+NASA CMR identifies the Terra/Aqua granule whose footprint covers the center of the
+requested map, and NASA GIBS supplies a georeferenced daily corrected-reflectance PNG
+for that platform and date.  This keeps the runtime to ``requests`` + Matplotlib and
+works on a laptop, Akamai, or a CHPC host with the same small cache staged offline.
+
+The selected CMR granule provides the closest observation time.  GIBS itself has a
+date (not granule) time dimension, so the provenance sidecar records that distinction
+explicitly rather than claiming that the WMS response is a raw granule crop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import math
+import os
+import platform as runtime_platform
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+import requests
+
+CMR_GRANULES_URL = "https://cmr.earthdata.nasa.gov/search/granules.json"
+GIBS_WMS_URL = "https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi"
+CMR_COLLECTION_VERSION = "6.1"
+SCHEMA_VERSION = 1
+
+_PLATFORMS = {
+    "Terra": {"short_name": "MOD02HKM", "gibs_prefix": "MODIS_Terra"},
+    "Aqua": {"short_name": "MYD02HKM", "gibs_prefix": "MODIS_Aqua"},
+}
+
+_PRODUCTS = {
+    "true-color": {
+        "suffix": "CorrectedReflectance_TrueColor",
+        "title": "Corrected reflectance: true color",
+        "key": "true_color",
+        "guide": "snow and cloud both appear white",
+    },
+    "snow-false-color": {
+        "suffix": "CorrectedReflectance_Bands721",
+        "title": "Corrected reflectance: bands 7-2-1",
+        "key": "snow_false_color",
+        "guide": "snow/ice: cyan; most liquid cloud: white",
+    },
+}
+
+
+def _utc_text(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_utc(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp and return an aware UTC datetime."""
+
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include Z or an explicit UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def validate_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
+    """Return ``(west, south, east, north)`` after geographic validation."""
+
+    if len(bbox) != 4:
+        raise ValueError("bbox must contain west south east north")
+    west, south, east, north = (float(value) for value in bbox)
+    if not (-180.0 <= west < east <= 180.0):
+        raise ValueError("bbox longitudes must satisfy -180 <= west < east <= 180")
+    if not (-90.0 <= south < north <= 90.0):
+        raise ValueError("bbox latitudes must satisfy -90 <= south < north <= 90")
+    return west, south, east, north
+
+
+def default_cache_dir() -> Path:
+    """Return the host-neutral MODIS cache outside the source checkout."""
+
+    configured = os.environ.get("BRC_TOOLS_MODIS_CACHE")
+    if configured:
+        return Path(configured).expanduser()
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    root = Path(xdg).expanduser() if xdg else Path.home() / ".cache"
+    return root / "brc-tools" / "modis"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _json_token(payload: Mapping[str, Any], length: int = 16) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return _sha256(encoded)[:length]
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_bytes(content)
+    temporary.replace(path)
+
+
+def _prepared_url(url: str, params: Mapping[str, Any]) -> str:
+    prepared = requests.Request("GET", url, params=params).prepare().url
+    if prepared is None:  # pragma: no cover - requests always provides it here
+        raise RuntimeError(f"could not prepare request URL for {url}")
+    return prepared
+
+
+def _get_with_retry(
+    session: requests.Session,
+    url: str,
+    *,
+    params: Mapping[str, Any],
+    timeout: float,
+    attempts: int = 3,
+) -> requests.Response:
+    """GET with bounded exponential backoff at the external-API boundary."""
+
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            response = session.get(
+                url,
+                params=params,
+                timeout=timeout,
+                headers={"User-Agent": "brc-tools MODIS context renderer"},
+            )
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:
+            last_error = exc
+            if attempt + 1 < attempts:
+                time.sleep(0.5 * (2**attempt))
+    raise RuntimeError(f"request failed after {attempts} attempts: {url}") from last_error
+
+
+def _parse_cmr_time(value: str) -> datetime:
+    return parse_utc(value)
+
+
+def _link(entry: Mapping[str, Any], relation_suffix: str) -> str | None:
+    for item in entry.get("links", []):
+        if str(item.get("rel", "")).endswith(relation_suffix):
+            href = item.get("href")
+            if href:
+                return str(href)
+    return None
+
+
+@dataclass(frozen=True)
+class Granule:
+    """A center-covering MODIS Level-1B granule returned by NASA CMR."""
+
+    platform: str
+    short_name: str
+    collection_version: str
+    producer_granule_id: str
+    concept_id: str
+    collection_concept_id: str
+    time_start: datetime
+    time_end: datetime
+    day_night_flag: str
+    data_url: str | None = None
+    browse_url: str | None = None
+
+    @property
+    def midpoint(self) -> datetime:
+        return self.time_start + (self.time_end - self.time_start) / 2
+
+    def offset_seconds(self, target: datetime) -> float:
+        return (self.midpoint - target).total_seconds()
+
+    def to_dict(self, *, target: datetime | None = None) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "platform": self.platform,
+            "short_name": self.short_name,
+            "collection_version": self.collection_version,
+            "producer_granule_id": self.producer_granule_id,
+            "concept_id": self.concept_id,
+            "collection_concept_id": self.collection_concept_id,
+            "time_start_utc": _utc_text(self.time_start),
+            "time_end_utc": _utc_text(self.time_end),
+            "midpoint_utc": _utc_text(self.midpoint),
+            "day_night_flag": self.day_night_flag,
+            "data_url": self.data_url,
+            "browse_url": self.browse_url,
+        }
+        if target is not None:
+            result["midpoint_offset_seconds_from_target"] = self.offset_seconds(target)
+        return result
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> Granule:
+        return cls(
+            platform=str(payload["platform"]),
+            short_name=str(payload["short_name"]),
+            collection_version=str(payload["collection_version"]),
+            producer_granule_id=str(payload["producer_granule_id"]),
+            concept_id=str(payload["concept_id"]),
+            collection_concept_id=str(payload["collection_concept_id"]),
+            time_start=parse_utc(str(payload["time_start_utc"])),
+            time_end=parse_utc(str(payload["time_end_utc"])),
+            day_night_flag=str(payload.get("day_night_flag", "")),
+            data_url=payload.get("data_url"),
+            browse_url=payload.get("browse_url"),
+        )
+
+
+@dataclass(frozen=True)
+class Discovery:
+    """Closest granule plus every candidate considered in the same search."""
+
+    target: datetime
+    bbox: tuple[float, float, float, float]
+    center: tuple[float, float]
+    selected: Granule
+    candidates: tuple[Granule, ...]
+    query_urls: tuple[str, ...]
+    cache_file: Path
+
+
+@dataclass(frozen=True)
+class GibsImage:
+    """One cached NASA GIBS product and its exact request metadata."""
+
+    product: str
+    layer: str
+    date: str
+    width: int
+    height: int
+    request_url: str
+    cache_file: Path
+    sha256: str
+    content: bytes
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    """Paths and selected acquisition returned by :func:`render_context`."""
+
+    discovery: Discovery
+    images: tuple[GibsImage, ...]
+    outputs: Mapping[str, str]
+    provenance_path: Path
+
+
+def _granule_from_entry(entry: Mapping[str, Any], platform: str) -> Granule:
+    info = _PLATFORMS[platform]
+    return Granule(
+        platform=platform,
+        short_name=str(info["short_name"]),
+        collection_version=CMR_COLLECTION_VERSION,
+        producer_granule_id=str(entry["producer_granule_id"]),
+        concept_id=str(entry["id"]),
+        collection_concept_id=str(entry["collection_concept_id"]),
+        time_start=_parse_cmr_time(str(entry["time_start"])),
+        time_end=_parse_cmr_time(str(entry["time_end"])),
+        day_night_flag=str(entry.get("day_night_flag", "")),
+        data_url=_link(entry, "data#"),
+        browse_url=_link(entry, "browse#"),
+    )
+
+
+def _platform_names(platform: str) -> tuple[str, ...]:
+    normalised = platform.strip().lower()
+    if normalised == "auto":
+        return ("Terra", "Aqua")
+    if normalised == "terra":
+        return ("Terra",)
+    if normalised == "aqua":
+        return ("Aqua",)
+    raise ValueError("platform must be auto, terra, or aqua")
+
+
+def discover_granules(
+    target: datetime,
+    bbox: Sequence[float],
+    *,
+    platform: str = "auto",
+    search_hours: float = 12.0,
+    cache_dir: Path | str | None = None,
+    offline: bool = False,
+    refresh: bool = False,
+    session: requests.Session | None = None,
+    timeout: float = 30.0,
+) -> Discovery:
+    """Find the closest daytime Terra/Aqua granule covering the map center.
+
+    The CMR spatial query uses the center point, not merely a bounding-box
+    intersection.  This prevents an adjacent five-minute swath that clips one map edge
+    from winning the time comparison while missing the basin itself.
+    """
+
+    target = target.astimezone(timezone.utc)
+    checked_bbox = validate_bbox(bbox)
+    if search_hours <= 0:
+        raise ValueError("search_hours must be positive")
+    if offline and refresh:
+        raise ValueError("offline and refresh cannot be used together")
+
+    west, south, east, north = checked_bbox
+    center = ((west + east) / 2.0, (south + north) / 2.0)
+    platforms = _platform_names(platform)
+    start = target - timedelta(hours=search_hours)
+    end = target + timedelta(hours=search_hours)
+    query_descriptor = {
+        "schema_version": SCHEMA_VERSION,
+        "target_utc": _utc_text(target),
+        "bbox": list(checked_bbox),
+        "center": list(center),
+        "platforms": list(platforms),
+        "search_hours": search_hours,
+        "collection_version": CMR_COLLECTION_VERSION,
+    }
+    cache_root = Path(cache_dir).expanduser() if cache_dir else default_cache_dir()
+    cache_file = cache_root / f"cmr_granules_{_json_token(query_descriptor)}.json"
+
+    query_urls: list[str] = []
+    candidates: list[Granule] = []
+    if cache_file.exists() and not refresh:
+        cached = json.loads(cache_file.read_text(encoding="utf-8"))
+        query_urls = [str(url) for url in cached.get("query_urls", [])]
+        candidates = [Granule.from_dict(item) for item in cached.get("granules", [])]
+    else:
+        if offline:
+            raise FileNotFoundError(f"CMR cache is missing in offline mode: {cache_file}")
+        client = session or requests.Session()
+        for platform_name in platforms:
+            params = {
+                "short_name": _PLATFORMS[platform_name]["short_name"],
+                "version": CMR_COLLECTION_VERSION,
+                "point": f"{center[0]:.6f},{center[1]:.6f}",
+                "temporal": f"{_utc_text(start)},{_utc_text(end)}",
+                "page_size": 50,
+            }
+            query_urls.append(_prepared_url(CMR_GRANULES_URL, params))
+            response = _get_with_retry(
+                client, CMR_GRANULES_URL, params=params, timeout=timeout
+            )
+            payload = response.json()
+            for entry in payload.get("feed", {}).get("entry", []):
+                granule = _granule_from_entry(entry, platform_name)
+                if granule.day_night_flag.upper() in ("", "DAY"):
+                    candidates.append(granule)
+        cache_payload = {
+            "query": query_descriptor,
+            "query_urls": query_urls,
+            "granules": [item.to_dict(target=target) for item in candidates],
+        }
+        _atomic_write(
+            cache_file,
+            (json.dumps(cache_payload, indent=2, sort_keys=True) + "\n").encode(),
+        )
+
+    if not candidates:
+        raise RuntimeError(
+            "NASA CMR returned no daytime MODIS granule covering the map center "
+            f"within {search_hours:g} h of {_utc_text(target)}"
+        )
+    selected = min(
+        candidates,
+        key=lambda item: (
+            abs(item.offset_seconds(target)),
+            0 if item.platform == "Terra" else 1,
+            item.time_start,
+        ),
+    )
+    return Discovery(
+        target=target,
+        bbox=checked_bbox,
+        center=center,
+        selected=selected,
+        candidates=tuple(sorted(candidates, key=lambda item: item.time_start)),
+        query_urls=tuple(query_urls),
+        cache_file=cache_file,
+    )
+
+
+def find_closest_granule(
+    target: datetime,
+    bbox: Sequence[float],
+    **kwargs: Any,
+) -> Granule:
+    """Convenience wrapper returning only the selected granule."""
+
+    return discover_granules(target, bbox, **kwargs).selected
+
+
+def _product_layer(platform: str, product: str) -> str:
+    if product not in _PRODUCTS:
+        choices = ", ".join(sorted(_PRODUCTS))
+        raise ValueError(f"unknown product {product!r}; choose {choices}")
+    return f"{_PLATFORMS[platform]['gibs_prefix']}_{_PRODUCTS[product]['suffix']}"
+
+
+def _image_height(bbox: Sequence[float], width: int) -> int:
+    west, south, east, north = validate_bbox(bbox)
+    return max(64, round(width * (north - south) / (east - west)))
+
+
+def fetch_gibs_image(
+    granule: Granule,
+    bbox: Sequence[float],
+    product: str,
+    *,
+    width: int = 1600,
+    height: int | None = None,
+    cache_dir: Path | str | None = None,
+    offline: bool = False,
+    refresh: bool = False,
+    session: requests.Session | None = None,
+    timeout: float = 60.0,
+) -> GibsImage:
+    """Fetch one MODIS corrected-reflectance map from NASA GIBS WMS."""
+
+    checked_bbox = validate_bbox(bbox)
+    if not 64 <= width <= 4096:
+        raise ValueError("width must be between 64 and 4096 pixels")
+    resolved_height = height if height is not None else _image_height(checked_bbox, width)
+    if not 64 <= resolved_height <= 4096:
+        raise ValueError("height must be between 64 and 4096 pixels")
+    if offline and refresh:
+        raise ValueError("offline and refresh cannot be used together")
+
+    layer = _product_layer(granule.platform, product)
+    date = granule.midpoint.date().isoformat()
+    params = {
+        "SERVICE": "WMS",
+        "VERSION": "1.1.1",
+        "REQUEST": "GetMap",
+        "LAYERS": layer,
+        "STYLES": "default",
+        "SRS": "EPSG:4326",
+        "BBOX": ",".join(f"{value:.6f}" for value in checked_bbox),
+        "WIDTH": width,
+        "HEIGHT": resolved_height,
+        "FORMAT": "image/png",
+        "TRANSPARENT": "false",
+        "TIME": date,
+    }
+    request_url = _prepared_url(GIBS_WMS_URL, params)
+    descriptor = {
+        "schema_version": SCHEMA_VERSION,
+        "layer": layer,
+        "date": date,
+        "bbox": list(checked_bbox),
+        "width": width,
+        "height": resolved_height,
+    }
+    cache_root = Path(cache_dir).expanduser() if cache_dir else default_cache_dir()
+    cache_file = cache_root / f"gibs_{date}_{product}_{_json_token(descriptor)}.png"
+
+    if cache_file.exists() and not refresh:
+        content = cache_file.read_bytes()
+    else:
+        if offline:
+            raise FileNotFoundError(f"GIBS cache is missing in offline mode: {cache_file}")
+        client = session or requests.Session()
+        response = _get_with_retry(client, GIBS_WMS_URL, params=params, timeout=timeout)
+        content = response.content
+        request_url = getattr(response, "url", None) or request_url
+        if not content.startswith(b"\x89PNG\r\n\x1a\n"):
+            content_type = response.headers.get("Content-Type", "unknown")
+            raise RuntimeError(
+                f"GIBS returned {content_type}, not a PNG, for layer {layer}"
+            )
+        _atomic_write(cache_file, content)
+
+    if not content.startswith(b"\x89PNG\r\n\x1a\n"):
+        raise RuntimeError(f"cached GIBS file is not a PNG: {cache_file}")
+    return GibsImage(
+        product=product,
+        layer=layer,
+        date=date,
+        width=width,
+        height=resolved_height,
+        request_url=request_url,
+        cache_file=cache_file,
+        sha256=_sha256(content),
+        content=content,
+    )
+
+
+def _format_lon(value: float, _position: float) -> str:
+    suffix = "W" if value < 0 else "E"
+    return f"{abs(value):g}°{suffix}"
+
+
+def _format_lat(value: float, _position: float) -> str:
+    suffix = "S" if value < 0 else "N"
+    return f"{abs(value):g}°{suffix}"
+
+
+def _draw_markers(ax: Any, markers: Mapping[str, tuple[float, float]]) -> None:
+    for name, (lon, lat) in markers.items():
+        ax.scatter(
+            [lon],
+            [lat],
+            s=24,
+            marker="o",
+            facecolor="white",
+            edgecolor="black",
+            linewidth=0.8,
+            zorder=20,
+        )
+        ax.annotate(
+            name,
+            (lon, lat),
+            xytext=(4, 3),
+            textcoords="offset points",
+            fontsize=7,
+            color="black",
+            bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.7, "pad": 1},
+            zorder=21,
+        )
+
+
+def _render_figure(
+    discovery: Discovery,
+    images: Sequence[GibsImage],
+    output_stem: Path,
+    *,
+    formats: Sequence[str],
+    markers: Mapping[str, tuple[float, float]],
+    title: str | None,
+    dpi: int,
+) -> dict[str, str]:
+    import matplotlib.pyplot as plt
+    from matplotlib import image as mpimg
+    from matplotlib.ticker import FuncFormatter, MaxNLocator
+
+    count = len(images)
+    if not count:
+        raise ValueError("at least one GIBS image is required")
+    west, south, east, north = discovery.bbox
+    middle_lat = (south + north) / 2.0
+    panel_width = 5.6
+    fig, axes = plt.subplots(
+        1,
+        count,
+        figsize=(panel_width * count, 5.3),
+        squeeze=False,
+    )
+    axes_flat = axes.ravel()
+    heading = title or (
+        f"Uinta Basin MODIS context near {discovery.target:%H:%M UTC}, "
+        f"{discovery.target.day} {discovery.target:%B %Y}"
+    )
+    fig.suptitle(heading, fontsize=12.5, y=0.97)
+
+    for ax, asset in zip(axes_flat, images):
+        pixels = mpimg.imread(io.BytesIO(asset.content), format="png")
+        ax.imshow(
+            pixels,
+            extent=(west, east, south, north),
+            origin="upper",
+            interpolation="nearest",
+            zorder=0,
+        )
+        ax.set_xlim(west, east)
+        ax.set_ylim(south, north)
+        ax.set_aspect(1.0 / math.cos(math.radians(middle_lat)))
+        ax.set_title(_PRODUCTS[asset.product]["title"], fontsize=9.5)
+        ax.xaxis.set_major_locator(MaxNLocator(5))
+        ax.yaxis.set_major_locator(MaxNLocator(5))
+        ax.xaxis.set_major_formatter(FuncFormatter(_format_lon))
+        ax.yaxis.set_major_formatter(FuncFormatter(_format_lat))
+        ax.tick_params(labelsize=7)
+        ax.grid(color="white", alpha=0.35, linewidth=0.35)
+        _draw_markers(ax, markers)
+        ax.text(
+            0.015,
+            0.015,
+            _PRODUCTS[asset.product]["guide"],
+            transform=ax.transAxes,
+            fontsize=7,
+            ha="left",
+            va="bottom",
+            bbox={"facecolor": "white", "edgecolor": "0.3", "alpha": 0.78, "pad": 2},
+            zorder=30,
+        )
+    for ax in axes_flat[1:]:
+        ax.tick_params(labelleft=False)
+    axes_flat[0].set_ylabel("Latitude", fontsize=8)
+    for ax in axes_flat:
+        ax.set_xlabel("Longitude", fontsize=8)
+
+    selected = discovery.selected
+    offset_minutes = selected.offset_seconds(discovery.target) / 60.0
+    acquisition = (
+        f"Target {discovery.target:%H:%M UTC}; nearest center-covering {selected.platform} "
+        f"granule {selected.time_start:%H:%M}–{selected.time_end:%H:%M} UTC "
+        f"(midpoint {selected.midpoint:%H:%M:%S}, {offset_minutes:+.1f} min)."
+    )
+    source = (
+        f"NASA GIBS daily corrected reflectance; NASA CMR "
+        f"{selected.short_name} Collection {selected.collection_version}."
+    )
+    fig.text(0.5, 0.055, acquisition, ha="center", fontsize=7.3)
+    fig.text(0.5, 0.027, source, ha="center", fontsize=7.3)
+    fig.subplots_adjust(left=0.07, right=0.985, bottom=0.17, top=0.88, wspace=0.05)
+
+    output_stem.parent.mkdir(parents=True, exist_ok=True)
+    output_hashes: dict[str, str] = {}
+    for fmt in formats:
+        clean = fmt.lower().lstrip(".")
+        if clean not in ("png", "pdf"):
+            raise ValueError("formats must contain only png and/or pdf")
+        path = output_stem.with_suffix(f".{clean}")
+        metadata = {"Creator": "brc-tools MODIS context renderer", "Title": heading}
+        if clean == "png":
+            metadata["Software"] = metadata.pop("Creator")
+        fig.savefig(path, dpi=dpi, metadata=metadata)
+        output_hashes[path.name] = _sha256(path.read_bytes())
+    plt.close(fig)
+    return output_hashes
+
+
+def _module_sha256() -> str:
+    return _sha256(Path(__file__).read_bytes())
+
+
+def _runtime_versions() -> dict[str, str]:
+    packages = {}
+    for name in ("matplotlib", "numpy", "pillow", "requests"):
+        try:
+            packages[name] = version(name)
+        except PackageNotFoundError:  # pragma: no cover - core deps should be present
+            packages[name] = "not-installed"
+    return {
+        "python": runtime_platform.python_version(),
+        "implementation": runtime_platform.python_implementation(),
+        "system": runtime_platform.system(),
+        **packages,
+    }
+
+
+def _write_provenance(
+    discovery: Discovery,
+    images: Sequence[GibsImage],
+    outputs: Mapping[str, str],
+    output_stem: Path,
+    *,
+    width: int,
+    height: int | None,
+    dpi: int,
+    markers: Mapping[str, tuple[float, float]],
+    title: str | None,
+) -> Path:
+    selected = discovery.selected
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": _utc_text(datetime.now(timezone.utc)),
+        "target_utc": _utc_text(discovery.target),
+        "selection_rule": (
+            "minimum absolute difference between target and midpoint of daytime "
+            "Terra/Aqua MOD02HKM/MYD02HKM v6.1 granules covering bbox center"
+        ),
+        "bbox_west_south_east_north": list(discovery.bbox),
+        "query_point_lon_lat": list(discovery.center),
+        "selected_granule": selected.to_dict(target=discovery.target),
+        "candidate_granules": [
+            item.to_dict(target=discovery.target) for item in discovery.candidates
+        ],
+        "cmr": {
+            "endpoint": CMR_GRANULES_URL,
+            "query_urls": list(discovery.query_urls),
+            "cache_file": discovery.cache_file.name,
+        },
+        "gibs": {
+            "endpoint": GIBS_WMS_URL,
+            "time_dimension": "calendar date; not a granule-specific timestamp",
+            "images": [
+                {
+                    "product": item.product,
+                    "layer": item.layer,
+                    "date": item.date,
+                    "width_pixels": item.width,
+                    "height_pixels": item.height,
+                    "request_url": item.request_url,
+                    "cache_file": item.cache_file.name,
+                    "sha256": item.sha256,
+                }
+                for item in images
+            ],
+        },
+        "rendering": {
+            "module": "brc_tools.satellite.modis",
+            "module_sha256": _module_sha256(),
+            "runtime_versions": _runtime_versions(),
+            "requested_width_pixels": width,
+            "requested_height_pixels": height,
+            "resolved_width_pixels": images[0].width,
+            "resolved_height_pixels": images[0].height,
+            "dpi": dpi,
+            "title": title,
+            "markers": {
+                name: {"lon": lon, "lat": lat}
+                for name, (lon, lat) in markers.items()
+            },
+            "outputs": dict(outputs),
+        },
+        "interpretation": {
+            "true_color": "snow and cloud can both appear white",
+            "bands_7_2_1": (
+                "snow and ice usually appear cyan; most liquid cloud appears white; "
+                "ice cloud can also appear cyan"
+            ),
+        },
+        "source_documentation": [
+            "https://nasa-gibs.github.io/gibs-api-docs/python-usage/",
+            "https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html",
+            (
+                "https://doi.org/10.5067/MODIS/MOD02HKM.061"
+                if selected.platform == "Terra"
+                else "https://doi.org/10.5067/MODIS/MYD02HKM.061"
+            ),
+        ],
+    }
+    path = output_stem.with_suffix(".provenance.json")
+    _atomic_write(path, (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode())
+    return path
+
+
+def render_context(
+    target: datetime,
+    bbox: Sequence[float],
+    output_stem: Path | str,
+    *,
+    products: Sequence[str] = ("true-color", "snow-false-color"),
+    platform: str = "auto",
+    search_hours: float = 12.0,
+    width: int = 1600,
+    height: int | None = None,
+    formats: Sequence[str] = ("png", "pdf"),
+    markers: Mapping[str, tuple[float, float]] | None = None,
+    title: str | None = None,
+    dpi: int = 300,
+    cache_dir: Path | str | None = None,
+    offline: bool = False,
+    refresh: bool = False,
+    session: requests.Session | None = None,
+    timeout: float = 60.0,
+) -> RenderResult:
+    """Discover, fetch, render, and provenance a MODIS context figure."""
+
+    if not products:
+        raise ValueError("products cannot be empty")
+    if len(set(products)) != len(products):
+        raise ValueError("products cannot contain duplicates")
+    if dpi <= 0:
+        raise ValueError("dpi must be positive")
+    stem = Path(output_stem).expanduser()
+    if stem.suffix.lower() in (".png", ".pdf"):
+        stem = stem.with_suffix("")
+
+    discovery = discover_granules(
+        target,
+        bbox,
+        platform=platform,
+        search_hours=search_hours,
+        cache_dir=cache_dir,
+        offline=offline,
+        refresh=refresh,
+        session=session,
+        timeout=timeout,
+    )
+    images = tuple(
+        fetch_gibs_image(
+            discovery.selected,
+            discovery.bbox,
+            product,
+            width=width,
+            height=height,
+            cache_dir=cache_dir,
+            offline=offline,
+            refresh=refresh,
+            session=session,
+            timeout=timeout,
+        )
+        for product in products
+    )
+    outputs = _render_figure(
+        discovery,
+        images,
+        stem,
+        formats=formats,
+        markers=markers or {},
+        title=title,
+        dpi=dpi,
+    )
+    provenance = _write_provenance(
+        discovery,
+        images,
+        outputs,
+        stem,
+        width=width,
+        height=height,
+        dpi=dpi,
+        markers=markers or {},
+        title=title,
+    )
+    return RenderResult(
+        discovery=discovery,
+        images=images,
+        outputs=outputs,
+        provenance_path=provenance,
+    )
+
+
+def _parse_csv(value: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _parse_marker(value: str) -> tuple[str, tuple[float, float]]:
+    try:
+        name, lon, lat = (item.strip() for item in value.split(",", 2))
+        return name, (float(lon), float(lat))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("marker must be NAME,LON,LAT") from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render host-neutral MODIS context imagery using NASA CMR timing and "
+            "NASA GIBS corrected-reflectance maps."
+        )
+    )
+    parser.add_argument("--target", required=True, help="UTC ISO timestamp, e.g. 2013-02-02T18:00:00Z")
+    parser.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        required=True,
+        metavar=("WEST", "SOUTH", "EAST", "NORTH"),
+    )
+    parser.add_argument("--output", required=True, help="output stem (outside brc-tools checkout)")
+    parser.add_argument(
+        "--products",
+        default="true-color,snow-false-color",
+        help="comma-separated: true-color,snow-false-color",
+    )
+    parser.add_argument("--platform", default="auto", choices=("auto", "terra", "aqua"))
+    parser.add_argument("--search-hours", type=float, default=12.0)
+    parser.add_argument("--width", type=int, default=1600)
+    parser.add_argument("--height", type=int)
+    parser.add_argument("--formats", default="png,pdf", help="comma-separated: png,pdf")
+    parser.add_argument("--dpi", type=int, default=300)
+    parser.add_argument("--cache-dir", help="default: $BRC_TOOLS_MODIS_CACHE or ~/.cache/brc-tools/modis")
+    parser.add_argument("--offline", action="store_true", help="read only from an already staged cache")
+    parser.add_argument("--refresh", action="store_true", help="replace matching CMR/GIBS cache entries")
+    parser.add_argument("--marker", action="append", default=[], type=_parse_marker, metavar="NAME,LON,LAT")
+    parser.add_argument("--title")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    products = _parse_csv(args.products)
+    formats = _parse_csv(args.formats)
+    markers = dict(args.marker)
+    result = render_context(
+        parse_utc(args.target),
+        args.bbox,
+        args.output,
+        products=products,
+        platform=args.platform,
+        search_hours=args.search_hours,
+        width=args.width,
+        height=args.height,
+        formats=formats,
+        markers=markers,
+        title=args.title,
+        dpi=args.dpi,
+        cache_dir=args.cache_dir,
+        offline=args.offline,
+        refresh=args.refresh,
+    )
+    selected = result.discovery.selected
+    offset = selected.offset_seconds(result.discovery.target) / 60.0
+    print(
+        f"selected {selected.platform} {selected.producer_granule_id} "
+        f"({selected.time_start:%H:%M}-{selected.time_end:%H:%M} UTC; "
+        f"midpoint offset {offset:+.1f} min)"
+    )
+    for name, digest in result.outputs.items():
+        print(f"wrote {Path(args.output).expanduser().parent / name} sha256={digest}")
+    print(f"wrote {result.provenance_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/API-CLIENTS.md
+++ b/docs/API-CLIENTS.md
@@ -14,6 +14,7 @@ credential-holding class.
 | Perplexity Sonar | `brc_tools.api.perplexity` | `PerplexityClient` | `PERPLEXITY_API_KEY` | Pay-per-request; OpenAI-compatible |
 | Mistral | `brc_tools.api.mistral` | `MistralClient` | `MISTRAL_API_KEY` | Usage-based |
 | Radiosondes | `brc_tools.api.soundings` | `fetch_sounding()` | — (open) | IGRA2 (NCEI) + Univ. Wyoming; auth-free |
+| EPA AQS AirData | `brc_tools.api.aqs` | `download_airdata()` / `load_airdata()` | — (open) | bulk CSV zips, cached with provenance sidecars |
 
 ## Install
 
@@ -83,6 +84,31 @@ df = fetch_sounding("KSLC", datetime(2013, 2, 2, 12))   # provider="auto"
   through, so any raw IGRA2 (`USM00072572`) or Wyoming (`72572`) id works too.
 - **Consumers**: `scripts/fetch_soundings.py` (writes the offline parquet
   cache the figure batch reads) and `brc_tools.visualize.profile.LiveSounding`.
+
+## EPA AQS AirData — `brc_tools.api.aqs`
+
+Auth-free, function-based. Downloads EPA's quality-assured AirData bulk
+files (annual CSV zips) — the citable AQ record for study periods where
+Synoptic has nothing (e.g. winter 2012-13 basin ozone):
+
+```python
+from brc_tools.api.aqs import download_airdata, load_airdata, basin_site_ids
+
+zp = download_airdata("daily", "ozone", 2013)      # ~5 MB, cached
+df = load_airdata(zp, sites=basin_site_ids(),
+                  start="2013-01-01", end="2013-02-28")   # polars frame
+```
+
+- **Cache**: `BRC_TOOLS_AQS_CACHE` (default `~/.cache/brc-tools/aqs`), with a
+  `*.meta.json` provenance sidecar (URL, retrieval time, server Last-Modified).
+  Record that vintage in studies — EPA regenerates files as QA updates land.
+- **MDA8**: use `"1st Max Value"` on `Pollutant Standard == "Ozone 8-hour 2015"`
+  rows from the daily files; **don't recompute from hourly** (EPA already
+  applied completeness/day-assignment rules).
+- **`UINTA_BASIN_SITES`** registers the basin tribal/regulatory monitors;
+  `basin_site_ids()` gives their ids for filtering.
+- **Consumers**: `scripts/fetch_aqs_airdata.py` (CLI); walk-through in
+  `docs/walkthroughs/aqs.md`.
 
 ## MCP servers
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -177,6 +177,29 @@ See `CASE-STUDY-GUIDE.md` for usage patterns.
 
 ---
 
+## brc_tools.satellite.modis — MODIS context imagery
+
+```python
+from datetime import datetime, timezone
+
+from brc_tools.satellite.modis import render_context
+
+result = render_context(
+    datetime(2013, 2, 2, 18, tzinfo=timezone.utc),
+    (-111.8, 39.2, -108.2, 41.5),
+    "/tmp/modis_uinta_20130202_near1800",
+)
+```
+
+`discover_granules()` queries NASA CMR for daytime Terra/Aqua Level-1B swaths
+covering the map center and selects the midpoint closest to the requested UTC time.
+`fetch_gibs_image()` retrieves a georeferenced daily corrected-reflectance PNG.
+`render_context()` orchestrates discovery, cached fetches, PNG/PDF rendering, and a
+JSON provenance sidecar. See `MODIS-CONTEXT-RENDERER.md` for the CLI, cache, offline,
+and interpretation contracts.
+
+---
+
 ## Configuration: lookups.toml
 
 Central registry at `brc_tools/nwp/lookups.toml`. Defines:

--- a/docs/CHPC-REFERENCE.md
+++ b/docs/CHPC-REFERENCE.md
@@ -67,7 +67,9 @@ export DATA_UPLOAD_API_KEY="<32-char-hex>"   # required for BasinWX uploads
 
 CLI: `scripts/export_hrrr_surface_layers.py`. Use `--server-url` to
 override the config-file URL — this is what lets dev/prod cron entries
-diverge.
+diverge. JSON stages to `~/.cache/brc-tools/basinwx` by default
+(`--output-dir` to override) before upload — it no longer lands in the
+repo checkout's `data/basinwx/`.
 
 ```bash
 30 * * * * source ~/.bashrc && conda activate brc-tools && cd ~/gits/brc-tools && \

--- a/docs/MODIS-CONTEXT-RENDERER.md
+++ b/docs/MODIS-CONTEXT-RENDERER.md
@@ -1,0 +1,125 @@
+# MODIS context renderer
+
+`brc_tools.satellite.modis` makes a provenance-bearing MODIS context figure without
+requiring WRF, Slurm, GDAL, rasterio, SatPy, or an Earthdata login.
+
+It has two separate NASA inputs:
+
+1. **CMR granule metadata** identifies the daytime Terra/Aqua swath covering the center
+   of the requested map whose temporal midpoint is closest to a target UTC timestamp.
+2. **GIBS WMS imagery** supplies a georeferenced corrected-reflectance PNG for that
+   platform and calendar date.
+
+That distinction is important: GIBS has a daily time dimension, not a granule-time
+selector. The JSON provenance sidecar therefore records both the exact closest CMR
+granule and the exact daily GIBS request without describing the map as a raw swath crop.
+
+## Portable dependency contract
+
+The online path needs only dependencies already in the `brc-tools` core environment:
+
+- `requests` for CMR and GIBS;
+- Matplotlib + Pillow for PNG decoding and PNG/PDF output;
+- NumPy, already required by Matplotlib and `brc-tools`.
+
+The implementation intentionally avoids the heavier HDF-EOS/geolocation route. This
+makes the same command usable on Akamai, a workstation, a CHPC login/DTN node, or an
+offline CHPC compute node after its small cache has been staged. The WRF optional extra
+(`netCDF4`, MetPy, and Siphon) is unrelated and is not required.
+
+Use the curated environment when creating a new installation:
+
+```bash
+mamba env create -f environment.yml
+conda activate brc-tools-2026
+pip install -e . --no-deps
+```
+
+An existing environment is sufficient if this succeeds:
+
+```bash
+python -c "import matplotlib, numpy, requests; print('MODIS renderer dependencies OK')"
+```
+
+## Uinta Basin example
+
+Set output and cache locations outside the `brc-tools` checkout:
+
+```bash
+export BRC_TOOLS_MODIS_CACHE="$HOME/.cache/brc-tools/modis"
+export BRC_TOOLS_OUTPUT="$HOME/brc-tools-output"
+mkdir -p "$BRC_TOOLS_OUTPUT"
+
+python scripts/render_modis_context.py \
+  --target 2013-02-02T18:00:00Z \
+  --bbox -111.8 39.2 -108.2 41.5 \
+  --output "$BRC_TOOLS_OUTPUT/modis_uinta_20130202_near1800" \
+  --products true-color,snow-false-color \
+  --marker Vernal,-109.529,40.455 \
+  --marker Ouray,-109.677,40.090
+```
+
+The command queries both platforms by default. For this target and map center, CMR
+selects Terra granule `MOD02HKM.A2013033.1815.061.2017294153853.hdf`, acquired
+18:15--18:20 UTC. Its 18:17:30 midpoint is 17.5 minutes after the 18:00 UTC target;
+the closest Aqua granule is 19:55--20:00 UTC.
+
+Outputs are:
+
+- `*.png` and `*.pdf`: the rendered figure;
+- `*.provenance.json`: target, selection rule, every candidate granule, exact CMR and
+  GIBS URLs, layer names, cache basenames, renderer-source hash, Python/dependency
+  versions, and output hashes;
+- cached raw GIBS PNG and CMR response under `$BRC_TOOLS_MODIS_CACHE`.
+
+Use `--products snow-false-color` for a single snow-discrimination panel. The default
+comparison is useful for inspection: true color is intuitive, while MODIS bands 7-2-1
+normally show snow and ice as cyan and most liquid cloud as white. Ice cloud can also
+appear cyan, so the image is snow context rather than a validated fractional-snow map.
+
+## Offline and cross-host use
+
+Run the command once on any host with outbound HTTPS. A later render with the identical
+target, bounding box, dimensions, platform choice, and products can be made without
+network access:
+
+```bash
+python scripts/render_modis_context.py \
+  --target 2013-02-02T18:00:00Z \
+  --bbox -111.8 39.2 -108.2 41.5 \
+  --output "$BRC_TOOLS_OUTPUT/modis_uinta_20130202_near1800" \
+  --cache-dir "$BRC_TOOLS_MODIS_CACHE" \
+  --offline
+```
+
+If a CHPC compute node cannot reach NASA, populate the cache on a login or DTN node and
+make that cache path visible to the compute job. Do not pass an Akamai path to CHPC or a
+CHPC path to Akamai; either rerun the small download on each networked host or copy the
+cache explicitly.
+
+The map canvas has fixed pixel dimensions for a given panel count and DPI. Font and
+FreeType builds can still change text antialiasing by a few pixels across environments;
+the sidecar records runtime versions and the exact output hash, while the cached NASA
+raster has its own independent hash.
+
+`--refresh` replaces matching cache entries. It cannot be combined with `--offline`.
+
+## Scientific and technical limits
+
+- The CMR query requires the granule footprint to cover the **map center**. This avoids
+  choosing an adjacent five-minute swath that merely touches the bounding box.
+- GIBS corrected reflectance is a browse/visualization product. It is suitable for
+  episode context, not quantitative snow-cover retrieval or model validation.
+- The 7-2-1 panel distinguishes most cloud from snow better than true color, but ice
+  cloud may still be cyan.
+- For quantitative snow fraction, cloud masks, or a strict raw-granule crop, add a
+  separate authenticated Level-1B/Level-2 pipeline and its heavier geolocation stack;
+  do not silently reinterpret this renderer.
+
+## Primary documentation
+
+- [NASA GIBS Python/WMS example](https://nasa-gibs.github.io/gibs-api-docs/python-usage/)
+- [NASA GIBS access basics](https://nasa-gibs.github.io/gibs-api-docs/access-basics/)
+- [NASA CMR search API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html)
+- [MOD02HKM Collection 6.1](https://doi.org/10.5067/MODIS/MOD02HKM.061)
+- [NASA explanation of MODIS 7-2-1 snow/cloud colors](https://modis.gsfc.nasa.gov/gallery/individual.php?db_date=2026-05-11)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Project documentation. Topical files only — agent context lives in
 
 - **walkthroughs/** — plain-language per-tool guides + GLOSSARY (start here if new).
 - **API-REFERENCE.md** — full module / function reference.
-- **API-CLIENTS.md** — external API wrappers (FlightAware, FR24, Perplexity, Mistral) under `brc_tools/api/`.
+- **API-CLIENTS.md** — external API wrappers (FlightAware, FR24, Perplexity, Mistral, soundings, EPA AQS AirData) under `brc_tools/api/`.
 - **CASE-STUDY-GUIDE.md** — how to write a case-study script.
 - **CHPC-REFERENCE.md** — canonical CHPC account, partitions, salloc, cron (incl. HRRR upload).
 - **CROSS-REPO-SYNC.md** — protocol for keeping the four sibling repos aligned.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ Project documentation. Topical files only — agent context lives in
 - **CROSS-REPO-SYNC.md** — protocol for keeping the four sibling repos aligned.
 - **WEBSITE-INTEGRATION.md** — BasinWX upload contract (endpoint, auth, dataTypes, schemas).
 - **ENVIRONMENT-SETUP.md** — venv/conda setup for new team members.
+- **MODIS-CONTEXT-RENDERER.md** — host-neutral NASA CMR/GIBS MODIS timing,
+  rendering, caching, and provenance workflow.
 - **WRF-INPUT-STAGING.md** — WRF/WPS GRIB staging reference: status, proof evidence, and microtasks (the playbook is the handoff).
 - **WRF-STAGING-STATE-PLAYBOOK.md** — the single WRF cold-start handoff + state packet (start here for the WRF lane).
 - **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (parked, not proven).

--- a/docs/walkthroughs/aqs.md
+++ b/docs/walkthroughs/aqs.md
@@ -1,0 +1,51 @@
+# Pull EPA air-quality observations (AQS AirData) — walk-through
+
+**What / why:** Get quality-assured ozone, PM2.5, and other monitor data from
+EPA's AirData bulk files — including the Uinta Basin tribal/regulatory sites.
+This is the citable AQ record for study periods where Synoptic has nothing
+(e.g. winter 2012-13 basin ozone).
+
+**Needs:** internet only — anonymous, no key.  Hourly ozone is ~66 MB zipped
+per year; daily is ~5 MB.  Files cache in `BRC_TOOLS_AQS_CACHE`
+(default `~/.cache/brc-tools/aqs`) with a `*.meta.json` provenance sidecar
+(URL, retrieval time, server Last-Modified) — record that vintage in studies,
+because EPA regenerates these files as QA updates land.
+
+## Get the winter-ozone episode record
+
+```python
+from brc_tools.api.aqs import download_airdata, load_airdata, basin_site_ids
+
+zp = download_airdata("daily", "ozone", 2013)      # ~5 MB, cached
+df = load_airdata(zp, sites=basin_site_ids(),
+                  start="2013-01-01", end="2013-02-28")
+```
+
+**Produces:** a Polars frame of EPA's daily summaries — `"1st Max Value"` on
+the `Pollutant Standard == "Ozone 8-hour 2015"` rows is the regulatory MDA8
+(ppm). **Don't recompute MDA8 from hourly data**; EPA already applied the
+completeness and day-assignment rules. Hourly files (`kind="hourly"`) gain a
+tz-naive UTC `valid_time` column for diurnal structure.
+
+## CLI
+
+```bash
+python scripts/fetch_aqs_airdata.py --param ozone --kind daily --years 2013 \
+    --basin --start 2013-01-01 --end 2013-02-28 \
+    --out /scratch/general/vast/$USER/aqs_ozone_daily.parquet
+```
+
+`--basin` uses the verified Uinta Basin registry (`UINTA_BASIN_SITES`): Ouray,
+Redwash, Whiterocks, Myton (Ute Indian Tribe — filed under normal FIPS codes,
+not "TT" tribal codes), Roosevelt, Vernal, Fruitland (UDAQ), Dinosaur NM and
+Rangely (NPS), Little Mountain (USFS). The Enefit industry monitor is excluded
+by default (2013 data flagged incomplete). PM2.5 at the tribal sites lives in
+`--param pm25_nonfrm` (88502), not the FRM 88101 file.
+
+**Not here:** USU study sites (Horsepool, Seven Sisters, Pariette Draw) are
+not in AQS — use the BRC public Box downloads
+(usu.edu/binghamresearch/data-access.php) or the NOAA CSL UBWOS archive
+(PI-contact data policy).
+
+**See also:** signatures → [`API-REFERENCE.md`](../API-REFERENCE.md) ·
+Synoptic weather obs → [obs.md](obs.md) · radiosondes → `brc_tools.api.soundings`

--- a/scripts/fetch_aqs_airdata.py
+++ b/scripts/fetch_aqs_airdata.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Fetch EPA AQS AirData bulk observations into a parquet cache.
+
+Anonymous download (no key).  One AirData file covers one parameter x one year
+x one cadence for the whole US; this script downloads what it needs into
+``BRC_TOOLS_AQS_CACHE`` (default ``~/.cache/brc-tools/aqs``), filters to the
+requested sites/bbox/dates, and writes one tidy parquet.
+
+The Uinta Basin winter-ozone monitor registry (Ute Tribe, UDAQ, NPS, USFS
+sites verified for winter 2012-13) ships in ``brc_tools.api.aqs`` -- pass
+``--basin`` to use it.  Use ``--kind daily`` for EPA's own regulatory MDA8
+("1st Max Value" per pollutant-standard row); do not recompute MDA8 from
+hourly data.
+
+Examples (pelican2013 episode context):
+    python scripts/fetch_aqs_airdata.py --param ozone --kind daily \
+        --years 2013 --basin --start 2013-01-01 --end 2013-02-28 \
+        --out /scratch/general/vast/$USER/aqs_ozone_daily_janfeb2013.parquet
+
+    python scripts/fetch_aqs_airdata.py --param ozone --kind hourly \
+        --years 2012 2013 --basin --start 2012-12-01 --end 2013-02-28 \
+        --out /scratch/general/vast/$USER/aqs_ozone_hourly_win1213.parquet
+
+    python scripts/fetch_aqs_airdata.py --param pm25_nonfrm --kind hourly \
+        --years 2013 --sites 49-047-2003 49-047-2002 49-013-0002 \
+        --start 2013-01-01 --end 2013-02-28 \
+        --out /scratch/general/vast/$USER/aqs_pm25_hourly_janfeb2013.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--param", default="ozone",
+                    help="PARAMS key (ozone, pm25_nonfrm, wind, ...) or raw AirData code")
+    ap.add_argument("--kind", default="daily", choices=["hourly", "daily"])
+    ap.add_argument("--years", nargs="+", type=int, required=True)
+    ap.add_argument("--sites", nargs="*", default=None,
+                    help="AQS ids like 49-047-2003 (zero-padding optional)")
+    ap.add_argument("--basin", action="store_true",
+                    help="use the verified Uinta Basin winter-ozone site registry")
+    ap.add_argument("--include-flagged", action="store_true",
+                    help="with --basin, keep sites flagged incomplete (Enefit)")
+    ap.add_argument("--bbox", nargs=4, type=float, default=None,
+                    metavar=("LON_MIN", "LAT_MIN", "LON_MAX", "LAT_MAX"))
+    ap.add_argument("--start", default=None, help="inclusive ISO date")
+    ap.add_argument("--end", default=None, help="inclusive ISO date")
+    ap.add_argument("--out", required=True, help="output parquet path (outside the repo)")
+    args = ap.parse_args()
+
+    import polars as pl
+
+    from brc_tools.api.aqs import basin_site_ids, download_airdata, load_airdata
+
+    sites = list(args.sites or [])
+    if args.basin:
+        sites += basin_site_ids(include_flagged=args.include_flagged)
+    sites = sites or None
+
+    frames = []
+    for year in args.years:
+        zp = download_airdata(args.kind, args.param, year)
+        print(f"cached {zp.name} ({zp.stat().st_size/1e6:.1f} MB)")
+        df = load_airdata(zp, sites=sites, bbox=args.bbox,
+                          start=args.start, end=args.end)
+        print(f"  {year}: {df.height} rows after filters")
+        frames.append(df)
+
+    df = pl.concat(frames, how="vertical_relaxed")
+    if not df.height:
+        raise SystemExit("no rows matched the filters")
+
+    keys = ["State Code", "County Code", "Site Num"]
+    time_col = "valid_time" if "valid_time" in df.columns else "date_local"
+    cov = (df.group_by(keys)
+             .agg(pl.len().alias("n"),
+                  pl.col(time_col).min().alias("first"),
+                  pl.col(time_col).max().alias("last"))
+             .sort(keys))
+    with pl.Config(tbl_rows=40):
+        print(cov)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(out)
+    print(f"wrote {df.height} rows -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_modis_context.py
+++ b/scripts/render_modis_context.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""CLI wrapper for :mod:`brc_tools.satellite.modis`.
+
+See ``docs/MODIS-CONTEXT-RENDERER.md`` for the online and staged-cache workflows.
+"""
+
+from brc_tools.satellite.modis import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_aqs_client.py
+++ b/tests/test_aqs_client.py
@@ -1,0 +1,118 @@
+"""Offline tests for brc_tools.api.aqs (no network).
+
+Loading/filtering runs against synthetic AirData CSVs built in tmp_path, so
+what is under test is the local layer -- site-id normalisation (zero-padding),
+hourly/daily time handling, bbox and date filters, zip extraction, and the
+basin site registry -- not EPA's servers.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from datetime import date, datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from brc_tools.api import aqs
+from brc_tools.api.aqs import client as ac
+
+BASIN_BBOX = (-110.9, 39.4, -108.7, 41.1)  # lookups.toml uinta_basin, east edge widened to Rangely CO
+
+
+def test_basin_registry_wellformed():
+    ids = [s.aqs_id for s in aqs.UINTA_BASIN_SITES.values()]
+    assert len(ids) == len(set(ids))
+    for site in aqs.UINTA_BASIN_SITES.values():
+        state, county, num = site.aqs_id.split("-")
+        assert state.isdigit() and county.isdigit() and num.isdigit()
+        assert BASIN_BBOX[0] <= site.lon <= BASIN_BBOX[2]
+        assert BASIN_BBOX[1] <= site.lat <= BASIN_BBOX[3]
+    # The incomplete-flagged industry monitor stays out unless asked for.
+    default = aqs.basin_site_ids()
+    assert aqs.UINTA_BASIN_SITES["enefit"].aqs_id not in default
+    assert aqs.UINTA_BASIN_SITES["ouray"].aqs_id in default
+    assert len(aqs.basin_site_ids(include_flagged=True)) == len(default) + 1
+
+
+def test_airdata_url_forms():
+    assert (aqs.airdata_url("daily", "ozone", 2013)
+            == "https://aqs.epa.gov/aqsweb/airdata/daily_44201_2013.zip")
+    # Raw segments pass through (met files use words, gases use codes).
+    assert aqs.airdata_url("hourly", "WIND", 2020).endswith("hourly_WIND_2020.zip")
+    assert aqs.airdata_url("hourly", "88502", 2013).endswith("hourly_88502_2013.zip")
+    with pytest.raises(ValueError):
+        aqs.airdata_url("weekly", "ozone", 2013)
+
+
+HOURLY_HEADER = ('"State Code","County Code","Site Num","Latitude","Longitude",'
+                 '"Date GMT","Time GMT","Sample Measurement","MDL","Units of Measure"')
+
+HOURLY_ROWS = [
+    '"49","047","2003",40.057,-109.688,"2013-02-02","12:00",0.060,1,"Parts per million"',
+    '"49","047","2003",40.057,-109.688,"2013-02-02","13:00",0.056,0.1,"Parts per million"',
+    '"8","103","6",40.087,-108.761,"2013-02-02","12:00",0.028,0.1,"Parts per million"',
+    '"49","013","0002",40.294,-110.010,"2013-03-15","12:00",0.055,0.1,"Parts per million"',
+]
+
+
+def _write_hourly_csv(path: Path) -> Path:
+    path.write_text("\n".join([HOURLY_HEADER, *HOURLY_ROWS]) + "\n")
+    return path
+
+
+def test_load_hourly_site_and_date_filters(tmp_path):
+    csv_path = _write_hourly_csv(tmp_path / "hourly_44201_2013.csv")
+    df = aqs.load_airdata(
+        csv_path,
+        sites=["49-047-2003", (8, 103, 6)],   # padded string + bare tuple
+        start="2013-02-01", end=date(2013, 2, 28),
+    )
+    # The March Roosevelt row is outside the window; both id styles match.
+    assert df.height == 3
+    assert df["valid_time"].dtype == pl.Datetime
+    assert df["valid_time"].min() == datetime(2013, 2, 2, 12)
+    # MDL mixes int-looking and float rows; the override keeps it float.
+    assert df["MDL"].dtype == pl.Float64
+
+
+def test_load_hourly_from_zip_and_bbox(tmp_path):
+    csv_path = _write_hourly_csv(tmp_path / "hourly_44201_2013.csv")
+    zp = tmp_path / "hourly_44201_2013.zip"
+    with zipfile.ZipFile(zp, "w") as zf:
+        zf.write(csv_path, csv_path.name)
+    csv_path.unlink()  # force the zip-extraction path
+
+    df = aqs.load_airdata(zp, bbox=(-110.9, 39.4, -109.0, 41.1))
+    # The Rangely row (-108.761) falls outside this bbox.
+    assert df.height == 3
+    assert (zp.parent / "hourly_44201_2013.csv").exists()
+
+
+def test_load_daily_dates_and_standard_rows(tmp_path):
+    header = ('"State Code","County Code","Site Num","Latitude","Longitude",'
+              '"Date Local","Pollutant Standard","1st Max Value"')
+    rows = [
+        '"49","047","2003",40.057,-109.688,"2013-02-02","Ozone 8-hour 2015",0.095',
+        '"49","047","2003",40.057,-109.688,"2013-02-06","Ozone 8-hour 2015",0.137',
+        '"49","047","2003",40.057,-109.688,"2013-02-02","Ozone 1-hour 1979",0.102',
+    ]
+    p = tmp_path / "daily_44201_2013.csv"
+    p.write_text("\n".join([header, *rows]) + "\n")
+
+    df = aqs.load_airdata(p, sites=["49-47-2003"])   # unpadded county accepted
+    assert df.height == 3
+    assert df["date_local"].dtype == pl.Date
+    mda8 = df.filter(pl.col("Pollutant Standard") == "Ozone 8-hour 2015")
+    assert mda8["1st Max Value"].max() == pytest.approx(0.137)
+
+
+def test_norm_code_and_site_tuple():
+    assert ac._norm_code("047") == "47"
+    assert ac._norm_code("0002") == "2"
+    assert ac._norm_code("0") == "0"
+    assert ac._site_tuple("49-013-0002") == ("49", "13", "2")
+    assert ac._site_tuple((8, 103, 6)) == ("8", "103", "6")
+    with pytest.raises(ValueError):
+        ac._site_tuple("49/013/0002")

--- a/tests/test_modis_satellite.py
+++ b/tests/test_modis_satellite.py
@@ -1,0 +1,191 @@
+"""Offline tests for the NASA CMR + GIBS MODIS context renderer."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from datetime import datetime, timezone
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from brc_tools.satellite import modis
+
+TARGET = datetime(2013, 2, 2, 18, tzinfo=timezone.utc)
+BBOX = (-111.8, 39.2, -108.2, 41.5)
+
+
+def _entry(platform: str) -> dict:
+    if platform == "Terra":
+        short = "MOD02HKM"
+        granule_id = "MOD02HKM.A2013033.1815.061.example.hdf"
+        start, end = "2013-02-02T18:15:00.000Z", "2013-02-02T18:20:00.000Z"
+        concept, collection = "G-TERRA", "C-TERRA"
+    else:
+        short = "MYD02HKM"
+        granule_id = "MYD02HKM.A2013033.1955.061.example.hdf"
+        start, end = "2013-02-02T19:55:00.000Z", "2013-02-02T20:00:00.000Z"
+        concept, collection = "G-AQUA", "C-AQUA"
+    return {
+        "producer_granule_id": granule_id,
+        "time_start": start,
+        "time_end": end,
+        "id": concept,
+        "collection_concept_id": collection,
+        "day_night_flag": "DAY",
+        "links": [
+            {
+                "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+                "href": f"https://example.test/{short}.hdf",
+            },
+            {
+                "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+                "href": f"https://example.test/{short}.jpg",
+            },
+        ],
+    }
+
+
+def _png_bytes() -> bytes:
+    buffer = io.BytesIO()
+    pixels = np.zeros((12, 18, 3), dtype=float)
+    pixels[..., 0] = np.linspace(0.1, 0.9, 18)
+    pixels[..., 1] = 0.65
+    pixels[..., 2] = np.linspace(0.9, 0.2, 18)
+    plt.imsave(buffer, pixels, format="png")
+    return buffer.getvalue()
+
+
+class FakeResponse:
+    def __init__(self, *, payload=None, content=b"", url="https://example.test"):
+        self._payload = payload
+        self.content = content
+        self.url = url
+        self.headers = {"Content-Type": "image/png" if content else "application/json"}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+        self.png = _png_bytes()
+
+    def get(self, url, *, params, timeout, headers):
+        self.calls.append((url, dict(params), timeout, dict(headers)))
+        if url == modis.CMR_GRANULES_URL:
+            platform = "Terra" if params["short_name"] == "MOD02HKM" else "Aqua"
+            return FakeResponse(payload={"feed": {"entry": [_entry(platform)]}})
+        if url == modis.GIBS_WMS_URL:
+            request_url = modis._prepared_url(url, params)
+            return FakeResponse(content=self.png, url=request_url)
+        raise AssertionError(f"unexpected URL {url}")
+
+
+class NoNetworkSession:
+    def get(self, *args, **kwargs):
+        raise AssertionError("network should not be used in offline mode")
+
+
+def test_parse_utc_requires_explicit_zone():
+    assert modis.parse_utc("2013-02-02T18:00:00Z") == TARGET
+    assert modis.parse_utc("2013-02-02T11:00:00-07:00") == TARGET
+    with pytest.raises(ValueError, match="explicit UTC offset"):
+        modis.parse_utc("2013-02-02T18:00:00")
+
+
+def test_discovery_selects_closest_midpoint_and_reuses_cache(tmp_path):
+    session = FakeSession()
+    result = modis.discover_granules(
+        TARGET, BBOX, cache_dir=tmp_path, session=session
+    )
+
+    assert result.selected.platform == "Terra"
+    assert result.selected.time_start.hour == 18
+    assert result.selected.offset_seconds(TARGET) == 17.5 * 60
+    assert result.center == pytest.approx((-110.0, 40.35))
+    assert len(result.candidates) == 2
+    assert len(session.calls) == 2
+    assert result.cache_file.exists()
+
+    cached = modis.discover_granules(
+        TARGET,
+        BBOX,
+        cache_dir=tmp_path,
+        offline=True,
+        session=NoNetworkSession(),
+    )
+    assert cached.selected.producer_granule_id == result.selected.producer_granule_id
+
+
+def test_gibs_product_layer_and_offline_cache(tmp_path):
+    session = FakeSession()
+    granule = modis._granule_from_entry(_entry("Terra"), "Terra")
+    image = modis.fetch_gibs_image(
+        granule,
+        BBOX,
+        "snow-false-color",
+        width=720,
+        cache_dir=tmp_path,
+        session=session,
+    )
+
+    assert image.layer == "MODIS_Terra_CorrectedReflectance_Bands721"
+    assert image.date == "2013-02-02"
+    assert image.sha256 == hashlib.sha256(image.content).hexdigest()
+    assert image.cache_file.exists()
+    gibs_call = session.calls[-1]
+    assert gibs_call[1]["SRS"] == "EPSG:4326"
+    assert gibs_call[1]["TIME"] == "2013-02-02"
+
+    cached = modis.fetch_gibs_image(
+        granule,
+        BBOX,
+        "snow-false-color",
+        width=720,
+        cache_dir=tmp_path,
+        offline=True,
+        session=NoNetworkSession(),
+    )
+    assert cached.sha256 == image.sha256
+
+
+def test_render_context_writes_figure_and_provenance(tmp_path, monkeypatch):
+    monkeypatch.setenv("MPLCONFIGDIR", str(tmp_path / "mpl"))
+    session = FakeSession()
+    stem = tmp_path / "output" / "modis_uinta_20130202_1800"
+    result = modis.render_context(
+        TARGET,
+        BBOX,
+        stem,
+        width=720,
+        products=("true-color", "snow-false-color"),
+        formats=("png", "pdf"),
+        markers={"Vernal": (-109.529, 40.455)},
+        cache_dir=tmp_path / "cache",
+        session=session,
+    )
+
+    assert stem.with_suffix(".png").exists()
+    assert stem.with_suffix(".pdf").exists()
+    assert result.provenance_path.exists()
+    provenance = json.loads(result.provenance_path.read_text())
+    assert provenance["selected_granule"]["platform"] == "Terra"
+    assert provenance["selected_granule"]["midpoint_utc"] == "2013-02-02T18:17:30Z"
+    assert provenance["gibs"]["time_dimension"].startswith("calendar date")
+    assert provenance["rendering"]["resolved_height_pixels"] == 460
+    assert provenance["rendering"]["markers"]["Vernal"]["lon"] == -109.529
+    assert provenance["rendering"]["runtime_versions"]["requests"]
+    assert set(provenance["rendering"]["outputs"]) == {
+        "modis_uinta_20130202_1800.png",
+        "modis_uinta_20130202_1800.pdf",
+    }


### PR DESCRIPTION
Bundles the two feature branches from the last 24 h plus housekeeping, on top of the freshly merged X8 batch (#37):

- **MODIS context renderer** (`brc_tools/satellite/modis.py`, `scripts/render_modis_context.py`) — portable NASA CMR granule timing + GIBS corrected-reflectance rendering with cache/provenance sidecars; doc: `docs/MODIS-CONTEXT-RENDERER.md`.
- **EPA AQS AirData client** (`brc_tools/api/aqs/`, `scripts/fetch_aqs_airdata.py`) — anonymous bulk-file pulls of the citable AQ record (Uinta Basin monitor registry included); walkthrough: `docs/walkthroughs/aqs.md`.
- **Housekeeping**: BasinWX HRRR export now stages JSON to `~/.cache/brc-tools/basinwx` instead of the repo checkout (convention fix; `data/basinwx/` gitignored); CLAUDE.md/docs updated to cover `satellite/`, the AQS client, and the pelican2013 manuscript-support focus.

Tests: full suite on this branch — **201 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)