### PR TITLE
feat(nwp): general lat/lon cross-section + county overlay + terrain alias

### DIFF
--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -309,6 +309,28 @@ lon = -109.357
 elevation_m = 1475
 reference_stid = "SPMU1"
 
+# ── Orientation landmarks (towns/cities for map + section labels; not obs sites) ──
+
+[waypoints.salt_lake_city]
+lat = 40.760
+lon = -111.890
+elevation_m = 1288
+
+[waypoints.heber]
+lat = 40.507
+lon = -111.413
+elevation_m = 1706
+
+[waypoints.rangely]
+lat = 40.087
+lon = -108.796
+elevation_m = 1621
+
+[waypoints.bonanza]
+lat = 40.017
+lon = -109.179
+elevation_m = 1596
+
 [waypoint_groups]
 us40_basin = ["fruitland", "duchesne", "myton", "roosevelt", "vernal"]
 basin_full = ["fruitland", "duchesne", "myton", "roosevelt", "vernal", "dinosaur"]
@@ -321,6 +343,12 @@ us40_dense = [
     "duchesne", "little_red_fox", "myton", "roosevelt",
     "fort_duchesne", "east_lapoint", "asphalt_ridge", "vernal",
     "split_mountain", "dinosaur",
+]
+# West-to-east orientation landmarks (Salt Lake Valley -> Rangely), for cross-section
+# transects and map context.
+basin_landmarks = [
+    "salt_lake_city", "heber", "strawberry", "duchesne", "roosevelt",
+    "myton", "ouray", "vernal", "dinosaur", "bonanza", "rangely",
 ]
 
 # ── Aliases: surface / near-surface ─────────────────────────────────────────
@@ -440,6 +468,15 @@ synoptic_name = "pressure"
 hrrr = "PRES:surface"
 gefs = "PRES:surface"
 rrfs = "PRES:surface"
+
+[aliases.terrain_height]
+description   = "Model terrain height (surface geopotential height / orography)"
+units         = "gpm"
+output_var    = "terrain_height"
+[aliases.terrain_height.search]
+hrrr = "HGT:surface"
+gefs = "HGT:surface"
+rrfs = "HGT:surface"
 
 [aliases.precip_1hr]
 description   = "1-hour accumulated precipitation"

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -176,6 +176,12 @@ ne = [41.7, -107.8]
 sw = [40.20, -111.50]
 ne = [40.55, -108.80]
 
+# S->N band on the Vernal meridian: Book Cliffs -> basin floor -> Uinta north slope
+# -> Flaming Gorge -> Wyoming line. Pairs with [waypoint_groups] basin_ns_landmarks.
+[regions.uinta_basin_xsection_sn]
+sw = [39.85, -109.70]
+ne = [41.15, -109.35]
+
 [regions.utah]
 sw = [36.9, -114.2]
 ne = [42.1, -108.9]
@@ -321,6 +327,26 @@ lat = 40.507
 lon = -111.413
 elevation_m = 1706
 
+[waypoints.manila]
+lat = 40.992
+lon = -109.721
+elevation_m = 1941
+
+[waypoints.dutch_john]
+lat = 40.930
+lon = -109.404
+elevation_m = 1967
+
+[waypoints.flaming_gorge_dam]
+lat = 40.914
+lon = -109.421
+elevation_m = 1843          # crest elevation
+
+[waypoints.marsh_peak]
+lat = 40.711
+lon = -109.828
+elevation_m = 3718          # highest summit of the eastern Uintas
+
 [waypoints.rangely]
 lat = 40.087
 lon = -108.796
