### PR TITLE
feat(forecast-funnel): NAM forecast-funnel montage + /basin-forecast-funnel skill

### DIFF
--- a/.claude/skills/basin-forecast-funnel/SKILL.md
+++ b/.claude/skills/basin-forecast-funnel/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: basin-forecast-funnel
+description: Render a NAM "forecast funnel" montage (250 hPa jet -> 500 hPa flow -> 600 hPa moisture/LLJ -> surface synoptic analysis) for a given analysis init time on CHPC. Use when asked to make a forecast funnel / synoptic overview figure from NAM.
+---
+
+# Basin forecast funnel
+
+Drives `scripts/forecast_funnel.py --init-time <when>` (brc-tools) to download a single
+NAM analysis and render the four-panel **forecast funnel** as one publication montage
+(shared Helvetica look via `visualize/style.py`; state borders, rivers, lakes, and
+population-ranked city labels via the fail-soft `visualize/basemap.py` overlays):
+
+- **1a** CONUS, 250 hPa — jet isotachs (fill) + heights + barbs
+- **1b** Western CONUS, 500 hPa — absolute-vorticity fill + heights + barbs
+- **1c** Utah + neighbours, 600 hPa — specific-humidity fill + heights + temperature advection (warm/cold air) + barbs; basin waypoints labelled
+- **1d** Western CONUS surface — smoothed MSLP isobars + auto H/L centres + diagnostic (TFP) frontal zones
+
+Engine: `brc_tools.nwp.forecast_funnel` (data) + `brc_tools.visualize.funnel` (render).
+Details + caveats: `docs/FORECAST-FUNNEL.md`.
+
+## Steps
+1. **Pick the analysis init time** (ask the user): `'YYYY-MM-DD HHZ'` or `YYYYMMDDHH`,
+   UTC. The NAM source is **auto-picked by date**:
+   - recent (>= 2020-03) → Herbie operational NAM (AWS/NOMADS);
+   - pre-2017 (<= 2017-04) → NCEI historical grib1 `namanl_218`;
+   - the 2017–2020 window is **unwired** and errors out — use a recent or pre-2017 init
+     for testing (see `docs/FORECAST-FUNNEL.md` for the post-2017 grib2 follow-up).
+   Override with `--source herbie|ncei` if you must.
+2. **Stage map overlays once (if not already cached):** city labels need the Natural-Earth
+   `populated_places` layer alongside the existing ones — `sbatch scripts/fetch_basemap.dtn.slurm`
+   into the persistent `$BRC_TOOLS_BASEMAP_DIR`. Overlays are fail-soft: an unstaged layer
+   is silently omitted, never a crash.
+3. **Submit on a DTN (never a login node):** downloads need internet, which only DTNs have —
+   `sbatch scripts/forecast_funnel.dtn.slurm "<init time>"` (or
+   `sbatch --export=ALL,INIT="<init time>" scripts/forecast_funnel.dtn.slurm`). The job
+   forces IPv4 (CHPC DTN IPv6 workaround), caches GRIB + matplotlib on scratch, points
+   `BRC_TOOLS_BASEMAP_DIR` at the persistent overlay cache, and runs download + plot together.
+4. **Verify output:** the montage lands at
+   `/scratch/general/vast/$USER/forecast_funnel/forecast_funnel_<YYYYMMDD_HHMM>Z.png`;
+   the job log (`/scratch/general/vast/$USER/forecast_funnel_<jobid>.out`) prints the path,
+   the chosen source, and the panel count. Spot-check that all four panels populated.
+
+## Notes
+- **Outputs + GRIB route to scratch, never the repo** (`--output-dir` overrides; the renderer
+  hard-refuses a repo-internal path). Default `/scratch/general/vast/$USER/forecast_funnel`.
+- Levels default to `250,500,600` hPa (`--levels`); it is a NAM **analysis** (f00), so the
+  valid time equals the init time.
+- **Fronts are diagnostic, not analyst-typed.** Panel 1d marks Thermal-Front-Parameter
+  baroclinic zones (blue where 850 hPa advection is cold, red where warm); treat them as a
+  first-guess overlay, not a hand analysis.
+- Uses the `brc-tools-2026` env python (herbie 2026.3.0) directly, since the login env does
+  not carry into batch jobs.
+- Quick local test without SLURM (on any network node): `python scripts/forecast_funnel.py
+  --init-time "<when>" --output-dir /scratch/general/vast/$USER/forecast_funnel`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ Repo: **`brc-tools`** (hyphen).
 ## Repo map
 ```
 brc_tools/        installable package
-  nwp/            NWPSource (Herbie), lookups.toml, derived, alignment, case_study, wrf_staging (WRF/WPS GRIB)
+  nwp/            NWPSource (Herbie), lookups.toml, derived, alignment, case_study, wrf_staging (WRF/WPS GRIB), forecast_funnel (NAM synoptic montage data)
   obs/            ObsSource (SynopticPy wrapper), scanner (event detection)
   verify/         deterministic metrics (paired_scores, RMSE/bias/MAE)
-  visualize/      planview + timeseries panels; grid.py (field/section plots — brc-wrf seam); figure-engine modules (surface/section/upperair/profile/domains/heatdeficit/deficitflux/basemap/style)
+  visualize/      planview + timeseries panels; grid.py (field/section plots — brc-wrf seam); figure-engine modules (surface/section/upperair/profile/domains/heatdeficit/deficitflux/funnel/basemap/style)
   download/       Synoptic obs script, push_data uploader, HRRR helpers
   api/            external API clients: FlightAware, FR24, Perplexity, Mistral (shared _auth); soundings (IGRA2/Wyoming RAOB) + aqs (EPA AQS AirData bulk), both auth-free
   satellite/      MODIS context imagery (NASA CMR timing + GIBS corrected reflectance, cached, provenance sidecars)
@@ -42,6 +42,7 @@ figures/          generated output (gitignored)
 - `docs/nwp/ROADMAP.md` — HRRR/RRFS strategy · `docs/nwp/NWP-SOURCE-MATRIX.md` — per-source download matrix
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — **WRF-staging cold-start SSOT**; detail in `docs/WRF-INPUT-STAGING.md`; two-stream draft `docs/WRF-GEFS-NAM-FIELD-MAP.md` (parked)
 - `docs/WRF-FIGURE-ENGINE.md` — dataset-agnostic figure engine (`brc_tools/nwp/wrf_figures.py` + `scripts/wrf_figures.py --config <case.toml>`). Per-study case TOMLs + the run/figure inventory live in the active study repo; SSOT index → `../latex-jrl-mjd-mdpiair-2026/verification/figures/archive-inventory.md`
+- `docs/FORECAST-FUNNEL.md` — NAM "forecast funnel" synoptic montage (`brc_tools/nwp/forecast_funnel.py` + `brc_tools/visualize/funnel.py` + `scripts/forecast_funnel.py`); `/basin-forecast-funnel` skill. NAM source auto-picks by init date (Herbie recent / NCEI pre-2017).
 - `WISHLIST-TASKS.md` — prioritised backlog
 
 When editing a topic, edit its canonical doc above; do not duplicate into CLAUDE.md.

--- a/WISHLIST-TASKS.md
+++ b/WISHLIST-TASKS.md
@@ -2,6 +2,21 @@
 
 Completed items are removed once merged; git history is the record.
 
+## Forecast funnel (NAM synoptic montage) — follow-ups
+
+Shipped: `/basin-forecast-funnel` skill + `scripts/forecast_funnel.py` (+ `.dtn.slurm`)
+rendering a 250/500/600 hPa + surface-analysis montage from a NAM analysis
+(`brc_tools/nwp/forecast_funnel.py` + `brc_tools/visualize/funnel.py`; city labels added to
+`visualize/basemap.py`). Reference: **`docs/FORECAST-FUNNEL.md`**. Not blocking:
+
+- **Post-2017 NCEI grib2 NAM template** to close the 2017-04 → 2020-03 auto-pick gap
+  (`nam_218_<date>_<hhmm>_000.grb2`; a new `[models.*]` block in `lookups.toml`).
+- Both data paths are validated against **real GRIB** (Herbie 2025-10-11 18Z from AWS; NCEI
+  2013-01-31 00Z) — this surfaced + fixed three bugs (per-variable cfgrib open for grib1,
+  TFP gradient-gate for front noise, RH→q fallback because `awphys` has no SPFH aloft).
+  Remaining: confirm the DTN `sbatch scripts/forecast_funnel.dtn.slurm` submission mechanics
+  on a real DTN (couldn't be run from the dev sandbox).
+
 ## WRF figure driver — dataset-agnostic engine (DONE 2026-07-08)
 
 The figure system is now a reusable engine (brc-tools) + a declarative case (study repo):

--- a/brc_tools/nwp/forecast_funnel.py
+++ b/brc_tools/nwp/forecast_funnel.py
@@ -1,0 +1,524 @@
+"""Forecast-funnel data layer: NAM analysis -> per-panel plain-array bundles.
+
+A "forecast funnel" is the classic top-down forecasting workflow — start synoptic
+(the jet, the long waves), zoom to the regional flow, then to the local scale, and
+finish at the surface synoptic analysis.  This module fetches a single NAM analysis
+(f00) and reduces it to the handful of cropped, plain-``numpy`` field bundles the
+renderer (:mod:`brc_tools.visualize.funnel`) needs — one :class:`Panel` per funnel
+step.  The renderer stays dataset-agnostic (it only ever sees ``numpy`` arrays), so
+this module owns every xarray/GRIB/Herbie concern.
+
+Two download paths, auto-picked by init date (:func:`funnel_source_for`):
+
+* **herbie** — Herbie's operational ``nam`` model (AWS/NOMADS), for recent inits.
+  Herbie-native (the repo's preferred route); ``awphys`` ships RH (not SPFH) aloft, so
+  specific humidity is derived from RH + T.
+* **ncei**  — the auth-free NCEI historical direct GET (:func:`~brc_tools.nwp.
+  wrf_staging.stage_nam_analysis`), for pre-2017 grib1 ``namanl_218``.
+
+The 2017-04 -> 2020-03 window is deliberately unwired (no post-2017 NCEI grib2
+template yet); auto-pick raises there rather than silently 404-ing.  Everything is
+UTC internally.  GRIB is cached to scratch / ``$BRC_TOOLS_HERBIE_CACHE`` — never the
+repo (see CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+from brc_tools.nwp._crop import crop_to_bbox
+from brc_tools.nwp.derived import (
+    mixing_ratio,
+    saturation_vapor_pressure,
+    wind_speed,
+)
+from brc_tools.nwp.source import _parse_init_time, load_lookups
+
+LOG = logging.getLogger(__name__)
+
+# ── source auto-pick windows ────────────────────────────────────────────────
+# Herbie's operational NAM (AWS ``noaa-nam-pds`` back to ~2020-02, NOMADS ~last
+# week) covers recent inits; the NCEI grib1 ``namanl_218`` archive ends in 2017.
+_HERBIE_MIN = dt.date(2020, 3, 1)
+_NCEI_MAX = dt.date(2017, 4, 1)
+
+# Herbie operational NAM: the 12 km CONUS (grid 218) full-physics file — analysis
+# at fxx=0 gives ``nam.tHHz.awphys00.tm00.grib2``.
+_NAM_HERBIE_MODEL = "nam"
+_NAM_HERBIE_PRODUCT = "awphys"
+
+DEFAULT_LEVELS = (250, 500, 600)
+DEFAULT_WAYPOINT_GROUP = "us40_basin"
+
+# cfgrib short-name candidates per logical field (first match wins).
+_CFGRIB_NAMES = {
+    "gh": ("gh", "HGT", "z"),
+    "u": ("u", "UGRD"),
+    "v": ("v", "VGRD"),
+    "t": ("t", "TMP"),
+    "q": ("q", "SPFH"),
+    "r": ("r", "RH"),
+    "mslp": ("prmsl", "msl", "mslet", "PRMSL"),
+}
+
+
+# ── panel specification ─────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class PanelSpec:
+    """One funnel step: what to draw, at which level, over which region."""
+
+    key: str          # "1a".."1d"
+    kind: str         # "isotach" | "moisture" | "synoptic"
+    region: str       # lookups.toml region name
+    level: int | None  # pressure level (hPa); None for the surface panel
+    title: str
+    style_key: str | None = None
+    waypoint_group: str | None = None
+
+
+# The default four-panel funnel (synoptic -> regional -> local -> surface).
+FUNNEL_PANELS: tuple[PanelSpec, ...] = (
+    PanelSpec("1a", "isotach", "conus", 250,
+              "250 hPa jet: isotachs, heights, wind", "wind_speed_250"),
+    PanelSpec("1b", "vorticity", "west_conus", 500,
+              "500 hPa: absolute vorticity, heights, wind", "abs_vorticity_500"),
+    PanelSpec("1c", "moisture", "utah", 600,
+              "600 hPa: specific humidity, heights, temp advection",
+              "spec_humidity_600", waypoint_group=DEFAULT_WAYPOINT_GROUP),
+    PanelSpec("1d", "synoptic", "west_conus", None,
+              "Surface analysis: MSLP, highs/lows, fronts"),
+)
+
+
+@dataclass
+class Panel:
+    """A single rendered-ready funnel panel of plain ``numpy`` arrays."""
+
+    key: str
+    kind: str
+    title: str
+    level_label: str
+    extent: tuple[float, float, float, float]  # (lon0, lon1, lat0, lat1)
+    lon: np.ndarray                              # 2-D
+    lat: np.ndarray                              # 2-D
+    fields: dict                                 # kind-specific arrays
+    style_key: str | None = None
+    waypoints: dict | None = None
+    centers: list | None = None                  # synoptic H/L
+    fronts: dict | None = None                   # synoptic frontal fields
+
+
+@dataclass
+class FunnelData:
+    """The complete funnel: metadata plus one :class:`Panel` per step."""
+
+    init_time: dt.datetime
+    valid_time: dt.datetime
+    source: str
+    model_label: str
+    panels: list = field(default_factory=list)
+
+
+# ── source selection ────────────────────────────────────────────────────────
+def funnel_source_for(init_dt: dt.datetime) -> str:
+    """Return ``"herbie"`` or ``"ncei"`` for an init date, or raise on the gap.
+
+    Recent inits (>= 2020-03) use Herbie's operational NAM; pre-2017 inits use the
+    NCEI historical grib1 GET.  The 2017-04..2020-03 window has no wired template.
+    """
+    d = init_dt.date()
+    if d >= _HERBIE_MIN:
+        return "herbie"
+    if d <= _NCEI_MAX:
+        return "ncei"
+    raise ValueError(
+        f"No NAM source wired for init {d:%Y-%m-%d}: Herbie operational NAM covers "
+        f">= {_HERBIE_MIN:%Y-%m}, the NCEI grib1 archive ends <= {_NCEI_MAX:%Y-%m}. "
+        "Test with a recent init (Herbie) or a pre-2017 init (NCEI). See "
+        "docs/FORECAST-FUNNEL.md for the post-2017 grib2 follow-up."
+    )
+
+
+# ── small helpers ───────────────────────────────────────────────────────────
+def _region_swne(region: str) -> tuple[tuple[float, float], tuple[float, float]]:
+    cfg = load_lookups().get("regions", {}).get(region)
+    if not cfg:
+        raise KeyError(f"region {region!r} not in lookups.toml [regions]")
+    return tuple(cfg["sw"]), tuple(cfg["ne"])
+
+
+def _first_ds(obj):
+    """Herbie ``.xarray`` returns a list when a search spans un-mergeable cubes."""
+    if isinstance(obj, list):
+        if not obj:
+            raise ValueError("Herbie returned an empty dataset list")
+        return obj[0]
+    return obj
+
+
+def _pick(ds, logical: str):
+    """Return the DataArray for a logical field, trying cfgrib short-name aliases."""
+    for name in _CFGRIB_NAMES[logical]:
+        if name in ds:
+            return ds[name]
+    # last resort: the sole data var (single-field search)
+    dvs = list(ds.data_vars)
+    if len(dvs) == 1:
+        return ds[dvs[0]]
+    raise KeyError(f"none of {_CFGRIB_NAMES[logical]} in dataset (have {dvs})")
+
+
+def _lonlat_2d(ds) -> tuple[np.ndarray, np.ndarray]:
+    lon = np.asarray(ds["longitude"].values, dtype=float)
+    lat = np.asarray(ds["latitude"].values, dtype=float)
+    # Normalise longitude to -180..180 for plotting over CONUS.
+    lon = np.where(lon > 180.0, lon - 360.0, lon)
+    return lon, lat
+
+
+def _grid_spacing_m(lon2d: np.ndarray, lat2d: np.ndarray) -> tuple[float, float]:
+    """Approximate (dx, dy) in metres from a 2-D lon/lat grid (for gradients)."""
+    latm = float(np.nanmean(lat2d))
+    dlon = float(np.nanmean(np.abs(np.diff(lon2d, axis=1)))) or 0.1
+    dlat = float(np.nanmean(np.abs(np.diff(lat2d, axis=0)))) or 0.1
+    dx = 111_320.0 * np.cos(np.deg2rad(latm)) * dlon
+    dy = 110_540.0 * dlat
+    return float(dx), float(dy)
+
+
+def specific_humidity_g_per_kg(q_kg_kg=None, *, rh_pct=None, temp_k=None,
+                               pressure_hpa=None) -> np.ndarray:
+    """Specific humidity in g/kg: direct SPFH if given, else derived from RH/T/p.
+
+    The Herbie path supplies SPFH directly; the NCEI grib1 analysis may carry only
+    RH, so we derive q via Bolton saturation pressure (reusing ``derived``).
+    """
+    if q_kg_kg is not None:
+        return np.asarray(q_kg_kg, dtype=float) * 1000.0
+    if rh_pct is None or temp_k is None or pressure_hpa is None:
+        raise ValueError("need q, or all of rh_pct/temp_k/pressure_hpa")
+    es = saturation_vapor_pressure(np.asarray(temp_k, dtype=float))  # Pa
+    e = np.clip(np.asarray(rh_pct, dtype=float) / 100.0, 0.0, 1.0) * es
+    r = mixing_ratio(e, float(pressure_hpa) * 100.0)  # kg/kg
+    return (r / (1.0 + r)) * 1000.0
+
+
+# ── diagnostics ─────────────────────────────────────────────────────────────
+def pressure_centers(mslp_hpa, lon2d, lat2d, *, window_pts: int = 25,
+                     edge_margin: int = 4, min_sep_deg: float = 6.0) -> list[dict]:
+    """Detect High/Low sea-level-pressure centres (local extrema).
+
+    Uses a moving-window min/max filter, drops edge hits, and greedily enforces a
+    minimum separation.  Returns dicts ``{lon, lat, value, kind}`` with ``kind`` in
+    ``{"H", "L"}`` and ``value`` in hPa.
+    """
+    from scipy.ndimage import maximum_filter, minimum_filter
+
+    p = np.asarray(mslp_hpa, dtype=float)
+    lon = np.asarray(lon2d, dtype=float)
+    lat = np.asarray(lat2d, dtype=float)
+    size = max(3, int(window_pts))
+    lows = (p == minimum_filter(p, size=size, mode="nearest"))
+    highs = (p == maximum_filter(p, size=size, mode="nearest"))
+
+    m = edge_margin
+    interior = np.zeros_like(p, dtype=bool)
+    interior[m:-m or None, m:-m or None] = True
+
+    cand: list[dict] = []
+    for mask, kind in ((lows, "L"), (highs, "H")):
+        jj, ii = np.where(mask & interior & np.isfinite(p))
+        for j, i in zip(jj, ii):
+            cand.append({"lon": float(lon[j, i]), "lat": float(lat[j, i]),
+                         "value": float(p[j, i]), "kind": kind})
+    # Rank lows by lowest pressure, highs by highest; interleave by extremeness.
+    cand.sort(key=lambda c: c["value"] if c["kind"] == "L" else -c["value"])
+    kept: list[dict] = []
+    for c in cand:
+        if all(abs(c["lon"] - k["lon"]) > min_sep_deg
+               or abs(c["lat"] - k["lat"]) > min_sep_deg for k in kept):
+            kept.append(c)
+    return kept
+
+
+def thermal_front_parameter(temp2d, dx_m: float, dy_m: float, *,
+                            smooth_sigma: float = 4.0,
+                            min_grad_per_100km: float = 1.5) -> np.ndarray:
+    """Thermal Front Parameter, TFP = -grad|gradT| . (gradT/|gradT|).
+
+    Returned in K per (100 km)^2 so a physical threshold (~1-3) is meaningful.  The
+    field is smoothed first (standard practice; ``smooth_sigma`` in grid cells) to tame
+    the double-gradient noise, and TFP is **gated to zero where the thermal gradient is
+    weaker than** ``min_grad_per_100km`` (K per 100 km) so real 12 km data does not
+    sprout spurious frontlets in near-barotropic air.  TFP marks baroclinic zones; it
+    does **not** type fronts.
+    """
+    from brc_tools.visualize.upperair import _nan_gaussian
+
+    t = np.asarray(temp2d, dtype=float)
+    if smooth_sigma and smooth_sigma > 0:
+        t = _nan_gaussian(t, smooth_sigma)
+    d_ty, d_tx = np.gradient(t, dy_m, dx_m)
+    mag = np.sqrt(d_tx**2 + d_ty**2)                    # K / m
+    with np.errstate(invalid="ignore", divide="ignore"):
+        nx = np.where(mag > 0, d_tx / mag, 0.0)
+        ny = np.where(mag > 0, d_ty / mag, 0.0)
+    d_my, d_mx = np.gradient(mag, dy_m, dx_m)
+    tfp = -(d_mx * nx + d_my * ny) * 1.0e10             # -> K / (100 km)^2
+    # Gate out weakly-baroclinic air (|gradT| in K per 100 km).
+    tfp = np.where(mag * 1.0e5 >= min_grad_per_100km, tfp, 0.0)
+    return tfp
+
+
+def temperature_advection(temp2d, u2d, v2d, dx_m: float, dy_m: float, *,
+                          smooth_sigma: float = 2.0) -> np.ndarray:
+    """Horizontal temperature advection -V.gradT (K/h) — warm/cold-air advection.
+
+    Positive = warm-air advection, negative = cold-air advection.  Used both for the
+    surface front colouring (850 hPa) and the 600 hPa thermal-advection contours.
+    """
+    from brc_tools.visualize.upperair import _nan_gaussian
+
+    t = np.asarray(temp2d, dtype=float)
+    if smooth_sigma and smooth_sigma > 0:
+        t = _nan_gaussian(t, smooth_sigma)
+    d_ty, d_tx = np.gradient(t, dy_m, dx_m)
+    adv = -(np.asarray(u2d, dtype=float) * d_tx + np.asarray(v2d, dtype=float) * d_ty)
+    return adv * 3600.0
+
+
+def absolute_vorticity(u2d, v2d, lat2d, dx_m: float, dy_m: float) -> np.ndarray:
+    """Absolute vorticity (relative + planetary) in 10^-5 s^-1.
+
+    zeta = dv/dx - du/dy; f = 2 Omega sin(phi).  Approximate on a lon/lat grid (dx/dy
+    from :func:`_grid_spacing_m`) — fine for a synoptic 500 hPa shortwave diagnostic.
+    """
+    u = np.asarray(u2d, dtype=float)
+    v = np.asarray(v2d, dtype=float)
+    du_dy, du_dx = np.gradient(u, dy_m, dx_m)
+    dv_dy, dv_dx = np.gradient(v, dy_m, dx_m)
+    zeta = dv_dx - du_dy
+    f = 2.0 * 7.2921e-5 * np.sin(np.deg2rad(np.asarray(lat2d, dtype=float)))
+    return (zeta + f) * 1.0e5
+
+
+# ── fetch: assemble a uniform "full" dataset ────────────────────────────────
+def _assemble_full(*, lat2d, lon2d, levels, gh, u, v, t600, t850, u850, v850,
+                   q600_g_kg, mslp_pa):
+    """Build one xarray Dataset (dims y,x; 2-D lat/lon coords) for uniform cropping."""
+    import xarray as xr
+
+    dv: dict = {}
+    for lv in levels:
+        dv[f"gh{lv}"] = (("y", "x"), np.asarray(gh[lv], dtype=float))
+        dv[f"u{lv}"] = (("y", "x"), np.asarray(u[lv], dtype=float))
+        dv[f"v{lv}"] = (("y", "x"), np.asarray(v[lv], dtype=float))
+    dv["t600"] = (("y", "x"), np.asarray(t600, dtype=float))
+    dv["t850"] = (("y", "x"), np.asarray(t850, dtype=float))
+    dv["u850"] = (("y", "x"), np.asarray(u850, dtype=float))
+    dv["v850"] = (("y", "x"), np.asarray(v850, dtype=float))
+    dv["q600"] = (("y", "x"), np.asarray(q600_g_kg, dtype=float))
+    dv["mslp"] = (("y", "x"), np.asarray(mslp_pa, dtype=float))
+    return xr.Dataset(
+        dv,
+        coords={"latitude": (("y", "x"), np.asarray(lat2d, dtype=float)),
+                "longitude": (("y", "x"), np.asarray(lon2d, dtype=float))},
+    )
+
+
+def _sel_level(da, level: int):
+    """Select a single pressure level from an isobaric DataArray -> 2-D array."""
+    if "isobaricInhPa" in da.dims:
+        return np.asarray(da.sel(isobaricInhPa=level).values, dtype=float)
+    return np.asarray(da.values, dtype=float)
+
+
+def _herbie_fetch_full(init_dt: dt.datetime, levels, cache_dir):
+    """Fetch the funnel fields from Herbie's operational NAM (analysis, fxx=0)."""
+    from herbie import Herbie
+
+    kwargs = dict(model=_NAM_HERBIE_MODEL, product=_NAM_HERBIE_PRODUCT, fxx=0)
+    if cache_dir:
+        kwargs["save_dir"] = str(cache_dir)
+    H = Herbie(init_dt, **kwargs)
+
+    lv_re = "|".join(str(int(lv)) for lv in levels)
+    iso = _first_ds(H.xarray(rf":(HGT|UGRD|VGRD|TMP):({lv_re}) mb:", remove_grib=False))
+    b850 = _first_ds(H.xarray(r":(TMP|UGRD|VGRD):850 mb:", remove_grib=False))
+    slp = _first_ds(H.xarray(r":(PRMSL|MSLET):mean sea level:", remove_grib=False))
+
+    lon2d, lat2d = _lonlat_2d(iso)
+    gh = {lv: _sel_level(_pick(iso, "gh"), lv) for lv in levels}
+    uu = {lv: _sel_level(_pick(iso, "u"), lv) for lv in levels}
+    vv = {lv: _sel_level(_pick(iso, "v"), lv) for lv in levels}
+    t600 = _sel_level(_pick(iso, "t"), 600)
+
+    # NAM awphys carries RH (not SPFH) on pressure levels, so derive q from RH + T; try
+    # SPFH first for any model that does ship it.  A search matching zero messages makes
+    # Herbie write no subset (cfgrib then FileNotFoundError), so fall back on any failure.
+    try:
+        q_ds = _first_ds(H.xarray(r":SPFH:600 mb:", remove_grib=False))
+        q600 = specific_humidity_g_per_kg(_sel_level(_pick(q_ds, "q"), 600))
+    except Exception:  # noqa: BLE001 - no SPFH message -> RH fallback
+        rh_ds = _first_ds(H.xarray(r":RH:600 mb:", remove_grib=False))
+        q600 = specific_humidity_g_per_kg(
+            rh_pct=_sel_level(_pick(rh_ds, "r"), 600),
+            temp_k=t600, pressure_hpa=600.0)
+    return _assemble_full(
+        lat2d=lat2d, lon2d=lon2d, levels=levels, gh=gh, u=uu, v=vv,
+        t600=t600,
+        t850=_sel_level(_pick(b850, "t"), 850),
+        u850=_sel_level(_pick(b850, "u"), 850),
+        v850=_sel_level(_pick(b850, "v"), 850),
+        q600_g_kg=q600, mslp_pa=_sel_level(_pick(slp, "mslp"), 0),
+    )
+
+
+def _ncei_fetch_full(init_time, levels, cache_dir):
+    """Fetch the funnel fields from a staged NCEI grib1 NAM analysis (f00)."""
+    import xarray as xr
+
+    from brc_tools.nwp.wrf_staging import stage_nam_analysis
+
+    import tempfile
+
+    staged = stage_nam_analysis(
+        init_time=init_time, fxx_window=(0, 0),
+        output_root=cache_dir or tempfile.gettempdir(), case="forecast_funnel",
+    )
+    path = staged[0].local_path
+
+    # Open ONE variable at a time. The grib1 namanl carries variables on different
+    # isobaric level sets (HGT ~39 levels, RH ~5), so a single typeOfLevel filter makes
+    # cfgrib raise DatasetBuildError and silently drop fields; a per-shortName filter
+    # gives each variable its own consistent cube.
+    def _open(short=None, level_type="isobaricInhPa"):
+        keys: dict = {"typeOfLevel": level_type}
+        if short:
+            keys["shortName"] = short
+        return xr.open_dataset(
+            str(path), engine="cfgrib",
+            backend_kwargs={"indexpath": "", "filter_by_keys": keys},
+        )
+
+    gh_ds, u_ds, v_ds, t_ds = _open("gh"), _open("u"), _open("v"), _open("t")
+    lon2d, lat2d = _lonlat_2d(gh_ds)
+    gh_da, u_da, v_da, t_da = (_pick(gh_ds, "gh"), _pick(u_ds, "u"),
+                               _pick(v_ds, "v"), _pick(t_ds, "t"))
+    gh = {lv: _sel_level(gh_da, lv) for lv in levels}
+    uu = {lv: _sel_level(u_da, lv) for lv in levels}
+    vv = {lv: _sel_level(v_da, lv) for lv in levels}
+
+    # SPFH may be absent from the historical analysis -> derive from RH + T.
+    try:
+        q600 = specific_humidity_g_per_kg(_sel_level(_pick(_open("q"), "q"), 600))
+    except Exception:  # noqa: BLE001 - no SPFH message -> RH fallback
+        q600 = specific_humidity_g_per_kg(
+            rh_pct=_sel_level(_pick(_open("r"), "r"), 600),
+            temp_k=_sel_level(t_da, 600), pressure_hpa=600.0)
+
+    slp = _open(level_type="meanSea")
+    return _assemble_full(
+        lat2d=lat2d, lon2d=lon2d, levels=levels, gh=gh, u=uu, v=vv,
+        t600=_sel_level(t_da, 600), t850=_sel_level(t_da, 850),
+        u850=_sel_level(u_da, 850), v850=_sel_level(v_da, 850),
+        q600_g_kg=q600, mslp_pa=_sel_level(_pick(slp, "mslp"), 0),
+    )
+
+
+# ── panel assembly ──────────────────────────────────────────────────────────
+def _build_panel(full, spec: PanelSpec, lu) -> Panel | None:
+    """Crop ``full`` to a panel's region and package its plain-array fields."""
+    sw, ne = _region_swne(spec.region)
+    sub = crop_to_bbox(full, sw, ne, "lonlat_after_aux")
+    lon = np.asarray(sub["longitude"].values, dtype=float)
+    lat = np.asarray(sub["latitude"].values, dtype=float)
+    if lon.size == 0 or lat.size == 0:
+        LOG.warning("panel %s: empty crop over region %s", spec.key, spec.region)
+        return None
+    extent = (float(np.nanmin(lon)), float(np.nanmax(lon)),
+              float(np.nanmin(lat)), float(np.nanmax(lat)))
+
+    waypoints = None
+    if spec.waypoint_group:
+        names = lu.get("waypoint_groups", {}).get(spec.waypoint_group, [])
+        waypoints = {n: lu["waypoints"][n] for n in names if n in lu.get("waypoints", {})}
+
+    if spec.kind in ("isotach", "vorticity", "moisture"):
+        lv = spec.level
+        u = np.asarray(sub[f"u{lv}"].values, dtype=float)
+        v = np.asarray(sub[f"v{lv}"].values, dtype=float)
+        fields = {"height": np.asarray(sub[f"gh{lv}"].values, dtype=float),
+                  "u": u, "v": v}
+        if spec.kind == "isotach":
+            fields["scalar"] = wind_speed(u, v)
+        elif spec.kind == "vorticity":
+            dx, dy = _grid_spacing_m(lon, lat)
+            fields["scalar"] = absolute_vorticity(u, v, lat, dx, dy)
+        else:  # moisture: humidity fill + warm/cold-air (temperature) advection.
+            # SPFH/TMP are staged at 600 hPa only (the moisture panel is fixed at 600).
+            dx, dy = _grid_spacing_m(lon, lat)
+            fields["scalar"] = np.asarray(sub["q600"].values, dtype=float)
+            fields["t_adv"] = temperature_advection(
+                np.asarray(sub["t600"].values, dtype=float), u, v, dx, dy)
+        return Panel(spec.key, spec.kind, spec.title, f"{lv} hPa", extent, lon, lat,
+                     fields, style_key=spec.style_key, waypoints=waypoints)
+
+    # synoptic surface panel
+    dx, dy = _grid_spacing_m(lon, lat)
+    t850 = np.asarray(sub["t850"].values, dtype=float)
+    mslp_hpa = np.asarray(sub["mslp"].values, dtype=float) / 100.0
+    fronts = {
+        "tfp": thermal_front_parameter(t850, dx, dy),
+        "t_adv": temperature_advection(
+            t850, np.asarray(sub["u850"].values, dtype=float),
+            np.asarray(sub["v850"].values, dtype=float), dx, dy),
+    }
+    return Panel(spec.key, spec.kind, spec.title, "mean sea level", extent, lon, lat,
+                 {"mslp": mslp_hpa}, style_key=None, waypoints=waypoints,
+                 centers=pressure_centers(mslp_hpa, lon, lat), fronts=fronts)
+
+
+def fetch_funnel_fields(
+    init_time,
+    *,
+    source: str = "auto",
+    cache_dir: str | Path | None = None,
+    levels=DEFAULT_LEVELS,
+    panels: tuple[PanelSpec, ...] = FUNNEL_PANELS,
+) -> FunnelData:
+    """Download a NAM analysis and reduce it to per-panel plain-array bundles.
+
+    ``source`` is ``"auto"`` (pick by init date), ``"herbie"``, or ``"ncei"``.  For
+    an analysis the valid time equals the init time.  GRIB caches under
+    ``cache_dir`` (or ``$BRC_TOOLS_HERBIE_CACHE`` for the Herbie path) — never the
+    repo checkout.
+    """
+    init_dt = _parse_init_time(init_time)
+    # Always fetch every level a panel needs, so a trimmed --levels can't starve one.
+    needed = {int(lv) for lv in levels} | {int(s.level) for s in panels if s.level}
+    levels = tuple(sorted(needed))
+    chosen = funnel_source_for(init_dt) if source == "auto" else source
+    LOG.info("forecast funnel: init %s, source=%s, levels=%s",
+             init_dt.isoformat(), chosen, levels)
+
+    if chosen == "herbie":
+        full = _herbie_fetch_full(init_dt, levels, cache_dir)
+        model_label = "NAM 12 km analysis (Herbie/operational)"
+    elif chosen == "ncei":
+        full = _ncei_fetch_full(init_time, levels, cache_dir)
+        model_label = "NAM 12 km analysis (NCEI namanl_218)"
+    else:
+        raise ValueError(f"unknown source {source!r} (want auto|herbie|ncei)")
+
+    lu = load_lookups()
+    built = [_build_panel(full, spec, lu) for spec in panels]
+    return FunnelData(
+        init_time=init_dt, valid_time=init_dt, source=chosen,
+        model_label=model_label, panels=[p for p in built if p is not None],
+    )

--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -184,6 +184,11 @@ ne = [42.1, -108.9]
 sw = [21.0, -125.0]
 ne = [50.0, -66.0]
 
+# Western CONUS — the forecast-funnel 500 hPa + surface-analysis panels.
+[regions.west_conus]
+sw = [28.0, -125.0]
+ne = [50.0, -100.0]
+
 # ── Waypoints ───────────────────────────────────────────────────────────────
 
 [waypoints.daniels_summit]

--- a/brc_tools/visualize/basemap.py
+++ b/brc_tools/visualize/basemap.py
@@ -32,6 +32,7 @@ _LAYERS: dict[str, tuple[str, str]] = {
     "roads": ("cultural", "roads"),
     "rivers": ("physical", "rivers_lake_centerlines"),
     "lakes": ("physical", "lakes"),
+    "cities": ("cultural", "populated_places"),
 }
 
 # Layer draw order and default line styling (rivers/roads over lakes, borders on top).
@@ -199,6 +200,76 @@ def draw_waypoints(
         placed.append((lon, lat))
 
 
+def _default_city_rank(extent) -> int:
+    """Pick a Natural-Earth SCALERANK cutoff from the map span (fewer on wide maps)."""
+    span = max(abs(float(extent[1]) - float(extent[0])),
+               abs(float(extent[3]) - float(extent[2])))
+    if span >= 28.0:   # CONUS-scale: only the largest cities
+        return 2
+    if span >= 12.0:   # regional (a few states)
+        return 4
+    return 7           # local: towns for context
+
+
+def draw_cities(
+    ax,
+    extent,
+    *,
+    resolution: str = "10m",
+    max_rank: int | None = None,
+    max_cities: int = 40,
+    transform=None,
+    fontsize: float = 6.0,
+    color: str = "0.15",
+    marker: str = "o",
+    ms: float = 2.5,
+    zorder: float = 6.0,
+) -> None:
+    """Plot population-ranked city markers + decluttered labels within ``extent``.
+
+    Reads the staged Natural-Earth ``populated_places`` layer and keeps only places
+    at or above ``max_rank`` prominence (lower ``SCALERANK`` = larger city); the cutoff
+    defaults to the map span so a CONUS panel shows only major cities and a local panel
+    shows towns.  Fail-soft: returns silently if the layer is not staged.
+    """
+    records = _load_records("cities", resolution)
+    if not records:
+        return
+    lo_x, hi_x = sorted((float(extent[0]), float(extent[1])))
+    lo_y, hi_y = sorted((float(extent[2]), float(extent[3])))
+    if max_rank is None:
+        max_rank = _default_city_rank(extent)
+    tkw = {} if transform is None else {"transform": transform}
+
+    cand: list[tuple] = []
+    for geom, attrs in records:
+        try:
+            x, y = float(geom.x), float(geom.y)
+        except Exception:  # pragma: no cover - non-point geometry
+            continue
+        if not (lo_x <= x <= hi_x and lo_y <= y <= hi_y):
+            continue
+        rank = attrs.get("SCALERANK", attrs.get("scalerank"))
+        rank = 99 if rank is None else int(rank)
+        if rank > max_rank:
+            continue
+        pop = attrs.get("POP_MAX", attrs.get("pop_max")) or 0
+        name = attrs.get("NAME", attrs.get("name")) or ""
+        cand.append((rank, -float(pop), x, y, name))
+
+    cand.sort()  # most prominent first (low rank, then high population)
+    span_x, span_y = hi_x - lo_x, hi_y - lo_y
+    sep_x, sep_y = 0.05 * span_x, 0.05 * span_y
+    placed: list[tuple[float, float]] = []
+    for _rank, _negpop, x, y, name in cand[:max_cities]:
+        ax.plot(x, y, marker=marker, color=color, ms=ms, zorder=zorder, **tkw)
+        if any(abs(x - px) < sep_x and abs(y - py) < sep_y for px, py in placed):
+            continue
+        ax.text(x, y, f" {name}", fontsize=fontsize, color=color, zorder=zorder,
+                clip_on=True, **tkw)
+        placed.append((x, y))
+
+
 def add_reference_overlays(
     ax,
     extent,
@@ -208,6 +279,8 @@ def add_reference_overlays(
     roads: bool = True,
     rivers: bool = True,
     lakes: bool = True,
+    cities: bool = False,
+    city_rank: int | None = None,
     highways_only: bool = True,
     resolution: str = "10m",
     transform=None,
@@ -218,13 +291,17 @@ def add_reference_overlays(
     e.g. a case's ``[map]`` table) overrides the individual flags when given.  Pass
     ``transform=ccrs.PlateCarree()`` for a cartopy GeoAxes; leave it ``None`` for the
     plain lon/lat axes the renderers use.  Fail-soft: any absent layer is skipped.
+
+    ``cities`` (off by default, so existing figures are unchanged) draws
+    population-ranked city labels via :func:`draw_cities`.
     """
     if layers is not None:
         states = bool(layers.get("states", states))
         roads = bool(layers.get("roads", roads))
         rivers = bool(layers.get("rivers", rivers))
         lakes = bool(layers.get("lakes", lakes))
-    if not (states or roads or rivers or lakes):
+        cities = bool(layers.get("cities", cities))
+    if not (states or roads or rivers or lakes or cities):
         return
     try:
         from shapely.geometry import box as _box
@@ -251,3 +328,6 @@ def add_reference_overlays(
     if states:
         _draw_lines(ax, _load_records("states", resolution), bbox, pbox,
                     _LINE_STYLE["states"], transform_kw=transform_kw)
+    if cities:
+        draw_cities(ax, extent, max_rank=city_rank, resolution=resolution,
+                    transform=transform)

--- a/brc_tools/visualize/funnel.py
+++ b/brc_tools/visualize/funnel.py
@@ -1,0 +1,253 @@
+"""Forecast-funnel renderers: synoptic -> regional -> local -> surface montage.
+
+The plotting half of the forecast funnel.  Like the rest of ``visualize`` these
+renderers take **plain lon/lat arrays** (never datasets), call ``use_publication_style``
+downstream for the shared Helvetica look, and dress each panel with the fail-soft
+Natural-Earth overlays (state borders, rivers, lakes, population-ranked city labels).
+The data layer :mod:`brc_tools.nwp.forecast_funnel` owns every GRIB concern and hands
+this module ready-cropped arrays as :class:`~brc_tools.nwp.forecast_funnel.Panel`
+objects; the panel functions are duck-typed on plain arrays so they unit-test with
+synthetic input.
+
+Panels:
+
+* **isotach** (250 / 500 hPa) — wind-speed fill, geopotential-height contours, barbs.
+* **moisture** (600 hPa) — specific-humidity fill, height contours, barbs, a bold
+  low-level-jet isotach contour.
+* **synoptic** (surface) — smoothed MSLP isobars, auto H/L centres, and diagnostic
+  Thermal-Front-Parameter frontal zones (approximate — TFP marks baroclinic zones,
+  it does not truly type warm/cold fronts).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+KT = 1.94384  # m/s -> knots
+
+# Funnel overlays: borders + hydrography + city labels; roads off (too busy at
+# synoptic scale).  ``cities`` is read from this dict by ``add_reference_overlays``.
+_FUNNEL_OVERLAYS = {"states": True, "roads": False, "rivers": True,
+                    "lakes": True, "cities": True}
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _validate_output_dir(path: Path) -> None:
+    """Refuse to write a funnel figure into the repo checkout (runtime output rule)."""
+    resolved = Path(path).resolve()
+    if resolved == _REPO_ROOT or _REPO_ROOT in resolved.parents:
+        raise SystemExit(f"refusing to write figure into the repo checkout: {resolved}")
+
+
+def _contour_levels(field, interval: float) -> np.ndarray:
+    """Evenly spaced contour levels spanning a field's finite range."""
+    vals = np.asarray(field, dtype=float)
+    finite = vals[np.isfinite(vals)]
+    if finite.size == 0:
+        return np.array([])
+    lo = np.floor(float(finite.min()) / interval) * interval
+    hi = np.ceil(float(finite.max()) / interval) * interval
+    return np.arange(lo, hi + interval, interval)
+
+
+def _draw_overlays(ax, extent, waypoints=None):
+    """Shared fail-soft dressing: Natural-Earth overlays + optional waypoints."""
+    from brc_tools.visualize.basemap import add_reference_overlays, draw_waypoints
+
+    add_reference_overlays(ax, extent, layers=_FUNNEL_OVERLAYS)
+    if waypoints:
+        draw_waypoints(ax, waypoints, extent, zorder=11)
+
+
+def _finish_axes(ax, lat, extent, title):
+    ax.set_xlim(extent[0], extent[1])
+    ax.set_ylim(extent[2], extent[3])
+    ax.set_aspect(1.0 / np.cos(np.deg2rad(float(np.nanmean(lat)))))
+    ax.tick_params(labelsize=7)
+    ax.set_title(title)
+
+
+def _draw_barbs(ax, lon, lat, u, v, stride):
+    sy = max(1, u.shape[0] // stride)
+    sx = max(1, u.shape[1] // stride)
+    ax.barbs(lon[::sy, ::sx], lat[::sy, ::sx],
+             (np.asarray(u) * KT)[::sy, ::sx], (np.asarray(v) * KT)[::sy, ::sx],
+             length=5, linewidth=0.5, zorder=5)
+
+
+def _draw_heights(ax, lon, lat, height_m, interval_dam):
+    dam = np.asarray(height_m, dtype=float) / 10.0  # metres -> decametres
+    levels = _contour_levels(dam, interval_dam)
+    if levels.size:
+        cs = ax.contour(lon, lat, dam, levels=levels, colors="black",
+                        linewidths=0.6, alpha=0.8, zorder=4)
+        ax.clabel(cs, fontsize=6, fmt="%d", inline=True)
+
+
+def plot_upperair_panel(ax, lon, lat, fill, height, u, v, *, style, level_label,
+                        extent, waypoints=None, barbs=True, height_interval_dam=6.0,
+                        barb_stride=18, title=None):
+    """Scalar fill (isotachs or absolute vorticity) + height contours + barbs."""
+    lon = np.asarray(lon)
+    lat = np.asarray(lat)
+    mesh = ax.pcolormesh(lon, lat, np.asarray(fill, dtype=float), shading="auto",
+                         cmap=style.cmap, vmin=style.vmin, vmax=style.vmax, alpha=0.95)
+    ax.figure.colorbar(mesh, ax=ax, shrink=0.85, extend=style.extend, label=style.label)
+    _draw_heights(ax, lon, lat, height, height_interval_dam)
+    if barbs and u is not None and v is not None:
+        _draw_barbs(ax, lon, lat, u, v, barb_stride)
+    _draw_overlays(ax, extent, waypoints)
+    _finish_axes(ax, lat, extent, title or f"{level_label}")
+    return mesh
+
+
+# Temperature-advection contour levels (K/h): warm (red, solid) / cold (blue, dashed).
+_ADV_LEVELS = np.array([-3.0, -2.0, -1.0, -0.5, 0.5, 1.0, 2.0, 3.0])
+
+
+def plot_moisture_panel(ax, lon, lat, spfh, height, u, v, *, style, level_label,
+                        extent, waypoints=None, t_adv=None, height_interval_dam=6.0,
+                        barb_stride=14, title=None):
+    """Specific-humidity fill + heights + warm/cold-air (temperature) advection + barbs."""
+    lon = np.asarray(lon)
+    lat = np.asarray(lat)
+    mesh = ax.pcolormesh(lon, lat, np.asarray(spfh, dtype=float), shading="auto",
+                         cmap=style.cmap, vmin=style.vmin, vmax=style.vmax, alpha=0.95)
+    ax.figure.colorbar(mesh, ax=ax, shrink=0.85, extend=style.extend, label=style.label)
+    _draw_heights(ax, lon, lat, height, height_interval_dam)
+    if t_adv is not None:
+        adv = np.asarray(t_adv, dtype=float)
+        if np.isfinite(adv).any() and float(np.nanmax(np.abs(adv))) >= _ADV_LEVELS[-1] * 0.15:
+            colors = ["#1565c0" if lv < 0 else "#c62828" for lv in _ADV_LEVELS]
+            styles = ["dashed" if lv < 0 else "solid" for lv in _ADV_LEVELS]
+            cs = ax.contour(lon, lat, adv, levels=_ADV_LEVELS, colors=colors,
+                            linestyles=styles, linewidths=0.8, alpha=0.9, zorder=4.5)
+            ax.clabel(cs, fontsize=5.5, fmt="%.1f", inline=True)
+    if u is not None and v is not None:
+        _draw_barbs(ax, lon, lat, u, v, barb_stride)
+    _draw_overlays(ax, extent, waypoints)
+    _finish_axes(ax, lat, extent, title or f"{level_label}")
+    return mesh
+
+
+def plot_synoptic_panel(ax, lon, lat, mslp_hpa, *, centers=None, tfp=None, t_adv=None,
+                        extent, waypoints=None, isobar_interval=4.0, smooth_sigma=1.5,
+                        tfp_threshold=1.5, title=None):
+    """Surface analysis: smoothed MSLP isobars, H/L centres, and TFP frontal zones."""
+    from brc_tools.visualize.upperair import _nan_gaussian
+
+    lon = np.asarray(lon)
+    lat = np.asarray(lat)
+    p = np.asarray(mslp_hpa, dtype=float)
+    if smooth_sigma and smooth_sigma > 0:
+        p = _nan_gaussian(p, smooth_sigma)
+
+    levels = _contour_levels(p, isobar_interval)
+    if levels.size:
+        cs = ax.contour(lon, lat, p, levels=levels, colors="0.25",
+                        linewidths=0.7, zorder=4)
+        ax.clabel(cs, fontsize=6, fmt="%d", inline=True)
+
+    # Diagnostic TFP frontal zones: contour the threshold isopleth, split by 850 hPa
+    # advection so the line is coloured cold (blue) / warm (red).  Mask by advection
+    # sign only — NOT by the threshold — so the field still crosses ``tfp_threshold``
+    # inside each region and ``contour`` actually draws a line.
+    if tfp is not None:
+        tfp = np.asarray(tfp, dtype=float)
+        adv = np.zeros_like(tfp) if t_adv is None else np.asarray(t_adv, dtype=float)
+        cold = np.where(adv < 0, tfp, np.nan)
+        warm = np.where(adv >= 0, tfp, np.nan)
+        for f, c in ((cold, "#1565c0"), (warm, "#c62828")):
+            if np.isfinite(f).any() and np.nanmax(f) >= tfp_threshold:
+                ax.contour(lon, lat, f, levels=[tfp_threshold], colors=c,
+                           linewidths=1.6, alpha=0.9, zorder=4.5)
+
+    for c in centers or []:
+        col = "#1565c0" if c["kind"] == "L" else "#c62828"
+        ax.text(c["lon"], c["lat"], c["kind"], fontsize=15, fontweight="bold",
+                color=col, ha="center", va="center", zorder=12)
+        off = 0.03 * (extent[3] - extent[2])
+        ax.text(c["lon"], c["lat"] - off, f"{c['value']:.0f}", fontsize=6.5,
+                color=col, ha="center", va="top", zorder=12)
+
+    _draw_overlays(ax, extent, waypoints)
+    _finish_axes(ax, lat, extent, title or "mean sea level")
+    return None
+
+
+# ── panel dispatch + montage ────────────────────────────────────────────────
+def _render_panel(ax, panel):
+    """Dispatch one funnel Panel onto an axis by its kind."""
+    from brc_tools.visualize.style import resolve_style
+
+    f = panel.fields
+    if panel.kind in ("isotach", "vorticity"):
+        default_style = "wind_speed" if panel.kind == "isotach" else "abs_vorticity_500"
+        style = resolve_style(panel.style_key or default_style)
+        interval = 12.0 if "250" in panel.level_label else 6.0
+        plot_upperair_panel(ax, panel.lon, panel.lat, f["scalar"], f["height"],
+                            f["u"], f["v"], style=style, level_label=panel.level_label,
+                            extent=panel.extent, waypoints=panel.waypoints,
+                            height_interval_dam=interval,
+                            title=f"{panel.key}) {panel.title}")
+    elif panel.kind == "moisture":
+        style = resolve_style(panel.style_key or "spec_humidity_600")
+        plot_moisture_panel(ax, panel.lon, panel.lat, f["scalar"], f["height"],
+                            f["u"], f["v"], style=style, level_label=panel.level_label,
+                            extent=panel.extent, waypoints=panel.waypoints,
+                            t_adv=f.get("t_adv"), title=f"{panel.key}) {panel.title}")
+    elif panel.kind == "synoptic":
+        fr = panel.fronts or {}
+        plot_synoptic_panel(ax, panel.lon, panel.lat, f["mslp"],
+                            centers=panel.centers, tfp=fr.get("tfp"),
+                            t_adv=fr.get("t_adv"), extent=panel.extent,
+                            waypoints=panel.waypoints,
+                            title=f"{panel.key}) {panel.title}")
+    else:  # pragma: no cover - defensive
+        ax.set_axis_off()
+
+
+def plot_forecast_funnel(data, out_path, *, dpi: int = 300, title: str | None = None,
+                         figsize: tuple[float, float] = (13.0, 11.0),
+                         annotation: str | None = None) -> Path:
+    """Assemble the four funnel panels into one 2x2 montage figure.
+
+    ``data`` is a :class:`~brc_tools.nwp.forecast_funnel.FunnelData` (duck-typed:
+    ``.panels``, ``.init_time``, ``.valid_time``, ``.model_label``).  Refuses to write
+    inside the repo checkout.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    out = Path(out_path)
+    _validate_output_dir(out.parent)
+
+    by_key = {p.key: p for p in data.panels}
+    order = ["1a", "1b", "1c", "1d"]
+
+    fig, axes = plt.subplots(2, 2, figsize=figsize, constrained_layout=True)
+    flat = axes.ravel()
+    for ax, key in zip(flat, order):
+        panel = by_key.get(key)
+        if panel is None:
+            ax.set_axis_off()
+            ax.text(0.5, 0.5, f"{key}: unavailable", transform=ax.transAxes,
+                    ha="center", va="center", fontsize=9, color="0.5")
+            continue
+        _render_panel(ax, panel)
+
+    init_s = data.init_time.strftime("%Y-%m-%d %H:%MZ")
+    suptitle = title or f"Forecast funnel — {data.model_label}\nanalysis valid {init_s}"
+    fig.suptitle(suptitle, fontsize=12, fontweight="bold")
+    stamp = annotation or f"{data.model_label} | init {init_s} | BRC Tools"
+    fig.text(0.995, 0.004, stamp, ha="right", va="bottom", fontsize=6, alpha=0.6)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi)
+    plt.close(fig)
+    return out

--- a/brc_tools/visualize/style.py
+++ b/brc_tools/visualize/style.py
@@ -41,6 +41,16 @@ VAR_STYLES: dict[str, VarStyle] = {
     "temp_2m_c":      VarStyle("RdYlBu_r", r"$T_{2\,\mathrm{m}}$ ($^{\circ}$C)", -25.0, 10.0),
     "wind_speed_10m": VarStyle("YlGnBu", r"10 m wind (m s$^{-1}$)", 0.0, 15.0, extend="max"),
     "wind_speed":     VarStyle("YlGnBu", r"wind speed (m s$^{-1}$)", 0.0, 15.0, extend="max"),
+    # Forecast-funnel fills (fixed per level so a panel reads the same across cases):
+    # the 250 hPa jet-stream core reaches ~70 m/s; 600 hPa specific humidity 0..6 g/kg.
+    "wind_speed_250":  VarStyle("YlGnBu", r"250 hPa wind (m s$^{-1}$)", 0.0, 80.0, extend="max"),
+    "spec_humidity_600": VarStyle("YlGn", r"600 hPa spec. humidity (g kg$^{-1}$)",
+                                  0.0, 6.0, extend="max"),
+    # Classic 500 hPa chart: absolute vorticity shaded (10^-5 s^-1).  Mid-latitude f is
+    # ~9-11, so cyclonic shortwave maxima ride ~15-40; sequential warm ramp makes the
+    # trough/vort-max stand out.
+    "abs_vorticity_500": VarStyle("YlOrRd", r"500 hPa abs. vorticity ($10^{-5}$ s$^{-1}$)",
+                                  0.0, 40.0, extend="max"),
     "snow_depth":     VarStyle("Blues", "snow depth (m)", 0.0, 0.5, extend="max"),
     "pblh":           VarStyle("YlOrRd", "PBLH (m)", 0.0, 1000.0, extend="max"),
     "tsk_minus_t2":   VarStyle("RdBu_r", r"$T_{\mathrm{skin}}-T_{2\,\mathrm{m}}$ (K)", -8.0, 8.0, diverging=True),

--- a/docs/FORECAST-FUNNEL.md
+++ b/docs/FORECAST-FUNNEL.md
@@ -1,0 +1,79 @@
+# Forecast funnel (NAM synoptic montage)
+
+A **forecast funnel** is the classic top-down forecasting workflow — read the synoptic
+scale first (the jet, the long waves), zoom to the regional flow and moisture, then finish
+at the surface synoptic analysis. This tool renders that as one publication montage from a
+single NAM analysis, matching the repo's WRF-figure aesthetic (Helvetica / minimalist /
+fixed colour scales via `visualize/style.py`; fail-soft Natural-Earth overlays via
+`visualize/basemap.py`).
+
+- **Skill:** `/basin-forecast-funnel` (`.claude/skills/basin-forecast-funnel/SKILL.md`).
+- **CLI:** `scripts/forecast_funnel.py --init-time <when>`.
+- **SLURM (DTN):** `scripts/forecast_funnel.dtn.slurm`.
+- **Engine:** `brc_tools/nwp/forecast_funnel.py` (data) + `brc_tools/visualize/funnel.py` (render).
+
+## Panels
+
+A 2×2 montage; every panel carries state borders, population-ranked city labels, rivers and
+lakes:
+
+| Panel | Domain | Level | Fill | Contours | Vectors |
+|-------|--------|-------|------|----------|---------|
+| 1a | CONUS | 250 hPa | wind speed (jet isotachs) | geopotential height | barbs |
+| 1b | Western CONUS | 500 hPa | **absolute vorticity** | geopotential height | barbs |
+| 1c | Utah + neighbours | 600 hPa | **specific humidity** | geopotential height + **temperature advection** (warm red / cold blue) | barbs; basin waypoints labelled |
+| 1d | Western CONUS | surface | — | smoothed MSLP isobars | H/L centres + TFP frontal zones |
+
+It is a NAM **analysis** (f00), so the valid time equals the init time.
+
+## NAM source (auto-picked by init date)
+
+`funnel_source_for(init_dt)` chooses the download path:
+
+| Init date | Source | How |
+|-----------|--------|-----|
+| ≥ 2020-03 | `herbie` | Herbie operational `nam` model (`product="awphys"`, AWS/NOMADS). Herbie-native (the repo's preferred route). `awphys` ships **RH** (not SPFH) on pressure levels, so specific humidity is derived from RH + T. |
+| ≤ 2017-04 | `ncei` | Auth-free NCEI historical grib1 `namanl_218` via `wrf_staging.stage_nam_analysis`. Uses SPFH when present, else derives it from RH + T. |
+| 2017-04 … 2020-03 | — | **Unwired** — raises with a clear message. No post-2017 NCEI grib2 template exists yet (see Follow-ups). Use a recent or pre-2017 init for testing. |
+
+Override with `--source herbie|ncei`. Herbie's operational archive reaches back to roughly
+2020-02 on AWS (`noaa-nam-pds`) and only the last ~week on NOMADS; a very old "recent" init
+may still miss.
+
+## Usage
+
+```bash
+# recent init — Herbie path (run on a DTN for internet)
+sbatch scripts/forecast_funnel.dtn.slurm "2026-07-20 00Z"
+
+# historical init — NCEI path
+sbatch scripts/forecast_funnel.dtn.slurm "2013-01-31 00Z"
+
+# quick local test on any network node (no SLURM)
+python scripts/forecast_funnel.py --init-time "2026-07-20 00Z" \
+    --output-dir /scratch/general/vast/$USER/forecast_funnel
+```
+
+The montage is written to
+`/scratch/general/vast/$USER/forecast_funnel/forecast_funnel_<YYYYMMDD_HHMM>Z.png`.
+Outputs and GRIB always route to scratch — the renderer hard-refuses a repo-internal path.
+
+**Map overlays** need the Natural-Earth shapefiles (now including `populated_places` for the
+city labels) staged once into the persistent cache: `sbatch scripts/fetch_basemap.dtn.slurm`
+→ `$BRC_TOOLS_BASEMAP_DIR`. Overlays are fail-soft — an unstaged layer is silently omitted.
+
+## Fronts are diagnostic
+
+Panel 1d marks **Thermal-Front-Parameter (TFP)** baroclinic zones, coloured by 850 hPa
+temperature advection (blue where cold, red where warm). TFP identifies frontal *zones*; it
+does **not** truly type warm/cold/stationary fronts the way an analyst would. Treat the
+frontal overlay as a first guess, not a hand analysis. On real 12 km data the raw TFP is
+noisy, so `forecast_funnel.thermal_front_parameter` smooths the temperature field
+(`smooth_sigma`) and **gates out weakly-baroclinic air** (`min_grad_per_100km`); tune those
+two, plus `tfp_threshold` in `visualize/funnel.plot_synoptic_panel`, if the zones are still
+busy or too sparse.
+
+## Follow-ups (not yet built)
+
+- **Post-2017 NCEI grib2 NAM template** to close the 2017–2020 auto-pick gap
+  (`nam_218_<date>_<hhmm>_000.grb2`, a new `[models.*]` block in `lookups.toml`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,5 +17,6 @@ Project documentation. Topical files only — agent context lives in
 - **WRF-STAGING-STATE-PLAYBOOK.md** — the single WRF cold-start handoff + state packet (start here for the WRF lane).
 - **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (parked, not proven).
 - **WRF-FIGURE-ENGINE.md** — dataset-agnostic WRF figure engine + `scripts/wrf_figures.py --config <case.toml>` CLI (TOML schema, domain-awareness, named-skip preflight). Per-study cases live in the study repo.
+- **FORECAST-FUNNEL.md** — NAM "forecast funnel" synoptic montage (250/500/600 hPa + surface analysis) + `/basin-forecast-funnel` skill and `scripts/forecast_funnel.py` CLI.
 - **nwp/NWP-SOURCE-MATRIX.md** — per-source download matrix (Herbie vs direct) + Herbie currency.
 - **nwp/** — HRRR/RRFS roadmap (current operational focus).

--- a/scripts/fetch_basemap.py
+++ b/scripts/fetch_basemap.py
@@ -34,6 +34,7 @@ from pathlib import Path
 _LAYERS = [
     ("cultural", "admin_1_states_provinces_lakes"),
     ("cultural", "roads"),
+    ("cultural", "populated_places"),  # city labels (forecast-funnel + opt-in overlays)
     ("physical", "rivers_lake_centerlines"),
     ("physical", "lakes"),
 ]

--- a/scripts/forecast_funnel.dtn.slurm
+++ b/scripts/forecast_funnel.dtn.slurm
@@ -1,0 +1,56 @@
+#!/bin/bash
+# forecast_funnel.dtn.slurm -- Download NAM + render the forecast-funnel montage on a DTN.
+#
+# The funnel downloads a NAM analysis (Herbie/S3 or the NCEI direct GET) and then makes
+# ONE lightweight 4-panel figure, so download + plot run together in a single DTN job.
+# Downloads belong on a DTN: it has direct internet (compute/interactive nodes may NOT)
+# and is the sanctioned place for large transfers. See docs/FORECAST-FUNNEL.md.
+#
+# Submit:  sbatch scripts/forecast_funnel.dtn.slurm "2026-07-20 00Z"
+#     or:  sbatch --export=ALL,INIT="2013-01-31 00Z" scripts/forecast_funnel.dtn.slurm
+
+#SBATCH --job-name=forecast_funnel
+#SBATCH --account=dtn
+#SBATCH --partition=notchpeak-dtn
+#SBATCH --qos=notchpeak-dtn
+#SBATCH --nodes=1
+#SBATCH --ntasks=2
+#SBATCH --mem=16G
+#SBATCH --time=0-01:00:00
+#SBATCH --output=/scratch/general/vast/%u/forecast_funnel_%j.out
+#SBATCH --error=/scratch/general/vast/%u/forecast_funnel_%j.err
+
+set -euo pipefail
+
+# Login env does NOT carry into batch jobs; call the conda env's python directly.
+PY=~/software/pkg/miniforge3/envs/brc-tools-2026/bin/python   # herbie 2026.3.0
+REPO=~/gits/brc-tools
+OUT=/scratch/general/vast/$USER/forecast_funnel
+
+# brc_tools is not pip-installed; running scripts/ puts scripts/ on sys.path, not the
+# repo root — so make the package importable (mirrors the study-repo figure wrapper).
+export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
+
+# Init time: positional $1, else $INIT, else a placeholder to edit.
+INIT="${1:-${INIT:-2026-07-20 00Z}}"
+
+cd "$REPO"
+echo "=== funnel start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) -- init '$INIT' ==="
+
+# CHPC DTNs can hang on outbound IPv6 (see stage_inputs.dtn.slurm); force IPv4 for
+# every download (Herbie/S3 + the direct NCEI NAM GET).
+export BRC_TOOLS_HTTP_IPV4_ONLY=1
+
+# matplotlib + basemap caches on writable storage (never the repo). Point
+# BRC_TOOLS_BASEMAP_DIR at the persistent Natural-Earth cache staged by
+# scripts/fetch_basemap.dtn.slurm so state borders + city labels render.
+export MPLCONFIGDIR="$OUT/.mplconfig"
+export BRC_TOOLS_HERBIE_CACHE="$OUT/.herbie_cache"
+: "${BRC_TOOLS_BASEMAP_DIR:=/uufs/chpc.utah.edu/common/home/lawson-group6/jrlawson/brc-tools-data/cartopy}"
+export BRC_TOOLS_BASEMAP_DIR
+mkdir -p "$MPLCONFIGDIR" "$BRC_TOOLS_HERBIE_CACHE"
+
+"$PY" scripts/forecast_funnel.py --init-time "$INIT" --output-dir "$OUT"
+
+echo "=== funnel done $(date -u +%H:%M:%S) ==="
+ls -lh "$OUT"/forecast_funnel_*.png | tail -3 || true

--- a/scripts/forecast_funnel.py
+++ b/scripts/forecast_funnel.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Render a NAM "forecast funnel" montage for a given analysis init time.
+
+Downloads a single NAM analysis (f00) and renders the four-panel forecast funnel
+(250 hPa jet -> 500 hPa flow -> 600 hPa moisture/LLJ -> surface synoptic analysis)
+as one publication montage.  The NAM source is auto-picked by init date: Herbie's
+operational NAM for recent inits, the NCEI historical grib1 archive for pre-2017
+(the 2017-2020 window is unwired — see ``docs/FORECAST-FUNNEL.md``).
+
+Examples
+--------
+    # recent init (Herbie path)
+    python scripts/forecast_funnel.py --init-time "2026-07-20 00Z"
+
+    # historical init (NCEI path), custom output dir
+    python scripts/forecast_funnel.py --init-time 2013013100 \
+        --output-dir /scratch/general/vast/$USER/forecast_funnel
+
+Downloads/figures route OUTSIDE the repo (scratch by default).  GRIB is heavy and
+needs a network node — run on a DTN via ``scripts/forecast_funnel.dtn.slurm``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from brc_tools.nwp.forecast_funnel import DEFAULT_LEVELS, fetch_funnel_fields
+from brc_tools.nwp.source import _parse_init_time
+from brc_tools.visualize.funnel import plot_forecast_funnel
+from brc_tools.visualize.style import use_publication_style
+
+
+def _default_output_dir() -> str:
+    user = os.environ.get("USER", "user")
+    return f"/scratch/general/vast/{user}/forecast_funnel"
+
+
+def _levels_arg(value: str) -> tuple[int, ...]:
+    return tuple(int(v) for v in value.split(",")) if value else DEFAULT_LEVELS
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--init-time", required=True,
+                    help="analysis init, 'YYYY-MM-DD HHZ' or YYYYMMDDHH (UTC).")
+    ap.add_argument("--output-dir", default=_default_output_dir(),
+                    help="figure output root (default: scratch; never the repo).")
+    ap.add_argument("--source", default="auto", choices=("auto", "herbie", "ncei"),
+                    help="NAM source (default: auto-pick by init date).")
+    ap.add_argument("--levels", default=",".join(str(x) for x in DEFAULT_LEVELS),
+                    help="pressure levels hPa, comma-separated (default: 250,500,600).")
+    ap.add_argument("--cache-dir", default=None,
+                    help="GRIB cache dir (default: $BRC_TOOLS_HERBIE_CACHE / scratch).")
+    ap.add_argument("--dpi", type=int, default=300, help="figure DPI (default: 300).")
+    args = ap.parse_args()
+
+    init_dt = _parse_init_time(args.init_time)
+    use_publication_style(dpi=args.dpi)
+
+    data = fetch_funnel_fields(
+        args.init_time, source=args.source, cache_dir=args.cache_dir,
+        levels=_levels_arg(args.levels),
+    )
+
+    stamp = init_dt.strftime("%Y%m%d_%H%M")
+    out_path = Path(args.output_dir) / f"forecast_funnel_{stamp}Z.png"
+    written = plot_forecast_funnel(data, out_path, dpi=args.dpi)
+    print(f"wrote {written}  (source={data.source}, panels={len(data.panels)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_forecast_funnel.py
+++ b/tests/test_forecast_funnel.py
@@ -1,0 +1,205 @@
+"""Unit tests for the forecast-funnel data layer + renderer (no network).
+
+The NAM fetch is monkeypatched with a synthetic CONUS grid, so these exercise the
+source auto-pick, the diagnostics (H/L centres, TFP), the panel-building crop, and the
+headless montage render without touching Herbie or NCEI.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brc_tools.nwp import forecast_funnel as ff
+from brc_tools.nwp.forecast_funnel import (
+    FunnelData,
+    Panel,
+    _assemble_full,
+    absolute_vorticity,
+    fetch_funnel_fields,
+    funnel_source_for,
+    pressure_centers,
+    specific_humidity_g_per_kg,
+    thermal_front_parameter,
+)
+
+
+# ── source auto-pick ────────────────────────────────────────────────────────
+def test_funnel_source_for_recent_is_herbie():
+    assert funnel_source_for(dt.datetime(2026, 7, 20, 0)) == "herbie"
+    assert funnel_source_for(dt.datetime(2021, 1, 1, 0)) == "herbie"
+
+
+def test_funnel_source_for_historical_is_ncei():
+    assert funnel_source_for(dt.datetime(2013, 1, 31, 0)) == "ncei"
+    assert funnel_source_for(dt.datetime(2016, 12, 1, 0)) == "ncei"
+
+
+def test_funnel_source_for_gap_raises():
+    with pytest.raises(ValueError, match="No NAM source"):
+        funnel_source_for(dt.datetime(2018, 6, 1, 0))
+
+
+# ── humidity helper ─────────────────────────────────────────────────────────
+def test_specific_humidity_direct():
+    q = specific_humidity_g_per_kg(np.array([0.006, 0.003]))
+    np.testing.assert_allclose(q, [6.0, 3.0])
+
+
+def test_specific_humidity_derived_from_rh_is_positive():
+    q = specific_humidity_g_per_kg(rh_pct=np.array([80.0]), temp_k=np.array([275.0]),
+                                   pressure_hpa=600.0)
+    assert q[0] > 0.0 and np.isfinite(q[0])
+
+
+# ── diagnostics ─────────────────────────────────────────────────────────────
+def _gaussian(lon2d, lat2d, lon0, lat0, amp, width=3.0):
+    return amp * np.exp(-((lon2d - lon0) ** 2 + (lat2d - lat0) ** 2) / (2 * width**2))
+
+
+def test_pressure_centers_finds_low_and_high():
+    lon = np.linspace(-120.0, -100.0, 60)
+    lat = np.linspace(30.0, 50.0, 60)
+    lon2d, lat2d = np.meshgrid(lon, lat)
+    field = (1013.0
+             - _gaussian(lon2d, lat2d, -112.0, 40.0, 20.0)   # a Low
+             + _gaussian(lon2d, lat2d, -104.0, 44.0, 15.0))  # a High
+    centers = pressure_centers(field, lon2d, lat2d, window_pts=11, min_sep_deg=3.0)
+    lows = [c for c in centers if c["kind"] == "L"]
+    highs = [c for c in centers if c["kind"] == "H"]
+    assert lows and highs
+    # strongest low near (-112, 40); strongest high near (-104, 44)
+    lo = min(lows, key=lambda c: c["value"])
+    hi = max(highs, key=lambda c: c["value"])
+    assert abs(lo["lon"] + 112.0) < 2.0 and abs(lo["lat"] - 40.0) < 2.0
+    assert abs(hi["lon"] + 104.0) < 2.0 and abs(hi["lat"] - 44.0) < 2.0
+
+
+def test_absolute_vorticity_cyclonic_positive():
+    # Cyclonic shear (v increases eastward -> dv/dx > 0 -> positive relative vorticity),
+    # plus planetary f, must exceed f alone at NH mid-latitudes.
+    x = np.linspace(-115.0, -105.0, 40)
+    y = np.linspace(38.0, 46.0, 40)
+    lon2d, lat2d = np.meshgrid(x, y)
+    u = np.zeros_like(lon2d)
+    v = 1.0e-3 * (lon2d - lon2d.min()) * 111_000.0  # ~m/s ramp with longitude
+    av = absolute_vorticity(u, v, lat2d, dx_m=12000.0, dy_m=12000.0)
+    f_only = 2.0 * 7.2921e-5 * np.sin(np.deg2rad(42.0)) * 1e5
+    assert np.isfinite(av).all()
+    assert float(np.nanmean(av)) > f_only  # cyclonic relative vorticity adds to f
+
+
+def test_thermal_front_parameter_nonzero_across_gradient():
+    ny, nx = 40, 40
+    # A sharp N-S temperature front (tanh) -> strong TFP in the transition band.
+    y = np.linspace(-3, 3, ny)[:, None] * np.ones((1, nx))
+    temp = 280.0 + 6.0 * np.tanh(y * 2.0)
+    tfp = thermal_front_parameter(temp, dx_m=12000.0, dy_m=12000.0, smooth_sigma=1.0)
+    assert np.isfinite(tfp).all()
+    assert np.nanmax(np.abs(tfp)) > 0.0
+
+
+# ── synthetic full grid + panel building ────────────────────────────────────
+def _synthetic_full(levels=(250, 500, 600)):
+    lon = np.linspace(-128.0, -64.0, 65)
+    lat = np.linspace(20.0, 52.0, 33)
+    lon2d, lat2d = np.meshgrid(lon, lat)
+    base_h = {250: 10500.0, 500: 5600.0, 600: 4300.0}
+    gh = {lv: base_h[lv] - 40.0 * (lat2d - 36.0) for lv in levels}
+    u = {lv: np.full_like(lon2d, 20.0) for lv in levels}
+    v = {lv: np.full_like(lon2d, 5.0) for lv in levels}
+    t600 = 268.0 - 0.5 * (lat2d - 36.0)
+    t850 = 285.0 - 0.5 * (lat2d - 36.0)
+    q600 = np.full_like(lon2d, 3.0)
+    mslp = (1013.0e2
+            - _gaussian(lon2d, lat2d, -110.0, 42.0, 18.0) * 100.0
+            + _gaussian(lon2d, lat2d, -95.0, 34.0, 12.0) * 100.0)
+    return _assemble_full(
+        lat2d=lat2d, lon2d=lon2d, levels=levels, gh=gh, u=u, v=v,
+        t600=t600, t850=t850, u850=u[500], v850=v[500], q600_g_kg=q600, mslp_pa=mslp,
+    )
+
+
+def test_fetch_funnel_fields_builds_four_panels(monkeypatch):
+    monkeypatch.setattr(ff, "_herbie_fetch_full",
+                        lambda init_dt, levels, cache_dir: _synthetic_full(levels))
+    data = fetch_funnel_fields("2026-07-20 00Z", source="herbie")
+    assert isinstance(data, FunnelData)
+    assert data.source == "herbie"
+    assert data.init_time == data.valid_time == dt.datetime(2026, 7, 20, 0)
+    kinds = {p.key: p.kind for p in data.panels}
+    assert kinds == {"1a": "isotach", "1b": "vorticity",
+                     "1c": "moisture", "1d": "synoptic"}
+    # the local (1c) panel carries basin waypoints + thermal advection; surface = fronts
+    p1c = next(p for p in data.panels if p.key == "1c")
+    p1d = next(p for p in data.panels if p.key == "1d")
+    assert p1c.waypoints and "duchesne" in p1c.waypoints
+    assert "t_adv" in p1c.fields
+    assert p1d.fronts is not None and "tfp" in p1d.fronts
+    assert p1d.centers is not None
+
+
+def test_fetch_funnel_fields_auto_picks_ncei(monkeypatch):
+    captured = {}
+
+    def fake_ncei(init_time, levels, cache_dir):
+        captured["called"] = True
+        return _synthetic_full(levels)
+
+    monkeypatch.setattr(ff, "_ncei_fetch_full", fake_ncei)
+    data = fetch_funnel_fields("2013-01-31 00Z", source="auto")
+    assert captured.get("called") and data.source == "ncei"
+
+
+# ── renderer (headless) ─────────────────────────────────────────────────────
+def _panels_from(full):
+    from brc_tools.nwp.source import load_lookups
+    lu = load_lookups()
+    return [ff._build_panel(full, spec, lu) for spec in ff.FUNNEL_PANELS]
+
+
+def test_plot_forecast_funnel_writes_png(tmp_path):
+    panels = [p for p in _panels_from(_synthetic_full()) if p is not None]
+    data = FunnelData(init_time=dt.datetime(2026, 7, 20, 0),
+                      valid_time=dt.datetime(2026, 7, 20, 0), source="herbie",
+                      model_label="NAM test", panels=panels)
+    from brc_tools.visualize.funnel import plot_forecast_funnel
+    out = plot_forecast_funnel(data, tmp_path / "funnel.png", dpi=80)
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_synoptic_panel_draws_fronts():
+    # A TFP field that crosses the 1.5 threshold within a uniform cold-advection region
+    # must add a frontal contour; masking by advection sign (not the threshold) is what
+    # lets contour find the crossing. Compare against the same panel with no TFP.
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from brc_tools.visualize.funnel import plot_synoptic_panel
+
+    x = np.linspace(-120.0, -105.0, 30)
+    y = np.linspace(35.0, 48.0, 26)
+    lon, lat = np.meshgrid(x, y)
+    mslp = 1013.0 - 0.2 * (lat - 40.0)
+    ext = (-120.0, -105.0, 35.0, 48.0)
+    tfp = 3.0 * (lat - 35.0) / 13.0          # ramps 0 -> 3, crosses 1.5
+    adv = np.full_like(tfp, -1.0)            # all cold advection
+
+    fig, (a0, a1) = plt.subplots(1, 2)
+    plot_synoptic_panel(a0, lon, lat, mslp, centers=[], tfp=None, extent=ext)
+    plot_synoptic_panel(a1, lon, lat, mslp, centers=[], tfp=tfp, t_adv=adv, extent=ext)
+    assert len(a1.collections) > len(a0.collections)
+    plt.close(fig)
+
+
+def test_plot_forecast_funnel_refuses_repo_path():
+    from brc_tools.visualize.funnel import _REPO_ROOT, plot_forecast_funnel
+    data = FunnelData(init_time=dt.datetime(2026, 7, 20, 0),
+                      valid_time=dt.datetime(2026, 7, 20, 0), source="herbie",
+                      model_label="NAM test", panels=[])
+    with pytest.raises(SystemExit, match="repo checkout"):
+        plot_forecast_funnel(data, _REPO_ROOT / "figures" / "nope.png")


### PR DESCRIPTION
Add a `/basin-forecast-funnel <init-time>` skill that downloads a NAM analysis and
renders a four-panel forecast-funnel montage — 250 hPa jet isotachs, 500 hPa absolute
vorticity, 600 hPa specific humidity + temperature advection, and a surface MSLP
analysis with auto High/Low centres and diagnostic TFP frontal zones. It reuses the
publication style + fail-soft Natural-Earth overlays and adds population-ranked city
labels, so it matches the WRF figure aesthetic without touching that engine.

- data: brc_tools/nwp/forecast_funnel.py — NAM source auto-picked by init date
  (Herbie operational `nam`/`awphys` for recent, NCEI historical grib1 for pre-2017;
  the 2017-2020 gap errors clearly); H/L, TFP (gradient-gated) and absolute-vorticity
  diagnostics; specific humidity derived from RH + T where SPFH is absent aloft.
- render: brc_tools/visualize/funnel.py — plain-array panels + 2x2 montage.
- CLI: scripts/forecast_funnel.py; DTN wrapper: scripts/forecast_funnel.dtn.slurm.
- basemap: opt-in `cities` (populated_places) layer, default off so existing figures
  are unchanged; scripts/fetch_basemap.py stages it too.
- lookups: west_conus region. style: 250 hPa isotach + 600 hPa humidity + 500 hPa
  absolute-vorticity fixed scales.
- docs/FORECAST-FUNNEL.md (+ doc-map/README), skill, CLAUDE.md repo map, wishlist.

Validated against real GRIB both eras (Herbie 2025-10-11 18Z from AWS; NCEI 2013-01-31
00Z), which surfaced and fixed three real-data bugs: per-variable cfgrib open for grib1
multi-level-set files, a thermal-gradient gate for TFP front noise, and the RH->q
fallback (awphys ships RH, not SPFH, on pressure levels). tests: 13 new; suite 201
passed / 2 skipped.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