@@ -349,6 +375,15 @@ us40_dense = [
 basin_landmarks = [
     "salt_lake_city", "heber", "strawberry", "duchesne", "roosevelt",
     "myton", "ouray", "vernal", "dinosaur", "bonanza", "rangely",
+]
+# South-to-north orientation landmarks along the Vernal meridian (~-109.53): basin
+# floor -> Vernal -> Uinta north slope -> Flaming Gorge -> the Wyoming line. All lie
+# within ~20 km of that line, so they project cleanly onto an S->N cross-section.
+# Marsh Peak is deliberately EXCLUDED (it sits ~25 km west, off this transect), and so
+# is flaming_gorge_dam -- it is ~2 km from Dutch John, so on a section the two labels
+# collide and the longer name wins the space for no extra context.
+basin_ns_landmarks = [
+    "ouray", "vernal", "dutch_john", "manila",
 ]
 
 # ── Aliases: surface / near-surface ─────────────────────────────────────────
@@ -483,10 +518,26 @@ description   = "1-hour accumulated precipitation"
 units         = "kg m-2"
 output_var    = "precip_1hr"
 synoptic_name = "precip_accum_one_hour"
+# HRRR sfc carries TWO APCP messages from f02 on -- the run total ("0-N hour acc")
+# and the hourly bucket ("N-1-N hour acc") -- so a bare "APCP:surface" matches both
+# and Herbie returns a LIST of datasets. Anchor on the hourly bucket: at f01 that is
+# "0-1 hour acc" (the only message); from f02 it is the non-zero-start bucket.
+# NB absent at f00 (analysis has no accumulation window) -- if you need a value at
+# every lead, fetch `precip_total` and difference it along time instead.
 [aliases.precip_1hr.search]
-hrrr = "APCP:surface"
+hrrr = 'APCP:surface:0-1 hour acc|APCP:surface:(?!0-)\d+-\d+ hour acc'
 gefs = "APCP:surface:0-1 hour acc"
 rrfs = "APCP:surface:0-1 hour acc"
+
+[aliases.precip_total]
+description   = "Run-total accumulated precipitation (init -> valid time)"
+units         = "kg m-2"
+output_var    = "precip_total"
+# Anchored on the "0-N" bucket so it never collides with the hourly one above.
+# Present at every lead, including f00 (labelled "0-0 day acc fcst", all zeros).
+[aliases.precip_total.search]
+hrrr = 'APCP:surface:0-\d+ (hour|day) acc'
+rrfs = 'APCP:surface:0-\d+ (hour|day) acc'
 
 [aliases.snowfall_1hr]
 description   = "1-hour accumulated snowfall"
@@ -574,6 +625,139 @@ output_var  = "pbl_height"
 hrrr = "HPBL:surface"
 rrfs = "HPBL:surface"
 
+# ── Aliases: convective / thunderstorm diagnostics (HRRR sfc, RRFS prslev) ──
+# Confirmed against the live HRRR sfc inventory (170 messages, 2026-07-15 18Z).
+# The hourly-max fields (MXUPHL / WIND / MAXREF / HAIL / MAXUVV) are labelled
+# "N-1-N hour max fcst" from f01 on and "0-0 day max fcst" at f00, so the searches
+# below deliberately stop before the window token and still match at every lead.
+
+[aliases.refl_comp]
+description = "Simulated composite reflectivity (column maximum)"
+units       = "dBZ"
+output_var  = "refl_comp"
+[aliases.refl_comp.search]
+hrrr = "REFC:entire atmosphere"
+rrfs = "REFC:entire atmosphere"
+
+[aliases.refl_1km]
+description = "Simulated reflectivity 1 km above ground"
+units       = "dBZ"
+output_var  = "refl_1km"
+[aliases.refl_1km.search]
+hrrr = "REFD:1000 m above ground"
+rrfs = "REFD:1000 m above ground"
+
+[aliases.echo_top]
+description = "Radar echo top height"
+units       = "m"
+output_var  = "echo_top"
+[aliases.echo_top.search]
+hrrr = "RETOP:cloud top"
+rrfs = "RETOP:cloud top"
+
+[aliases.prate]
+description = "Instantaneous surface precipitation rate"
+units       = "kg m-2 s-1"
+output_var  = "prate"
+[aliases.prate.search]
+hrrr = "PRATE:surface"
+rrfs = "PRATE:surface"
+
+[aliases.pwat]
+description = "Precipitable water (whole column)"
+units       = "kg m-2"
+output_var  = "pwat"
+[aliases.pwat.search]
+hrrr = "PWAT:entire atmosphere"
+rrfs = "PWAT:entire atmosphere"
+
+[aliases.cape_ml]
+description = "Mixed-layer CAPE (lowest 180 hPa mean parcel)"
+units       = "J kg-1"
+output_var  = "cape_ml"
+[aliases.cape_ml.search]
+hrrr = "CAPE:180-0 mb above ground"
+rrfs = "CAPE:180-0 mb above ground"
+
+[aliases.cin_ml]
+description = "Mixed-layer CIN (lowest 180 hPa mean parcel)"
+units       = "J kg-1"
+output_var  = "cin_ml"
+[aliases.cin_ml.search]
+hrrr = "CIN:180-0 mb above ground"
+rrfs = "CIN:180-0 mb above ground"
+
+[aliases.cape_mu]
+description = "Most-unstable CAPE (lowest 255 hPa)"
+units       = "J kg-1"
+output_var  = "cape_mu"
+[aliases.cape_mu.search]
+hrrr = "CAPE:255-0 mb above ground"
+rrfs = "CAPE:255-0 mb above ground"
+
+[aliases.srh_0to3km]
+description = "0-3 km storm-relative helicity"
+units       = "m2 s-2"
+output_var  = "srh_0to3km"
+[aliases.srh_0to3km.search]
+hrrr = "HLCY:3000-0 m above ground"
+rrfs = "HLCY:3000-0 m above ground"
+
+[aliases.srh_0to1km]
+description = "0-1 km storm-relative helicity"
+units       = "m2 s-2"
+output_var  = "srh_0to1km"
+[aliases.srh_0to1km.search]
+hrrr = "HLCY:1000-0 m above ground"
+rrfs = "HLCY:1000-0 m above ground"
+
+[aliases.shear_u_0to6km]
+description = "0-6 km bulk shear, eastward component"
+units       = "m s-1"
+output_var  = "shear_u_0to6km"
+[aliases.shear_u_0to6km.search]
+hrrr = "VUCSH:0-6000 m above ground"
+rrfs = "VUCSH:0-6000 m above ground"
+
+[aliases.shear_v_0to6km]
+description = "0-6 km bulk shear, northward component"
+units       = "m s-1"
+output_var  = "shear_v_0to6km"
+[aliases.shear_v_0to6km.search]
+hrrr = "VVCSH:0-6000 m above ground"
+rrfs = "VVCSH:0-6000 m above ground"
+
+[aliases.uphel_max_2to5km]
+description = "Hourly-maximum 2-5 km updraft helicity"
+units       = "m2 s-2"
+output_var  = "uphel_max_2to5km"
+[aliases.uphel_max_2to5km.search]
+hrrr = "MXUPHL:5000-2000 m above ground"
+rrfs = "MXUPHL:5000-2000 m above ground"
+
+[aliases.updraft_max]
+description = "Hourly-maximum updraft vertical velocity (100-1000 hPa AGL)"
+units       = "m s-1"
+output_var  = "updraft_max"
+[aliases.updraft_max.search]
+hrrr = "MAXUVV:100-1000 mb above ground"
+rrfs = "MAXUVV:100-1000 mb above ground"
+
+[aliases.wind_max_10m]
+description = "Hourly-maximum 10 m wind speed (distinct from the GUST diagnostic)"
+units       = "m s-1"
+output_var  = "wind_max_10m"
+[aliases.wind_max_10m.search]
+hrrr = "WIND:10 m above ground"
+rrfs = "WIND:10 m above ground"
+
+[aliases.lightning]
+description = "Lightning flash rate"
+units       = "flashes km-2 s-1"
+output_var  = "lightning"
+[aliases.lightning.search]
+hrrr = "LTNG:entire atmosphere"
+
 # ── Aliases: pressure levels (3-D, caller passes levels=[...]) ──────────────
 # {level} placeholder is substituted per requested level (hPa).
 
@@ -650,6 +834,19 @@ rrfs = "RH:{level} mb"
 [aliases.rh_pl.products]
 hrrr = "prs"
 gefs = "atmos.25"
+rrfs = "prslev"
+
+[aliases.dewpoint_pl]
+description    = "Dewpoint on pressure levels"
+units          = "K"
+output_var     = "dewpoint"
+vertical_kind  = "pressure"
+default_levels = [1000, 925, 850, 700, 500]
+[aliases.dewpoint_pl.search]
+hrrr = "DPT:{level} mb"
+rrfs = "DPT:{level} mb"
+[aliases.dewpoint_pl.products]
+hrrr = "prs"
 rrfs = "prslev"
 
 [aliases.omega_pl]

--- a/brc_tools/nwp/section.py
+++ b/brc_tools/nwp/section.py
@@ -1,0 +1,176 @@
+"""Vertical cross-section along an arbitrary lat/lon line from gridded NWP data.
+
+The NWP analogue of :func:`brc_tools.nwp.wrf_output.build_section`. Where the WRF
+path cuts a grid-aligned row/column of native eta levels, this samples the nearest
+model column along an arbitrary A->B geographic line and stacks per-level pressure
+fields into a height-distance curtain.
+
+It consumes an :class:`xarray.Dataset` whose pressure-level fields are *flat
+per-level variables* named ``{prefix}_{level}`` -- exactly what
+:meth:`brc_tools.nwp.NWPSource.fetch` returns for HRRR/RRFS when ``levels=[...]``
+is passed (e.g. ``wind_u_850``, ``height_700``) -- plus a 2-D terrain field, and
+hands plain numpy arrays to the ``visualize`` renderers. Like the rest of the
+package it keeps the physics here and the Matplotlib rendering in ``visualize``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+_RD = 287.05  # J kg-1 K-1 (dry air gas constant)
+_G = 9.80665  # m s-2
+_P0 = 100000.0  # Pa (reference pressure)
+_RCP = 0.2854  # R_d / c_p
+
+
+@dataclass
+class NWPSection:
+    """A vertical cross-section sampled along a geographic line.
+
+    Distances are km from terminus A; heights are geometric (m ASL) from the
+    model's per-level geopotential height, so the curtain is drawn at true
+    altitude. Fields are NaN below the terrain surface.
+    """
+
+    distance_km: np.ndarray  # (n,)
+    lon_line: np.ndarray  # (n,) -180..180
+    lat_line: np.ndarray  # (n,)
+    height2d: np.ndarray  # (nz, n) m ASL
+    speed2d: np.ndarray  # (nz, n) horizontal wind speed, m/s
+    theta2d: np.ndarray  # (nz, n) potential temperature, K
+    temp2d: np.ndarray  # (nz, n) temperature, K
+    along2d: np.ndarray  # (nz, n) along-transect horizontal wind (+ toward B), m/s
+    w2d: np.ndarray  # (nz, n) vertical velocity, m/s
+    terrain1d: np.ndarray  # (n,) m ASL
+    pressure_hpa: np.ndarray  # (nz,)
+    termini: tuple[str, str] = ("A", "B")
+    orientation: str = "EW"  # accent-colour key for the crosssection helpers
+
+
+def _lon180(lon) -> np.ndarray:
+    """Wrap longitudes from 0..360 to -180..180 (HRRR grids are 0..360)."""
+    lon = np.asarray(lon, dtype=float)
+    return np.where(lon > 180.0, lon - 360.0, lon)
+
+
+def _sample_line(start, end, n):
+    """Sample ``n`` points on the straight A->B line; return lon, lat, distance(km).
+
+    ``start``/``end`` are ``(lat, lon)``. Distance uses a local equirectangular
+    metric -- accurate to well under a percent over a single basin-scale transect.
+    """
+    lat0, lon0 = float(start[0]), float(start[1])
+    lat1, lon1 = float(end[0]), float(end[1])
+    frac = np.linspace(0.0, 1.0, n)
+    lon_line = lon0 + frac * (lon1 - lon0)
+    lat_line = lat0 + frac * (lat1 - lat0)
+    coslat = np.cos(np.deg2rad(0.5 * (lat0 + lat1)))
+    dx = (lon_line - lon0) * 111.320 * coslat
+    dy = (lat_line - lat0) * 110.574
+    return lon_line, lat_line, np.hypot(dx, dy)
+
+
+def extract_nwp_section(
+    ds,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    levels,
+    *,
+    n_points: int = 220,
+    prefixes: tuple[str, str, str, str, str] = ("wind_u", "wind_v", "temp", "height", "omega"),
+    terrain_var: str = "terrain_height",
+    time_index: int = 0,
+    termini: tuple[str, str] = ("A", "B"),
+) -> NWPSection:
+    """Extract a cross-section from ``start`` to ``end`` (each ``(lat, lon)``).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Must hold 2-D ``latitude``/``longitude`` coords and flat per-level vars
+        ``{u}_{lev}``, ``{v}_{lev}``, ``{temp}_{lev}``, ``{height}_{lev}`` (and
+        optionally ``{omega}_{lev}``) for each level in *levels*, plus *terrain_var*.
+    levels : sequence of int
+        Pressure levels (hPa) present as per-level variables, ordered as desired
+        (bottom-up recommended, e.g. ``[1000, 975, ..., 700]``).
+    n_points : int
+        Samples along the line (nearest model column per sample).
+    prefixes : (u, v, temp, height, omega)
+        Variable-name prefixes; ``{prefix}_{level}`` is looked up per level.
+    terrain_var : str
+        2-D terrain-height variable name (m ASL) for the terrain floor + masking.
+
+    Returns
+    -------
+    NWPSection
+    """
+    from scipy.spatial import cKDTree
+
+    lat2d = np.asarray(ds["latitude"].values, dtype=float)
+    lon2d = _lon180(ds["longitude"].values)
+    tree = cKDTree(np.column_stack([lat2d.ravel(), lon2d.ravel()]))
+
+    lon_line, lat_line, dist = _sample_line(start, end, n_points)
+    _, flat = tree.query(np.column_stack([lat_line, lon_line]))
+    flat = np.asarray(flat, dtype=int)
+
+    def gather(varname: str) -> np.ndarray:
+        da = ds[varname]
+        if "time" in da.dims:
+            da = da.isel(time=time_index)
+        return np.asarray(da.values, dtype=float).ravel()[flat]
+
+    levels = [int(x) for x in levels]
+    nz, n = len(levels), n_points
+    up, vp, tp, hp, op = prefixes
+    u = np.full((nz, n), np.nan)
+    v = np.full((nz, n), np.nan)
+    temp = np.full((nz, n), np.nan)
+    hgt = np.full((nz, n), np.nan)
+    omega = np.full((nz, n), np.nan)
+    for k, lev in enumerate(levels):
+        u[k] = gather(f"{up}_{lev}")
+        v[k] = gather(f"{vp}_{lev}")
+        temp[k] = gather(f"{tp}_{lev}")
+        hgt[k] = gather(f"{hp}_{lev}")
+        if f"{op}_{lev}" in ds:
+            omega[k] = gather(f"{op}_{lev}")
+    terrain1d = gather(terrain_var)
+
+    pres_pa = (np.array(levels, dtype=float) * 100.0)[:, None]  # (nz, 1)
+    speed = np.hypot(u, v)
+    theta = temp * (_P0 / pres_pa) ** _RCP
+    # omega (Pa/s) -> geometric w (m/s):  w = -omega * R_d * T / (p * g)
+    w = -omega * _RD * temp / (pres_pa * _G)
+
+    # along-transect horizontal component (+ toward B), east/north basis
+    lat0, lon0 = float(start[0]), float(start[1])
+    lat1, lon1 = float(end[0]), float(end[1])
+    coslat = np.cos(np.deg2rad(0.5 * (lat0 + lat1)))
+    tx, ty = (lon1 - lon0) * coslat, (lat1 - lat0)
+    tnorm = np.hypot(tx, ty) or 1.0
+    tx, ty = tx / tnorm, ty / tnorm
+    along = u * tx + v * ty
+
+    # Mask fields below the terrain surface (isobaric levels under ground are
+    # extrapolated); keep height2d valid so pcolormesh can still place the cells,
+    # and let the terrain fill cover them.
+    below = hgt < terrain1d[None, :]
+    for a in (speed, theta, temp, along, w):
+        a[below] = np.nan
+
+    return NWPSection(
+        distance_km=dist,
+        lon_line=lon_line,
+        lat_line=lat_line,
+        height2d=hgt,
+        speed2d=speed,
+        theta2d=theta,
+        temp2d=temp,
+        along2d=along,
+        w2d=w,
+        terrain1d=terrain1d,
+        pressure_hpa=np.array(levels, dtype=float),
+        termini=termini,
+    )

--- a/brc_tools/nwp/section.py
+++ b/brc_tools/nwp/section.py
@@ -44,6 +44,7 @@ class NWPSection:
     w2d: np.ndarray  # (nz, n) vertical velocity, m/s
     terrain1d: np.ndarray  # (n,) m ASL
     pressure_hpa: np.ndarray  # (nz,)
+    thetae2d: np.ndarray | None = None  # (nz, n) equiv. potential temp, K (needs dewpoint)
     termini: tuple[str, str] = ("A", "B")
     orientation: str = "EW"  # accent-colour key for the crosssection helpers
 
@@ -79,6 +80,7 @@ def extract_nwp_section(
     *,
     n_points: int = 220,
     prefixes: tuple[str, str, str, str, str] = ("wind_u", "wind_v", "temp", "height", "omega"),
+    dewpoint_prefix: str | None = "dewpoint",
     terrain_var: str = "terrain_height",
     time_index: int = 0,
     termini: tuple[str, str] = ("A", "B"),
@@ -98,6 +100,10 @@ def extract_nwp_section(
         Samples along the line (nearest model column per sample).
     prefixes : (u, v, temp, height, omega)
         Variable-name prefixes; ``{prefix}_{level}`` is looked up per level.
+    dewpoint_prefix : str or None
+        Prefix for per-level dewpoint (K).  When every level is present,
+        ``thetae2d`` (equivalent potential temperature) is computed via Bolton
+        (1980); otherwise it stays ``None``.  Pass ``None`` to skip.
     terrain_var : str
         2-D terrain-height variable name (m ASL) for the terrain floor + masking.
 
@@ -129,6 +135,9 @@ def extract_nwp_section(
     temp = np.full((nz, n), np.nan)
     hgt = np.full((nz, n), np.nan)
     omega = np.full((nz, n), np.nan)
+    has_td = dewpoint_prefix is not None and all(
+        f"{dewpoint_prefix}_{lev}" in ds for lev in levels)
+    dewpoint = np.full((nz, n), np.nan) if has_td else None
     for k, lev in enumerate(levels):
         u[k] = gather(f"{up}_{lev}")
         v[k] = gather(f"{vp}_{lev}")
@@ -136,11 +145,17 @@ def extract_nwp_section(
         hgt[k] = gather(f"{hp}_{lev}")
         if f"{op}_{lev}" in ds:
             omega[k] = gather(f"{op}_{lev}")
+        if has_td:
+            dewpoint[k] = gather(f"{dewpoint_prefix}_{lev}")
     terrain1d = gather(terrain_var)
 
     pres_pa = (np.array(levels, dtype=float) * 100.0)[:, None]  # (nz, 1)
     speed = np.hypot(u, v)
     theta = temp * (_P0 / pres_pa) ** _RCP
+    thetae = None
+    if has_td:
+        from brc_tools.nwp.derived import theta_e
+        thetae = np.asarray(theta_e(temp, dewpoint, pres_pa / 100.0), dtype=float)
     # omega (Pa/s) -> geometric w (m/s):  w = -omega * R_d * T / (p * g)
     w = -omega * _RD * temp / (pres_pa * _G)
 
@@ -157,7 +172,7 @@ def extract_nwp_section(
     # extrapolated); keep height2d valid so pcolormesh can still place the cells,
     # and let the terrain fill cover them.
     below = hgt < terrain1d[None, :]
-    for a in (speed, theta, temp, along, w):
+    for a in (speed, theta, temp, along, w) + ((thetae,) if thetae is not None else ()):
         a[below] = np.nan
 
     return NWPSection(
@@ -172,5 +187,6 @@ def extract_nwp_section(
         w2d=w,
         terrain1d=terrain1d,
         pressure_hpa=np.array(levels, dtype=float),
+        thetae2d=thetae,
         termini=termini,
     )

--- a/brc_tools/nwp/static.py
+++ b/brc_tools/nwp/static.py
@@ -1,0 +1,108 @@
+"""Fetch-once, reuse-forever staging for model fields that do not vary with time.
+
+A model's orography is fixed for the life of a model version, so re-fetching it for
+every case date -- or worse, concurrently from several jobs -- is pure waste. It is
+also an outright race: :class:`~brc_tools.nwp.NWPSource` asks Herbie for subsets with
+``remove_grib=True``, so two processes requesting the *same* field land on the same
+cache filename and one deletes the GRIB while the other is still reading it::
+
+    FileNotFoundError: .../subset_7bef8322__hrrr.t06z.wrfsfcf00.grib2
+
+Herbie fetches are guarded by an inter-process lock, but that lock defaults to
+``tempfile.gettempdir()`` -- which is **node-local**, so it does not serialize jobs
+spread across compute nodes. The cache here is keyed by ``(model, bbox)`` and its lock
+lives beside the cache on shared storage, so concurrent jobs on different nodes either
+reuse a staged file or serialize behind one download.
+
+Verified for HRRR: terrain over the Uinta Basin was bit-identical between 2026-02-22
+and 2026-07-15 (max |dz| = 0 m over the 6,264 shared grid points). The cache key does
+**not** encode a model version, so purge ``BRC_TOOLS_STATIC_DIR`` after a model
+upgrade that moves the grid or the orography.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+TERRAIN_ALIAS = "terrain_height"
+
+
+def static_cache_dir(explicit: str | os.PathLike | None = None) -> Path:
+    """Where staged time-invariant fields live.
+
+    ``explicit`` > ``BRC_TOOLS_STATIC_DIR`` > a ``static/`` sibling of the Herbie
+    cache > ``~/.cache/brc_tools/static``. Prefer somewhere shared and persistent:
+    the whole point is that it outlives a single job and a single case date.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    env = os.environ.get("BRC_TOOLS_STATIC_DIR")
+    if env:
+        return Path(env)
+    herbie = os.environ.get("BRC_TOOLS_HERBIE_CACHE")
+    base = Path(herbie).parent if herbie else Path.home() / ".cache" / "brc_tools"
+    return base / "static"
+
+
+def _cache_key(model: str, bbox) -> str:
+    raw = f"{model}|" + ",".join(f"{float(v):.4f}" for v in bbox)
+    return hashlib.sha1(raw.encode()).hexdigest()[:10]
+
+
+def terrain_cache_path(model: str, bbox, *, cache_dir=None) -> Path:
+    """Path this ``(model, bbox)`` pair stages its terrain to."""
+    return static_cache_dir(cache_dir) / f"{model}_terrain_{_cache_key(model, bbox)}.nc"
+
+
+def load_terrain(
+    model: str,
+    bbox,
+    *,
+    init_time,
+    cache_dir=None,
+    source=None,
+    refresh: bool = False,
+) -> xr.Dataset:
+    """Return the model's static terrain over ``bbox``, downloading only on a miss.
+
+    Parameters
+    ----------
+    model, bbox
+        Model key and ``(sw_lat, sw_lon, ne_lat, ne_lon)``, together the cache key.
+    init_time
+        Any cycle that has an f00 -- used only when the cache misses. Terrain does
+        not vary, so which cycle you pass does not affect the result.
+    source
+        An existing :class:`~brc_tools.nwp.NWPSource`; one is built if omitted.
+    refresh
+        Re-download and overwrite the staged copy (use after a model upgrade).
+    """
+    import fasteners
+
+    path = terrain_cache_path(model, bbox, cache_dir=cache_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if path.exists() and not refresh:
+        logger.debug("terrain cache hit: %s", path)
+        return xr.open_dataset(path)
+
+    # Lock beside the cache (shared storage) so jobs on different nodes serialize.
+    lock = fasteners.InterProcessLock(str(path.with_suffix(".lock")))
+    with lock:
+        if path.exists() and not refresh:  # staged while we waited
+            return xr.open_dataset(path)
+        from brc_tools.nwp import NWPSource
+        src = source if source is not None else NWPSource(model)
+        logger.info("staging %s terrain -> %s", model, path)
+        ds = src.fetch(init_time=init_time, forecast_hours=[0],
+                       variables=[TERRAIN_ALIAS], bbox=bbox)
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
+        ds.to_netcdf(tmp)
+        os.replace(tmp, path)  # atomic: readers never see a partial file
+    return xr.open_dataset(path)

--- a/brc_tools/visualize/basemap.py
+++ b/brc_tools/visualize/basemap.py
@@ -29,16 +29,20 @@ _HIGHWAY_TYPES = {"Major Highway", "Secondary Highway", "Beltway", "Bypass"}
 # Engine layer key -> (Natural-Earth category, dataset name).
 _LAYERS: dict[str, tuple[str, str]] = {
     "states": ("cultural", "admin_1_states_provinces_lakes"),
+    "counties": ("cultural", "admin_2_counties"),
     "roads": ("cultural", "roads"),
     "rivers": ("physical", "rivers_lake_centerlines"),
     "lakes": ("physical", "lakes"),
     "cities": ("cultural", "populated_places"),
 }
 
-# Layer draw order and default line styling (rivers/roads over lakes, borders on top).
+# Layer draw order and default line styling (rivers/roads over lakes, county lines
+# under the heavier state borders on top).
 _LINE_STYLE = {
     "rivers": dict(color="#3a6ea5", linewidth=0.5, alpha=0.75, zorder=3.0),
     "roads": dict(color="#8a5a2b", linewidth=0.6, alpha=0.85, zorder=3.1),
+    "counties": dict(color="0.45", linewidth=0.4, alpha=0.7, zorder=3.15,
+                     linestyle=(0, (5, 2))),
     "states": dict(color="0.15", linewidth=0.8, alpha=0.9, zorder=3.2),
 }
 
@@ -276,6 +280,7 @@ def add_reference_overlays(
     *,
     layers=None,
     states: bool = True,
+    counties: bool = False,
     roads: bool = True,
     rivers: bool = True,
     lakes: bool = True,
@@ -290,18 +295,21 @@ def add_reference_overlays(
     ``extent`` is ``(lon0, lon1, lat0, lat1)``.  ``layers`` (a ``{name: bool}`` mapping,
     e.g. a case's ``[map]`` table) overrides the individual flags when given.  Pass
     ``transform=ccrs.PlateCarree()`` for a cartopy GeoAxes; leave it ``None`` for the
-    plain lon/lat axes the renderers use.  Fail-soft: any absent layer is skipped.
+    plain lon/lat axes the renderers use.  Fail-soft: any absent layer is skipped
+    (``counties`` in particular needs the ``admin_2_counties`` layer staged; when it
+    is not, the call simply draws nothing for it).
 
     ``cities`` (off by default, so existing figures are unchanged) draws
     population-ranked city labels via :func:`draw_cities`.
     """
     if layers is not None:
         states = bool(layers.get("states", states))
+        counties = bool(layers.get("counties", counties))
         roads = bool(layers.get("roads", roads))
         rivers = bool(layers.get("rivers", rivers))
         lakes = bool(layers.get("lakes", lakes))
         cities = bool(layers.get("cities", cities))
-    if not (states or roads or rivers or lakes or cities):
+    if not (states or counties or roads or rivers or lakes or cities):
         return
     try:
         from shapely.geometry import box as _box

--- a/brc_tools/visualize/nwp_maps.py
+++ b/brc_tools/visualize/nwp_maps.py
@@ -1,0 +1,343 @@
+"""Publication maps for gridded NWP fields (HRRR/RRFS) over a basin domain.
+
+Two renderers that consume an :class:`xarray.Dataset` from
+:meth:`brc_tools.nwp.NWPSource.fetch` (plus, for the section, an
+:class:`~brc_tools.nwp.section.NWPSection`) and produce the offline-safe,
+staged-shapefile style used across the group's figures:
+
+* :func:`plot_nwp_surface_map` -- a plan-view field (e.g. 10 m wind speed) with
+  wind barbs, terrain contours, and reference overlays (states / counties /
+  roads / rivers / lakes) plus decluttered town labels.
+* :func:`plot_nwp_section` -- a terrain-filled vertical cross-section at true
+  altitude (m ASL), wind-speed shaded with in-plane vectors and potential-
+  temperature contours, a geographic locator inset, and the same town set
+  projected onto the transect.
+
+Everything geographic comes from the staged Natural-Earth cache
+(:mod:`brc_tools.visualize.basemap`), so these render on an offline compute node.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from brc_tools.visualize.basemap import add_reference_overlays, draw_waypoints
+from brc_tools.visualize.grid import terrain_contour_levels
+from brc_tools.visualize.style import get_style
+
+_KT = 1.94384  # m/s -> knots
+_ACCENT = "#c62828"
+_DEFAULT_OVERLAYS = {"states": True, "counties": True, "roads": True,
+                     "rivers": True, "lakes": True}
+
+
+def _lon180(lon) -> np.ndarray:
+    lon = np.asarray(lon, dtype=float)
+    return np.where(lon > 180.0, lon - 360.0, lon)
+
+
+def _sel(ds, name, time_index):
+    da = ds[name]
+    if "time" in da.dims:
+        da = da.isel(time=time_index)
+    return np.asarray(da.values, dtype=float)
+
+
+def _annotate(ax, text):
+    if text:
+        ax.text(0.99, 0.01, text, transform=ax.transAxes, ha="right", va="bottom",
+                fontsize=6, alpha=0.65,
+                bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.55, "pad": 1.5})
+
+
+# --------------------------------------------------------------------------- #
+# Plan view
+# --------------------------------------------------------------------------- #
+def plot_nwp_surface_map(
+    ds,
+    field: str,
+    out_path,
+    *,
+    time_index: int = 0,
+    wind: tuple[str, str] | None = ("wind_u_10m", "wind_v_10m"),
+    terrain_var: str | None = "terrain_height",
+    style=None,
+    cmap: str | None = None,
+    vmin: float | None = None,
+    vmax: float | None = None,
+    wind_barbs: bool = True,
+    barb_stride: int = 4,
+    waypoints: dict | None = None,
+    overlays: dict | None = None,
+    extent: tuple[float, float, float, float] | None = None,
+    terrain_contours: bool = True,
+    title: str | None = None,
+    annotation: str | None = None,
+    figsize: tuple[float, float] = (9.0, 7.6),
+    dpi: int = 150,
+) -> Path:
+    """Render a plan-view NWP field with wind barbs, terrain, overlays, and towns.
+
+    ``field`` is a data-var name (e.g. ``"wind_speed_10m"``). ``extent`` is
+    ``(lon0, lon1, lat0, lat1)`` in -180..180; if ``None`` the full grid is shown.
+    ``overlays`` is a ``{layer: bool}`` map passed to
+    :func:`~brc_tools.visualize.basemap.add_reference_overlays` (default: all,
+    incl. counties).
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    lon2d = _lon180(ds["longitude"].values)
+    lat2d = np.asarray(ds["latitude"].values, dtype=float)
+    fld = _sel(ds, field, time_index)
+
+    st = style if style is not None else _safe_style(field)
+    cmap = cmap or (st.cmap if st else "viridis")
+    if vmin is None and st is not None:
+        vmin = st.vmin
+    if vmax is None and st is not None:
+        vmax = st.vmax
+    label = st.label if st is not None else field
+
+    fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
+    mesh = ax.pcolormesh(lon2d, lat2d, fld, cmap=cmap, vmin=vmin, vmax=vmax, shading="auto")
+    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=(st.extend if st else "neither"), label=label)
+
+    if terrain_contours and terrain_var and terrain_var in ds:
+        terr = _sel(ds, terrain_var, time_index)
+        levels = terrain_contour_levels(terr)
+        if levels is not None:
+            ax.contour(lon2d, lat2d, terr, levels=levels, colors="0.35",
+                       linewidths=0.3, alpha=0.5, zorder=1.5)
+
+    if wind_barbs and wind and wind[0] in ds and wind[1] in ds:
+        u = _sel(ds, wind[0], time_index) * _KT
+        v = _sel(ds, wind[1], time_index) * _KT
+        s = barb_stride
+        ax.barbs(lon2d[::s, ::s], lat2d[::s, ::s], u[::s, ::s], v[::s, ::s],
+                 length=5.0, linewidth=0.4, zorder=4)
+
+    view = extent if extent is not None else (
+        float(lon2d.min()), float(lon2d.max()), float(lat2d.min()), float(lat2d.max()))
+    add_reference_overlays(ax, view, layers=(overlays or _DEFAULT_OVERLAYS))
+    if waypoints:
+        draw_waypoints(ax, waypoints, view, fontsize=6.5)
+
+    ax.set_xlim(view[0], view[1])
+    ax.set_ylim(view[2], view[3])
+    ax.set_aspect(1.0 / np.cos(np.deg2rad(0.5 * (view[2] + view[3]))))
+    ax.set_xlabel("longitude")
+    ax.set_ylabel("latitude")
+    if title:
+        ax.set_title(title)
+    _annotate(ax, annotation)
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def _safe_style(field):
+    try:
+        return get_style(field)
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Cross-section
+# --------------------------------------------------------------------------- #
+def _terrain_floor(terrain: np.ndarray) -> float:
+    return float(np.floor(np.nanmin(terrain) / 100.0) * 100.0 - 50.0)
+
+
+def _project_waypoints(section, waypoints, max_offset_km):
+    """(distance_km, name, offset_km, terrain_m) for waypoints near the line."""
+    if not waypoints:
+        return []
+    lon = _lon180(section.lon_line)
+    lat = np.asarray(section.lat_line, dtype=float)
+    dist = np.asarray(section.distance_km, dtype=float)
+    terr = np.asarray(section.terrain1d, dtype=float)
+    kx = 111.320 * np.cos(np.deg2rad(float(np.mean(lat))))
+    ky = 110.574
+    found = []
+    for name, wp in waypoints.items():
+        d2 = ((lon - float(wp["lon"])) * kx) ** 2 + ((lat - float(wp["lat"])) * ky) ** 2
+        i = int(np.argmin(d2))
+        off = float(np.sqrt(d2[i]))
+        if off <= max_offset_km and 0 < i < dist.size - 1:
+            found.append((float(dist[i]), str(name), off, float(terr[i])))
+    return sorted(found)
+
+
+def _draw_section_towns(ax, section, waypoints, max_offset_km):
+    y_top = ax.get_ylim()[1]
+    for d_km, name, _off, terr_m in _project_waypoints(section, waypoints, max_offset_km):
+        ax.axvline(d_km, color="0.15", lw=0.6, ls=(0, (4, 3)), alpha=0.6, zorder=5)
+        ax.plot(d_km, terr_m, marker="v", color=_ACCENT, ms=5, zorder=9)
+        ax.text(d_km, y_top, f"{name} ", rotation=90, va="top", ha="right", fontsize=6.5,
+                color="0.1", zorder=9,
+                bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.6, "pad": 0.6})
+
+
+def _geo_locator_inset(ax, section, locator):
+    """Small basin map (top-right) with terrain, overlays, the transect line, towns."""
+    lon2d = _lon180(locator["lon2d"])
+    lat2d = np.asarray(locator["lat2d"], dtype=float)
+    terr2d = np.asarray(locator["terrain2d"], dtype=float)
+    extent = locator.get("extent") or (
+        float(lon2d.min()), float(lon2d.max()), float(lat2d.min()), float(lat2d.max()))
+    axins = ax.inset_axes([0.66, 0.60, 0.34, 0.40])
+    axins.contourf(lon2d, lat2d, terr2d, levels=12, cmap="terrain", alpha=0.85, zorder=0)
+    add_reference_overlays(axins, extent,
+                           layers={"states": True, "counties": True, "roads": False,
+                                   "rivers": True, "lakes": True})
+    axins.plot(_lon180(section.lon_line), section.lat_line, color=_ACCENT, lw=1.6, zorder=6)
+    axins.plot([_lon180(section.lon_line)[0]], [section.lat_line[0]], marker="o",
+               color=_ACCENT, ms=4, zorder=7)
+    axins.plot([_lon180(section.lon_line)[-1]], [section.lat_line[-1]], marker="s",
+               color=_ACCENT, ms=4, zorder=7)
+    if locator.get("waypoints"):
+        draw_waypoints(axins, locator["waypoints"], extent, fontsize=5.0, ms=3.0)
+    axins.set_xlim(extent[0], extent[1])
+    axins.set_ylim(extent[2], extent[3])
+    axins.set_aspect(1.0 / np.cos(np.deg2rad(0.5 * (extent[2] + extent[3]))))
+    axins.set_xticks([])
+    axins.set_yticks([])
+    for sp in axins.spines.values():
+        sp.set_edgecolor(_ACCENT)
+
+
+def _interp_to_heights(section, field2d, heights, *, fill_to_ground=True):
+    """Interpolate each column of ``field2d`` (on ``section.height2d``) onto a common
+    regular ``heights`` axis, turning coarse isobaric levels into a smooth curtain.
+
+    Over high terrain the lowest above-ground isobaric level can sit a few hundred
+    metres up; with ``fill_to_ground`` the column is held at that lowest valid value
+    down to the surface (the usual "fill to ground" choice for isobaric curtains --
+    the true 10 m wind lives on the plan-view map), else it stays NaN below it."""
+    z = np.asarray(section.height2d, dtype=float)
+    f = np.asarray(field2d, dtype=float)
+    n = z.shape[1]
+    out = np.full((heights.size, n), np.nan)
+    for i in range(n):
+        zc, fc = z[:, i], f[:, i]
+        m = np.isfinite(zc) & np.isfinite(fc)
+        if m.sum() >= 2:
+            order = np.argsort(zc[m])
+            zz, ff = zc[m][order], fc[m][order]
+            out[:, i] = np.interp(heights, zz, ff,
+                                  left=(ff[0] if fill_to_ground else np.nan),
+                                  right=np.nan)
+    return out
+
+
+def _smooth1d(a, window=3):
+    a = np.asarray(a, dtype=float)
+    if a.size < window:
+        return a
+    k = np.ones(window) / window
+    out = np.convolve(a, k, mode="same")
+    out[0], out[-1] = a[0], a[-1]
+    return out
+
+
+def plot_nwp_section(
+    section,
+    out_path,
+    *,
+    style=None,
+    title: str,
+    annotation: str | None = None,
+    theta_contours: bool = True,
+    theta_interval: float = 2.0,
+    w_exaggeration: float = 100.0,
+    quiver_stride: tuple[int, int] = (6, 12),
+    dz_m: float = 40.0,
+    y_top_m: float = 3000.0,
+    waypoints: dict | None = None,
+    waypoint_offset_km: float = 15.0,
+    locator: dict | None = None,
+    figsize: tuple[float, float] = (11.0, 6.2),
+    dpi: int = 150,
+) -> Path:
+    """Render an :class:`~brc_tools.nwp.section.NWPSection` as a terrain-filled curtain.
+
+    Wind speed is shaded on a true-altitude (m ASL) axis capped at ``y_top_m``;
+    in-plane vectors show along-transect + (exaggerated) vertical wind; thin
+    contours mark potential temperature. Columns are interpolated onto a regular
+    ``dz_m`` height grid for a smooth curtain. ``locator`` (``{lon2d, lat2d,
+    terrain2d, extent?, waypoints?}``) draws the geographic inset; ``waypoints``
+    marks towns within ``waypoint_offset_km`` of the line.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    st = style if style is not None else get_style("wind_speed_10m")
+    dist = np.asarray(section.distance_km, dtype=float)
+    terrain = np.asarray(section.terrain1d, dtype=float)
+    terr_disp = _smooth1d(terrain, 5)
+    y_bottom = _terrain_floor(terrain)
+
+    heights = np.arange(y_bottom, y_top_m + dz_m, dz_m)
+    speed = _interp_to_heights(section, section.speed2d, heights)
+    theta = _interp_to_heights(section, section.theta2d, heights)
+    along = _interp_to_heights(section, section.along2d, heights)
+    w = _interp_to_heights(section, section.w2d, heights)
+    below = heights[:, None] < terr_disp[None, :]
+    for a in (speed, theta, along, w):
+        a[below] = np.nan
+
+    fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
+    ax.set_facecolor("0.6")  # below-ground / below-lowest-level cells read as terrain
+    mesh = ax.pcolormesh(dist, heights, speed, cmap=st.cmap, vmin=st.vmin, vmax=st.vmax,
+                         shading="gouraud")
+    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=st.extend, label=st.label)
+
+    if theta_contours:
+        lo = np.floor(np.nanmin(theta) / theta_interval) * theta_interval
+        hi = np.ceil(np.nanmax(theta) / theta_interval) * theta_interval
+        levels = np.arange(lo, hi + 0.1, theta_interval)
+        cs = ax.contour(dist, heights, theta, levels=levels, colors="black",
+                        linewidths=0.4, alpha=0.5)
+        ax.clabel(cs, cs.levels[::2], fontsize=6, fmt="%.0f")
+
+    # in-plane wind: along-transect + exaggerated vertical, on the regular grid
+    sz, sx = quiver_stride
+    dd, hh = np.meshgrid(dist, heights)
+    q = ax.quiver(dd[::sz, ::sx], hh[::sz, ::sx], along[::sz, ::sx],
+                  w[::sz, ::sx] * w_exaggeration, color="black", width=0.0016,
+                  alpha=0.85, zorder=8)
+    ax.quiverkey(q, 0.86, 1.02, 10.0, rf"10 m s$^{{-1}}$ along, $w\times${int(w_exaggeration)}",
+                 labelpos="E", coordinates="axes", fontproperties={"size": 7})
+
+    ax.fill_between(dist, y_bottom, terr_disp, color="0.6", linewidth=0, zorder=6)
+    ax.plot(dist, terr_disp, color="black", linewidth=0.7, zorder=7)
+
+    ax.set_ylim(y_bottom, y_top_m)
+    ax.set_xlim(float(dist.min()), float(dist.max()))
+    ax.set_xlabel("distance along transect (km)")
+    ax.set_ylabel("height (m ASL)")
+    ax.set_title(title)
+
+    tkw = dict(color=_ACCENT, fontsize=11, fontweight="bold", transform=ax.transAxes)
+    ax.text(0.0, -0.09, section.termini[0], ha="left", va="top", **tkw)
+    ax.text(1.0, -0.09, section.termini[1], ha="right", va="top", **tkw)
+
+    if waypoints:
+        _draw_section_towns(ax, section, waypoints, waypoint_offset_km)
+    if locator is not None:
+        _geo_locator_inset(ax, section, locator)
+    _annotate(ax, annotation)
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return out

--- a/brc_tools/visualize/nwp_maps.py
+++ b/brc_tools/visualize/nwp_maps.py
@@ -192,7 +192,9 @@ def _geo_locator_inset(ax, section, locator):
     terr2d = np.asarray(locator["terrain2d"], dtype=float)
     extent = locator.get("extent") or (
         float(lon2d.min()), float(lon2d.max()), float(lat2d.min()), float(lat2d.max()))
-    axins = ax.inset_axes([0.66, 0.60, 0.34, 0.40])
+    # A tall/narrow transect (e.g. S->N) wants a different inset box than a wide one,
+    # so the caller may override the default top-right placement.
+    axins = ax.inset_axes(locator.get("rect") or [0.66, 0.60, 0.34, 0.40])
     axins.contourf(lon2d, lat2d, terr2d, levels=12, cmap="terrain", alpha=0.85, zorder=0)
     add_reference_overlays(axins, extent,
                            layers={"states": True, "counties": True, "roads": False,
@@ -209,6 +211,12 @@ def _geo_locator_inset(ax, section, locator):
     axins.set_aspect(1.0 / np.cos(np.deg2rad(0.5 * (extent[2] + extent[3]))))
     axins.set_xticks([])
     axins.set_yticks([])
+    # Sit above the quivers (zorder 8), which would otherwise stripe straight across the
+    # locator map, but below the town markers/labels (zorder 9) so a transect whose
+    # landmarks run under the inset still reads them.
+    axins.set_zorder(8.5)
+    axins.patch.set_facecolor("white")
+    axins.patch.set_alpha(1.0)
     for sp in axins.spines.values():
         sp.set_edgecolor(_ACCENT)
 
@@ -247,10 +255,15 @@ def _smooth1d(a, window=3):
     return out
 
 
+_SECTION_SHADE = {"speed": "speed2d", "theta_e": "thetae2d", "theta": "theta2d",
+                  "temp": "temp2d", "along": "along2d"}
+
+
 def plot_nwp_section(
     section,
     out_path,
     *,
+    shade: str = "speed",
     style=None,
     title: str,
     annotation: str | None = None,
@@ -268,17 +281,32 @@ def plot_nwp_section(
 ) -> Path:
     """Render an :class:`~brc_tools.nwp.section.NWPSection` as a terrain-filled curtain.
 
-    Wind speed is shaded on a true-altitude (m ASL) axis capped at ``y_top_m``;
-    in-plane vectors show along-transect + (exaggerated) vertical wind; thin
-    contours mark potential temperature. Columns are interpolated onto a regular
-    ``dz_m`` height grid for a smooth curtain. ``locator`` (``{lon2d, lat2d,
-    terrain2d, extent?, waypoints?}``) draws the geographic inset; ``waypoints``
-    marks towns within ``waypoint_offset_km`` of the line.
+    ``shade`` selects the shaded field -- ``"speed"`` (default, the wind case),
+    ``"theta_e"`` (moist instability; needs a section built with dewpoint),
+    ``"theta"``, ``"temp"``, or ``"along"`` -- and is shaded on a true-altitude
+    (m ASL) axis capped at ``y_top_m``. Pass a matching ``style`` for anything but
+    the default. In-plane vectors show along-transect + (exaggerated) vertical
+    wind; thin contours mark potential temperature. Columns are interpolated onto
+    a regular ``dz_m`` height grid for a smooth curtain. ``locator`` (``{lon2d,
+    lat2d, terrain2d, extent?, waypoints?}``) draws the geographic inset;
+    ``waypoints`` marks towns within ``waypoint_offset_km`` of the line; an optional
+    ``locator["rect"]`` (axes-fraction ``[x, y, w, h]``) moves/resizes that inset.
+
+    ``w_exaggeration`` scales the vertical component of the in-plane vectors. A
+    sensible default is the plot's own aspect ratio (transect length / ``y_top_m``),
+    so a deep section wants a much smaller value than a shallow one.
     """
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
+    if shade not in _SECTION_SHADE:
+        raise ValueError(f"shade must be one of {sorted(_SECTION_SHADE)}, got {shade!r}")
+    shade_arr = getattr(section, _SECTION_SHADE[shade])
+    if shade_arr is None:
+        raise ValueError(
+            f"section has no {_SECTION_SHADE[shade]} for shade={shade!r} -- rebuild it "
+            "with extract_nwp_section(..., dewpoint_prefix=...)")
     st = style if style is not None else get_style("wind_speed_10m")
     dist = np.asarray(section.distance_km, dtype=float)
     terrain = np.asarray(section.terrain1d, dtype=float)
@@ -286,17 +314,17 @@ def plot_nwp_section(
     y_bottom = _terrain_floor(terrain)
 
     heights = np.arange(y_bottom, y_top_m + dz_m, dz_m)
-    speed = _interp_to_heights(section, section.speed2d, heights)
+    shaded = _interp_to_heights(section, shade_arr, heights)
     theta = _interp_to_heights(section, section.theta2d, heights)
     along = _interp_to_heights(section, section.along2d, heights)
     w = _interp_to_heights(section, section.w2d, heights)
     below = heights[:, None] < terr_disp[None, :]
-    for a in (speed, theta, along, w):
+    for a in (shaded, theta, along, w):
         a[below] = np.nan
 
     fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
     ax.set_facecolor("0.6")  # below-ground / below-lowest-level cells read as terrain
-    mesh = ax.pcolormesh(dist, heights, speed, cmap=st.cmap, vmin=st.vmin, vmax=st.vmax,
+    mesh = ax.pcolormesh(dist, heights, shaded, cmap=st.cmap, vmin=st.vmin, vmax=st.vmax,
                          shading="gouraud")
     fig.colorbar(mesh, ax=ax, shrink=0.85, extend=st.extend, label=st.label)
 

--- a/scripts/fetch_basemap.py
+++ b/scripts/fetch_basemap.py
@@ -33,6 +33,7 @@ from pathlib import Path
 # (category, dataset name) for each layer the overlays can draw.
 _LAYERS = [
     ("cultural", "admin_1_states_provinces_lakes"),
+    ("cultural", "admin_2_counties"),
     ("cultural", "roads"),
     ("cultural", "populated_places"),  # city labels (forecast-funnel + opt-in overlays)
     ("physical", "rivers_lake_centerlines"),

--- a/tests/test_nwp_section.py
+++ b/tests/test_nwp_section.py
@@ -1,0 +1,82 @@
+"""Unit tests for brc_tools.nwp.section (arbitrary lat/lon NWP cross-sections)."""
+
+import numpy as np
+import xarray as xr
+
+from brc_tools.nwp.section import NWPSection, extract_nwp_section
+
+
+def _synth(levels=(850, 800, 750, 700), ny=10, nx=12, terrain=1200.0, with_time=True):
+    """Small synthetic HRRR-like dataset: 0..360 lon, flat per-level vars."""
+    lat1d = np.linspace(40.0, 41.0, ny)
+    lon1d = np.linspace(248.0, 251.5, nx)  # 0..360 (i.e. -112 .. -108.5)
+    lon2d, lat2d = np.meshgrid(lon1d, lat1d)
+    data = {}
+    for i, lev in enumerate(levels):
+        h = 1000.0 + i * 500.0  # height rises as pressure falls
+        data[f"wind_u_{lev}"] = (("y", "x"), np.full((ny, nx), 5.0))
+        data[f"wind_v_{lev}"] = (("y", "x"), np.zeros((ny, nx)))
+        data[f"temp_{lev}"] = (("y", "x"), np.full((ny, nx), 280.0 - 5.0 * i))
+        data[f"height_{lev}"] = (("y", "x"), np.full((ny, nx), h))
+        data[f"omega_{lev}"] = (("y", "x"), np.zeros((ny, nx)))
+    data["terrain_height"] = (("y", "x"), np.full((ny, nx), terrain))
+    ds = xr.Dataset(data, coords={"latitude": (("y", "x"), lat2d),
+                                  "longitude": (("y", "x"), lon2d)})
+    return ds.expand_dims("time") if with_time else ds
+
+
+class TestExtract:
+    def test_shapes_and_distance(self):
+        ds = _synth()
+        sec = extract_nwp_section(ds, (40.1, -111.5), (40.9, -108.6),
+                                  [850, 800, 750, 700], n_points=50)
+        assert isinstance(sec, NWPSection)
+        assert sec.height2d.shape == (4, 50)
+        assert sec.speed2d.shape == (4, 50)
+        assert sec.distance_km[0] == 0.0
+        assert np.all(np.diff(sec.distance_km) >= 0.0)
+        assert sec.distance_km[-1] > 100.0  # hundreds of km across the basin
+
+    def test_speed_and_along_sign(self):
+        ds = _synth()
+        # due-east transect + eastward 5 m/s wind -> speed 5, along ~ +5
+        sec = extract_nwp_section(ds, (40.5, -111.5), (40.5, -108.6),
+                                  [850, 800, 750, 700])
+        np.testing.assert_allclose(np.nanmax(sec.speed2d), 5.0, atol=1e-6)
+        assert np.nanmean(sec.along2d) > 4.5
+
+    def test_below_ground_masked(self):
+        ds = _synth(terrain=1500.0)  # above the 850 hPa height (1000 m)
+        sec = extract_nwp_section(ds, (40.1, -111.5), (40.9, -108.6),
+                                  [850, 800, 750, 700])
+        assert np.all(np.isnan(sec.speed2d[0]))       # lowest level underground
+        assert np.any(np.isfinite(sec.speed2d[-1]))   # 700 hPa (2500 m) above ground
+
+    def test_longitude_wrapped(self):
+        ds = _synth()  # coords in 0..360
+        sec = extract_nwp_section(ds, (40.5, -111.0), (40.5, -109.0),
+                                  [850, 800, 750, 700])
+        assert np.all(sec.lon_line < 0.0)  # wrapped to -180..180
+
+    def test_omega_to_w_and_theta(self):
+        ds = _synth()
+        sec = extract_nwp_section(ds, (40.1, -111.5), (40.9, -108.6),
+                                  [850, 800, 750, 700])
+        # zero omega -> zero vertical velocity; theta > temperature above 850 hPa
+        assert np.allclose(np.nan_to_num(sec.w2d), 0.0)
+        assert np.nanmin(sec.theta2d) > 280.0
+
+
+class TestLookups:
+    def test_terrain_height_alias(self):
+        from brc_tools.nwp.source import load_lookups
+        lu = load_lookups()
+        assert "terrain_height" in lu["aliases"]
+        assert lu["aliases"]["terrain_height"]["search"]["hrrr"] == "HGT:surface"
+
+    def test_basin_landmarks_group(self):
+        from brc_tools.nwp.source import load_lookups
+        lu = load_lookups()
+        assert "basin_landmarks" in lu["waypoint_groups"]
+        for town in ("salt_lake_city", "rangely", "duchesne"):
+            assert town in lu["waypoints"]

--- a/tests/test_visualize_nwp_maps.py
+++ b/tests/test_visualize_nwp_maps.py
@@ -1,0 +1,64 @@
+"""Smoke tests for brc_tools.visualize.nwp_maps (plan-view + NWP cross-section)."""
+
+import numpy as np
+import xarray as xr
+
+from brc_tools.nwp.section import extract_nwp_section
+from brc_tools.visualize import basemap
+from brc_tools.visualize.nwp_maps import plot_nwp_section, plot_nwp_surface_map
+
+
+def _synth(levels=(850, 800, 750, 700), ny=12, nx=16):
+    lat1d = np.linspace(39.9, 41.1, ny)
+    lon1d = np.linspace(248.0, 251.6, nx)  # 0..360
+    lon2d, lat2d = np.meshgrid(lon1d, lat1d)
+    rng = np.arange(ny * nx).reshape(ny, nx) % 7
+    data = {
+        "wind_u_10m": (("y", "x"), 3.0 + 0.1 * rng),
+        "wind_v_10m": (("y", "x"), -2.0 + 0.1 * rng),
+        "wind_speed_10m": (("y", "x"), 4.0 + 0.2 * rng),
+        "terrain_height": (("y", "x"), 1400.0 + 30.0 * rng),
+    }
+    for i, lev in enumerate(levels):
+        data[f"wind_u_{lev}"] = (("y", "x"), np.full((ny, nx), 5.0 + i))
+        data[f"wind_v_{lev}"] = (("y", "x"), np.zeros((ny, nx)))
+        data[f"temp_{lev}"] = (("y", "x"), np.full((ny, nx), 278.0 - 4.0 * i))
+        data[f"height_{lev}"] = (("y", "x"), np.full((ny, nx), 1500.0 + 500.0 * i))
+        data[f"omega_{lev}"] = (("y", "x"), np.full((ny, nx), 0.01))
+    ds = xr.Dataset(data, coords={"latitude": (("y", "x"), lat2d),
+                                  "longitude": (("y", "x"), lon2d)})
+    return ds.expand_dims("time")
+
+
+_TOWNS = {"Duchesne": {"lat": 40.16, "lon": -110.40},
+          "Vernal": {"lat": 40.46, "lon": -109.53}}
+
+
+def test_counties_layer_registered():
+    assert "counties" in basemap._LAYERS
+    assert basemap._LAYERS["counties"] == ("cultural", "admin_2_counties")
+
+
+def test_surface_map_smoke(tmp_path):
+    ds = _synth()
+    out = plot_nwp_surface_map(
+        ds, "wind_speed_10m", tmp_path / "map.png",
+        waypoints=_TOWNS, extent=(-112.0, -108.5, 39.9, 41.1),
+        overlays={"states": True, "counties": True, "roads": True,
+                  "rivers": True, "lakes": True},
+        title="smoke")
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_section_smoke(tmp_path):
+    ds = _synth()
+    sec = extract_nwp_section(ds, (40.3, -111.4), (40.06, -108.8),
+                              [850, 800, 750, 700], n_points=60)
+    lon2d = np.where(ds.longitude.values > 180, ds.longitude.values - 360,
+                     ds.longitude.values)
+    out = plot_nwp_section(
+        sec, tmp_path / "sec.png", title="smoke", waypoints=_TOWNS, y_top_m=3000.0,
+        locator=dict(lon2d=lon2d, lat2d=ds.latitude.values,
+                     terrain2d=ds["terrain_height"].isel(time=0).values,
+                     extent=(-112.0, -108.5, 39.9, 41.1), waypoints=_TOWNS))
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## What & why

Adds a **general lat/lon cross-section capability for gridded NWP** (HRRR/RRFS). The
existing cross-section engine (`visualize/crosssection.py` + `nwp/wrf_output.build_section`)
is grid-aligned and WRF-native-eta only, so it cannot express an arbitrary diagonal
transect on isobaric NWP data. This fills that gap and adds the offline-safe plan-view
map + county overlay needed alongside it.

## Changes

- **`nwp/section.py`** — `extract_nwp_section(ds, start, end, levels) -> NWPSection`:
  samples the nearest model column along an A→B line, stacks flat per-level vars
  (`{prefix}_{level}`) into a height–distance curtain, derives `w` from `omega`, masks
  below terrain.
- **`visualize/nwp_maps.py`** — `plot_nwp_section` (terrain-filled AMSL curtain, in-plane
  vectors, θ contours, geographic locator inset) and `plot_nwp_surface_map` (plan-view
  field + barbs + reference overlays + towns). Offline-safe via the staged Natural-Earth
  basemap.
- **`visualize/basemap.py`** — county-line overlay (`admin_2_counties`); staged by
  `scripts/fetch_basemap.py`.
- **`nwp/lookups.toml`** — `terrain_height` alias (`HGT:surface`); `basin_landmarks` town
  group + `salt_lake_city` / `heber` / `rangely` / `bonanza` waypoints.
- **Tests** — `test_nwp_section.py`, `test_visualize_nwp_maps.py` (10 tests).

## Testing

Full suite: **198 passed, 2 skipped** (`pytest tests/ -q`). Seeded and exercised end-to-end
by the `ub-wx` 2026-02-22 basin-winds case (5 HRRR runs → 156 figures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
