### PR TITLE
feat(wrf): input staging for the Ashley cases + TOML-driven wrf_winds figure engine

### DIFF
--- a/.claude/skills/wrf-basin-winds/SKILL.md
+++ b/.claude/skills/wrf-basin-winds/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: wrf-basin-winds
+description: Render basin-winds-style figures (10 m wind plan views + terrain-filled cross-sections along named transects, with locator insets) from a WRF run's wrfout files on CHPC SLURM — including a run that is still writing. Use when asked for better-than-quicklook WRF images for a case/time, or for the WRF version of /basin-winds.
+---
+
+# WRF basin-winds figures
+
+The WRF counterpart of ub-wx's `/basin-winds`: per nest, a plan-view surface map
+(10 m wind + barbs + terrain + towns + Natural-Earth overlays) plus terrain-filled
+wind curtains along named A→B transects with the geographic locator inset. Same
+renderers as the HRRR case (`brc_tools.visualize.nwp_maps`), fed by the wrfout
+adapter `brc_tools/nwp/wrf_section.py`, so sections keep the model's **native eta
+levels** instead of being flattened onto isobaric surfaces.
+
+Engine + TOML schema: `docs/WRF-WINDS.md`. For a study's publication figure set
+(grid-aligned EW/NS sections, difference maps, heat-deficit diagnostics) use
+`/wrf-full-figures` instead — different engine, different job.
+
+## Steps
+
+1. **Find the run and its case TOML.** Configs live in the repo owning the case —
+   e.g. `~/gits/ub-wx/experiments/20260424-ashley-drainage-120m/figures.toml`. A
+   different run of the same case needs no edit: pass `--run-dir <...>/wrf_run`.
+   New case → new TOML (schema + a worked example in `docs/WRF-WINDS.md`).
+2. **Pick the time(s).** `--hourly` sweeps every whole hour written so far — the
+   right choice for "show me the run so far"; `--all` adds sub-hourly times.
+   `--valid YYYY-MM-DD_HH:MM` or `--lead <minutes-after-init>` pick one. With none
+   of those it renders the latest valid time present on *every* requested domain,
+   which is what you want for a single look at a running job (a 3 km parent on
+   hourly output lags a 600 m nest on 5-minute output).
+   - `ls <run>/wrfout_d0*_* | tail` to see how far the run has got.
+   - Existing figures are overwritten, so re-running as the job advances is safe.
+   - Ask the user which time only if the run offers a genuinely different choice;
+     otherwise take the latest common one and say which you used.
+   - **A sweep that crosses sunset crosses regimes**: one `w_exag` cannot serve
+     both a convective afternoon and a drainage night. Check the last hour and say
+     so if a second pass with `--w-exag` is warranted.
+3. **Submit on the DTN, never a login node.** Two reasons this is not optional:
+   `lawson-group6` is mounted **read-only** on the notchpeak login nodes, so
+   figures reach group storage only from a compute or DTN node; and `lawson-np` is
+   a single node, so if a WRF run is occupying it — the usual reason to want these
+   figures — a job queued there waits for the very run it is meant to monitor.
+   ```
+   sbatch scripts/wrf_winds.dtn.slurm --config <case.toml> [--run-dir <run>] \
+          [--valid ...|--lead ...] [--domain N] [--w-exag X] [--output-dir <dir>]
+   ```
+   Report the job id and the output path; check with `squeue -j <jobid>` and the
+   `.out` on scratch. ~1 min per (nest × time) for a 600 m nest.
+4. **Check the output.** Read one plan view and one section. The two things that
+   go wrong first:
+   - **All vectors vertical** on a section → `w_exag` is set for the wrong regime.
+     A convective afternoon wants ~10; a quiescent drainage night wants ~100.
+     Re-render with `--w-exag`, don't edit the TOML.
+   - **Locator inset over the town labels** → move `loc_rect` into the panel's dead
+     space (usually inside the terrain fill).
+5. **Promote the keepers.** Scratch holds the mass output; copy the best few to
+   `$UB_WX_FIGS_KEEP` / group6 — from the same job or a DTN, not the login node.
+
+## Notes
+
+- Reads **both** wrfout filename conventions, including `nocolons = .true.`
+  (`..._21_00_00`). `brc_tools.nwp.wrf_output` — and therefore the
+  `/wrf-full-figures` engine — assumes colons and will report "no wrfout" on a
+  nocolons run.
+- One nest can carry several views: give each `[[domains]]` entry its own `tag`
+  (e.g. a full-extent `d02` plus a zoomed `d02_ashley`).
+- Colour scales come from `brc_tools.visualize.style`, which is tuned for **winter
+  cold pools**. Any warm-season case needs `[style.overrides.<var>]` in its TOML.
+- Transect endpoints must lie inside the nest being cut. A line running off the
+  grid silently samples the edge column for the rest of its length — sample `HGT`
+  along a new transect before trusting it.
+- Basemap overlays need `BRC_TOOLS_BASEMAP_DIR` (the SLURM wrapper points at the
+  staged group6 cache); missing layers are skipped, never fatal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,9 @@ with headers `x-api-key` (32-char hex from `DATA_UPLOAD_API_KEY`) and
 a cross-repo PR. Operational deployment lives in `docs/CHPC-REFERENCE.md`.
 
 A second cross-repo seam: `brc_tools.visualize.grid` (`plot_grid_field`,
-`plot_vertical_section`) is imported by `brc-wrf`'s `wrf_quicklook.py` — signatures
-load-bearing. The publication figure engine built on it (`wrf_figures.py` over
+`plot_vertical_section`, `terrain_contour_levels`) is imported by `brc-wrf`'s
+`wrf_quicklook.py` — signatures load-bearing. That script also shells out to
+`scripts/stage_wrf_inputs.py` to verify a manifest, so its CLI is part of the seam too. The publication figure engine built on it (`wrf_figures.py` over
 `wrf_output.py` + `visualize/*`) is documented in `docs/WRF-FIGURE-ENGINE.md` (Doc map).
 
 ## Conventions
@@ -101,11 +102,17 @@ no client wires it yet); `FR24_API_KEY` is reserved for the skeleton FlightRadar
 ## Testing
 ```
 pytest tests/
+cd /tmp && python -c "import brc_tools, brc_tools.visualize.grid"   # editable install present?
 ```
 Use a conda env with the deps (herbie, polars, pandas, matplotlib, cfgrib, requests).
 Preferred: the dedicated **`brc-tools-2026`** env (`mamba env create -f environment.yml`;
-herbie 2026.3.0 — validated, 180 passed / 2 skipped); the shared `clyfar-nov2025` also works. Fresh
-setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
+herbie 2026.3.0 — validated 2026-07-27, 253 passed / 2 skipped); the shared `clyfar-nov2025` also
+works. Fresh setup → `docs/ENVIRONMENT-SETUP.md`. Not bare `python`.
+**Verify the import from OUTSIDE the checkout.** A cwd-inside-the-repo test passes even with no
+install, so a missing `pip install -e .` only shows up later as `ImportError` in `brc-wrf`/`clyfar`
+(both import brc_tools from their own trees). On CHPC that install needs
+`--no-build-isolation` (pypi.org unreachable) and `--no-user` (else pip targets a read-only
+`~/.local/lib`).
 
 ## Related repos
 - `ubair-website` — Node.js receiver for uploads (data contract).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Repo: **`brc-tools`** (hyphen).
 ## Repo map
 ```
 brc_tools/        installable package
-  nwp/            NWPSource (Herbie), lookups.toml, derived, alignment, case_study, wrf_staging (WRF/WPS GRIB), forecast_funnel (NAM synoptic montage data)
+  nwp/            NWPSource (Herbie), lookups.toml, derived, alignment, case_study, wrf_staging (WRF/WPS GRIB), wrf_section (wrfout → plan/arbitrary-transect adapter), forecast_funnel (NAM synoptic montage data)
   obs/            ObsSource (SynopticPy wrapper), scanner (event detection)
   verify/         deterministic metrics (paired_scores, RMSE/bias/MAE)
   visualize/      planview + timeseries panels; grid.py (field/section plots — brc-wrf seam); figure-engine modules (surface/section/upperair/profile/domains/heatdeficit/deficitflux/funnel/basemap/style)
@@ -42,6 +42,7 @@ figures/          generated output (gitignored)
 - `docs/nwp/ROADMAP.md` — HRRR/RRFS strategy · `docs/nwp/NWP-SOURCE-MATRIX.md` — per-source download matrix
 - `docs/WRF-STAGING-STATE-PLAYBOOK.md` — **WRF-staging cold-start SSOT**; detail in `docs/WRF-INPUT-STAGING.md`; two-stream draft `docs/WRF-GEFS-NAM-FIELD-MAP.md` (parked)
 - `docs/WRF-FIGURE-ENGINE.md` — dataset-agnostic figure engine (`brc_tools/nwp/wrf_figures.py` + `scripts/wrf_figures.py --config <case.toml>`). Per-study case TOMLs + the run/figure inventory live in the active study repo; SSOT index → `../latex-jrl-mjd-mdpiair-2026/verification/figures/archive-inventory.md`
+- `docs/WRF-WINDS.md` — basin-winds-style figures from `wrfout` (`brc_tools/nwp/wrf_section.py` + `visualize/wrf_curtain.py` + `visualize/coldpool3d.py` + `scripts/wrf_winds.py --config <case.toml>` + `scripts/wrf_winds.dtn.slurm`); `/wrf-basin-winds` skill. Arbitrary A→B transects flat-shaded on **native eta cells**, plan views, and 3-D isentrope cold-pool views; matched across nests, sweeps a still-writing run. Distinct from the publication engine above; per-case TOMLs live in the repo owning the case (ashley → `../ub-wx/experiments/20260424-ashley-drainage-120m/figures.toml`).
 - `docs/FORECAST-FUNNEL.md` — NAM "forecast funnel" synoptic montage (`brc_tools/nwp/forecast_funnel.py` + `brc_tools/visualize/funnel.py` + `scripts/forecast_funnel.py`); `/basin-forecast-funnel` skill. NAM source auto-picks by init date (Herbie recent / NCEI pre-2017).
 - `WISHLIST-TASKS.md` — prioritised backlog
 

--- a/brc_tools/nwp/section.py
+++ b/brc_tools/nwp/section.py
@@ -47,6 +47,11 @@ class NWPSection:
     thetae2d: np.ndarray | None = None  # (nz, n) equiv. potential temp, K (needs dewpoint)
     termini: tuple[str, str] = ("A", "B")
     orientation: str = "EW"  # accent-colour key for the crosssection helpers
+    # True vertical CELL EDGES (nz+1, n) when the source has them -- WRF's w-level
+    # geopotential heights.  Lets a renderer draw the curtain on the model's own
+    # grid with flat shading instead of resampling onto a regular height axis.
+    # Isobaric sources (the HRRR path) have no such edges and leave this None.
+    height_w2d: np.ndarray | None = None
 
 
 def _lon180(lon) -> np.ndarray:

--- a/brc_tools/nwp/wrf_section.py
+++ b/brc_tools/nwp/wrf_section.py
@@ -1,0 +1,285 @@
+"""Plan views and arbitrary-line cross-sections straight from ``wrfout`` files.
+
+This is the WRF-side adapter onto the renderers written for gridded NWP --
+:func:`brc_tools.visualize.nwp_maps.plot_nwp_surface_map` and
+:func:`~brc_tools.visualize.nwp_maps.plot_nwp_section` -- so a WRF nest can be
+drawn in exactly the layout the ``basin-winds`` HRRR case uses (10 m wind plan
+view plus terrain-filled wind curtains along named A->B transects, with the
+geographic locator inset and along-section town labels).
+
+Two adapters, and a deliberate difference from the HRRR path:
+
+``plan_dataset``
+    ``wrfout`` -> a minimal :class:`xarray.Dataset` in the surface schema those
+    renderers expect (2-D ``latitude``/``longitude``, ``terrain_height``, and
+    style-keyed fields such as ``wind_speed_10m``).
+
+``extract_wrf_section``
+    ``wrfout`` -> :class:`brc_tools.nwp.section.NWPSection` sampled along an
+    arbitrary geographic line **on the model's native eta levels**.  The HRRR
+    analogue in :mod:`brc_tools.nwp.section` has to stack isobaric levels because
+    that is all GRIB carries; here the native column is available, so a 600 m
+    nest keeps the stretched near-surface levels intact.  That matters when the
+    feature of interest -- a drainage layer tens of metres deep -- lives entirely
+    below the first isobaric level a pressure interpolation would offer.
+
+Winds are earth-relative throughout (rotated via ``COSALPHA``/``SINALPHA``), so
+the along-transect component of a section means the same thing whatever the map
+projection is doing.  Nothing here is case-specific: transect endpoints, extents,
+waypoints, and colour scales are the caller's business.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from brc_tools.nwp import wrf_output as wo
+from brc_tools.nwp.section import NWPSection
+
+__all__ = ["WRFPlane", "load_plane", "plan_dataset", "plan_extent",
+           "section_from_plane", "extract_wrf_section",
+           "list_valid_times", "wrfout_path", "init_time"]
+
+_KM_PER_DEG_LAT = 110.574
+_KM_PER_DEG_LON = 111.320
+
+# WRF writes history filenames as `%Y-%m-%d_%H:%M:%S`, unless the run set
+# `nocolons = .true.` (common on filesystems and tooling that dislike colons), in
+# which case the time separators become underscores.  wrf_output assumes the first;
+# everything here accepts either, so one run directory convention is not a
+# precondition for getting figures out.
+_TIME_FMTS = ("%Y-%m-%d_%H:%M:%S", "%Y-%m-%d_%H_%M_%S")
+
+
+def _parse_stamp(stamp: str) -> datetime | None:
+    for fmt in _TIME_FMTS:
+        try:
+            return datetime.strptime(stamp, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def list_valid_times(run_dir: str | Path, domain: int) -> list[datetime]:
+    """Valid times present for a domain, parsed from either filename convention."""
+    prefix = f"wrfout_d{domain:02d}_"
+    times = [t for p in sorted(Path(run_dir).glob(f"{prefix}*"))
+             if (t := _parse_stamp(p.name[len(prefix):])) is not None]
+    return sorted(times)
+
+
+def wrfout_path(run_dir: str | Path, domain: int, valid_time: datetime) -> Path:
+    """Path to one wrfout, trying both time conventions; returns the one on disk.
+
+    Falls back to the colon form (WRF's default) when neither exists, so the
+    caller's ``FileNotFoundError`` names something recognisable.
+    """
+    run_dir = Path(run_dir)
+    candidates = [run_dir / f"wrfout_d{domain:02d}_{valid_time:{fmt}}" for fmt in _TIME_FMTS]
+    return next((p for p in candidates if p.exists()), candidates[0])
+
+
+def init_time(run_dir: str | Path, domain: int) -> datetime:
+    """Model initialization time: ``SIMULATION_START_DATE``, else earliest wrfout."""
+    times = list_valid_times(run_dir, domain)
+    if not times:
+        raise FileNotFoundError(f"no wrfout_d{domain:02d}_* files under {run_dir}")
+    ds = wo.open_wrfout(wrfout_path(run_dir, domain, times[0]))
+    try:
+        stamp = ds.attrs.get("SIMULATION_START_DATE")
+    finally:
+        ds.close()
+    return (_parse_stamp(str(stamp).strip()) or times[0]) if stamp else times[0]
+
+
+def _lon180(lon) -> np.ndarray:
+    lon = np.asarray(lon, dtype=float)
+    return np.where(lon > 180.0, lon - 360.0, lon)
+
+
+def _rotate_to_earth(ds, u, v):
+    """Rotate grid-relative ``(u, v)`` onto earth axes; identity if unrotated."""
+    cosa = wo.surface_field(ds, "COSALPHA") if "COSALPHA" in ds else np.ones(u.shape)
+    sina = wo.surface_field(ds, "SINALPHA") if "SINALPHA" in ds else np.zeros(u.shape)
+    return u * cosa - v * sina, v * cosa + u * sina
+
+
+# --------------------------------------------------------------------------- #
+# plan view
+# --------------------------------------------------------------------------- #
+def plan_dataset(ds, *, extra: dict | None = None):
+    """Build the surface :class:`xarray.Dataset` the plan-view renderer expects.
+
+    Field names are :mod:`brc_tools.visualize.style` keys, because
+    :func:`~brc_tools.visualize.nwp_maps.plot_nwp_surface_map` looks the colour
+    scale up by variable name: ``wind_speed_10m``, ``wind_u_10m``,
+    ``wind_v_10m``, ``theta_2m``, ``temp_2m``, ``pblh``, plus ``terrain_height``
+    and 2-D ``latitude``/``longitude``.  ``pblh`` is omitted when the run did not
+    write ``PBLH``.  ``extra`` adds ``{name: 2-D array}`` pairs verbatim.
+    """
+    import xarray as xr
+
+    u10, v10 = _rotate_to_earth(ds, wo.surface_field(ds, "U10"), wo.surface_field(ds, "V10"))
+    fields = {
+        "terrain_height": wo.surface_field(ds, "HGT"),
+        "wind_u_10m": u10,
+        "wind_v_10m": v10,
+        "wind_speed_10m": np.hypot(u10, v10),
+        "theta_2m": wo.theta_2m(ds),
+        "temp_2m": wo.surface_field(ds, "T2"),
+    }
+    if "PBLH" in ds:
+        fields["pblh"] = wo.surface_field(ds, "PBLH")
+    fields.update(extra or {})
+    return xr.Dataset(
+        {k: (("y", "x"), np.asarray(a, dtype=float)) for k, a in fields.items()},
+        coords={
+            "latitude": (("y", "x"), wo.surface_field(ds, "XLAT")),
+            "longitude": (("y", "x"), _lon180(wo.surface_field(ds, "XLONG"))),
+        },
+    )
+
+
+def plan_extent(ds, *, pad_deg: float = 0.0) -> tuple[float, float, float, float]:
+    """``(lon0, lon1, lat0, lat1)`` covering the domain, inset by ``pad_deg``.
+
+    A positive ``pad_deg`` trims the view inward -- useful for hiding the nest's
+    relaxation zone, where the solution is blended toward the parent.
+    """
+    lat = wo.surface_field(ds, "XLAT")
+    lon = _lon180(wo.surface_field(ds, "XLONG"))
+    return (float(lon.min()) + pad_deg, float(lon.max()) - pad_deg,
+            float(lat.min()) + pad_deg, float(lat.max()) - pad_deg)
+
+
+# --------------------------------------------------------------------------- #
+# cross-section
+# --------------------------------------------------------------------------- #
+@dataclass
+class WRFPlane:
+    """The 3-D state one ``wrfout`` time needs for arbitrary-line sections.
+
+    Read once per file and reused across transects: the 3-D arrays are the
+    expensive part, and a case typically cuts several lines through the same
+    time.  All winds are earth-relative; heights are geometric m ASL on mass
+    levels.
+    """
+
+    lat2d: np.ndarray  # (ny, nx)
+    lon2d: np.ndarray  # (ny, nx) -180..180
+    terrain: np.ndarray  # (ny, nx) m ASL
+    height: np.ndarray  # (nz, ny, nx) m ASL, mass levels
+    height_w: np.ndarray  # (nz+1, ny, nx) m ASL, w levels = the true cell edges
+    theta: np.ndarray  # (nz, ny, nx) K
+    temp: np.ndarray  # (nz, ny, nx) K
+    ue: np.ndarray  # (nz, ny, nx) m/s, earth-relative east
+    ve: np.ndarray  # (nz, ny, nx) m/s, earth-relative north
+    w: np.ndarray  # (nz, ny, nx) m/s
+    pressure_hpa: np.ndarray  # (nz,) domain-mean level pressure, for reference only
+
+
+def load_plane(ds) -> WRFPlane:
+    """Read the 3-D fields for :func:`section_from_plane` from an open ``wrfout``."""
+    ue, ve = wo.earth_relative_winds(ds)
+    return WRFPlane(
+        lat2d=wo.surface_field(ds, "XLAT"),
+        lon2d=_lon180(wo.surface_field(ds, "XLONG")),
+        terrain=wo.surface_field(ds, "HGT"),
+        height=wo.geopotential_height_mass(ds),
+        height_w=wo.geopotential_height_w(ds),
+        theta=wo.potential_temperature(ds),
+        temp=wo.temperature_k(ds),
+        ue=ue,
+        ve=ve,
+        w=wo.vertical_velocity(ds),
+        pressure_hpa=wo.pressure_pa(ds).mean(axis=(1, 2)) / 100.0,
+    )
+
+
+def _sample_line(start, end, n):
+    """``n`` points on the straight A->B line: lon, lat, distance-from-A (km)."""
+    lat0, lon0 = float(start[0]), float(start[1])
+    lat1, lon1 = float(end[0]), float(end[1])
+    frac = np.linspace(0.0, 1.0, n)
+    lon_line = lon0 + frac * (lon1 - lon0)
+    lat_line = lat0 + frac * (lat1 - lat0)
+    coslat = np.cos(np.deg2rad(0.5 * (lat0 + lat1)))
+    dx = (lon_line - lon0) * _KM_PER_DEG_LON * coslat
+    dy = (lat_line - lat0) * _KM_PER_DEG_LAT
+    return lon_line, lat_line, np.hypot(dx, dy)
+
+
+def _unit_ab(start, end) -> tuple[float, float]:
+    """Unit (east, north) components of the A->B direction."""
+    coslat = np.cos(np.deg2rad(0.5 * (float(start[0]) + float(end[0]))))
+    e = (float(end[1]) - float(start[1])) * _KM_PER_DEG_LON * coslat
+    n = (float(end[0]) - float(start[0])) * _KM_PER_DEG_LAT
+    mag = float(np.hypot(e, n))
+    if mag == 0.0:
+        raise ValueError("section start and end are the same point")
+    return e / mag, n / mag
+
+
+def section_from_plane(
+    plane: WRFPlane,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    *,
+    n_points: int = 240,
+    termini: tuple[str, str] = ("A", "B"),
+    orientation: str = "EW",
+) -> NWPSection:
+    """Cut an :class:`NWPSection` from ``plane`` along ``start`` -> ``end``.
+
+    Each sample takes the *nearest model column* -- no horizontal interpolation,
+    matching the HRRR path in :func:`brc_tools.nwp.section.extract_nwp_section`.
+    Nearest is measured in kilometres (longitudes scaled by cos(lat)), so the
+    pick does not drift east-west the way a raw-degree distance would.
+
+    ``start``/``end`` are ``(lat, lon)``.  The along-section component is
+    positive toward B.  ``pressure_hpa`` carries the domain-mean level pressures
+    for reference; the curtain itself is drawn on geometric height.
+    """
+    from scipy.spatial import cKDTree
+
+    lon_line, lat_line, dist = _sample_line(start, end, n_points)
+    coslat = float(np.cos(np.deg2rad(np.mean(plane.lat2d))))
+    tree = cKDTree(np.column_stack([
+        plane.lat2d.ravel() * _KM_PER_DEG_LAT,
+        plane.lon2d.ravel() * _KM_PER_DEG_LON * coslat,
+    ]))
+    _, flat = tree.query(np.column_stack([
+        lat_line * _KM_PER_DEG_LAT, lon_line * _KM_PER_DEG_LON * coslat]))
+    jj, ii = np.unravel_index(flat, plane.lat2d.shape)
+
+    e_hat, n_hat = _unit_ab(start, end)
+    ue = plane.ue[:, jj, ii]
+    ve = plane.ve[:, jj, ii]
+    return NWPSection(
+        distance_km=dist,
+        lon_line=lon_line,
+        lat_line=lat_line,
+        height2d=plane.height[:, jj, ii],
+        speed2d=np.hypot(ue, ve),
+        theta2d=plane.theta[:, jj, ii],
+        temp2d=plane.temp[:, jj, ii],
+        along2d=ue * e_hat + ve * n_hat,
+        w2d=plane.w[:, jj, ii],
+        terrain1d=plane.terrain[jj, ii],
+        pressure_hpa=plane.pressure_hpa,
+        termini=termini,
+        orientation=orientation,
+        height_w2d=plane.height_w[:, jj, ii],
+    )
+
+
+def extract_wrf_section(ds, start, end, **kwargs) -> NWPSection:
+    """One-shot :func:`load_plane` + :func:`section_from_plane`.
+
+    Convenient for a single transect; for several lines through the same time,
+    call :func:`load_plane` once and reuse the plane.
+    """
+    return section_from_plane(load_plane(ds), start, end, **kwargs)

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -1010,6 +1010,153 @@ def stage_hrrr(
     return staged
 
 
+# ── GFS soil snapshot via Herbie/AWS (modern dates) ──────────────────────────
+
+
+DEFAULT_GFS_SOIL_SOURCE = "gfs_soil"
+GFS_CADENCE_HOURS = 6
+
+
+def stage_gfs_soil(
+    *,
+    init: str | dt.datetime,
+    output_root: str | Path = DEFAULT_SCRATCH_ROOT,
+    case: str = DEFAULT_HRRR_CASE,
+    source: str = DEFAULT_GFS_SOIL_SOURCE,
+    product: str = "pgrb2.0p25",
+    herbie_save_dir: str | Path | None = None,
+    overwrite: bool = False,
+    keep_herbie_cache: bool = False,
+    max_back_cycles: int = 4,
+) -> list[StagedFile]:
+    """Stage ONE GFS file carrying soil, valid at ``init`` where possible, via Herbie/AWS.
+
+    Why this exists alongside :func:`stage_gfs_analysis`. That function reaches NCEI
+    by direct HTTP because it was built for the Pelican **2013** case, and Herbie's
+    GFS sources (aws/nomads) do not go back that far — see ``[models.gfs_analysis]``
+    in ``lookups.toml``. For a modern date the constraint does not apply, and NCEI
+    is the fragile link: it returned 502 Proxy Errors on three consecutive attempts
+    for the April-2026 Ashley case (job 14297023).
+
+    It also fixes a science compromise rather than merely a reliability one. The
+    analysis stager fetches ``f000`` on the 6-hourly cadence grid, so a WRF init at
+    23Z gets soil valid at 18Z — five hours stale, and the top soil layer is exactly
+    what swings diurnally. Here the most recent cycle **at or before** ``init`` is
+    chosen (a rule that can never reach for a future analysis) and the lead is set to
+    the gap, so the file is valid **at** ``init``. For 23Z that is the 18Z cycle,
+    ``f005``. As a bonus AWS carries 0.25°, against NCEI's 0.5°.
+
+    Purpose is soil only: HRRR supplies the atmosphere and surface, this supplies the
+    layered soil HRRR lacks entirely. Whole file is retained (no subset) so the WPS
+    Vtable, not this function, decides which fields are read.
+    """
+    init_dt = _parse_init_time(init)
+    cycle0 = _snap_down_to_cadence(init_dt, GFS_CADENCE_HOURS)
+
+    # Availability is never guaranteed -- AWS has gaps, cycles get pulled, and archive
+    # edges move. Rather than fail the gate on one missing object, walk an ordered
+    # preference list and take the first that exists, recording HOW FAR from ideal it
+    # landed so the compromise appears in the manifest instead of being invisible.
+    #
+    # Order: valid-at-init from the nearest cycle (ideal), then that cycle's analysis
+    # (stale by the lead), then the same two from each earlier cycle. Never a cycle
+    # AFTER init -- that would be reaching into the future for an initial condition.
+    candidates: list[tuple[int, int, dt.datetime, int]] = []  # (staleness, lead, cycle, lead)
+    for back in range(0, int(max_back_cycles) + 1):
+        c = cycle0 - dt.timedelta(hours=GFS_CADENCE_HOURS * back)
+        lead_at_init = int((init_dt - c).total_seconds() // 3600)
+        for ld in ({lead_at_init, 0} if lead_at_init else {0}):
+            stale = int((init_dt - (c + dt.timedelta(hours=ld))).total_seconds() // 3600)
+            candidates.append((stale, ld, c, ld))
+    # Rank by STALENESS first, then by shortest forecast lead. Ranking by cycle
+    # recency instead would zig-zag: a 5 h-stale analysis from the newest cycle would
+    # be preferred over a file from an older cycle that is valid AT init. For soil the
+    # valid time is what matters -- GFS barely assimilates it, so a longer lead costs
+    # little, whereas being 5 h off catches the top layer mid-diurnal-swing.
+    candidates.sort(key=lambda x: (x[0], x[1]))
+
+    cycle = lead = None
+    H = None
+    for stale, _, c, ld in candidates:
+        try:
+            probe = Herbie(c, model="gfs", fxx=ld, product=product,
+                           save_dir=str(Path(tempfile.gettempdir())), verbose=False)
+            if not probe.grib:
+                raise FileNotFoundError("no grib source")
+        except Exception as exc:  # noqa: BLE001
+            LOG.info("GFS soil: %s f%02d unavailable (%s) -- trying next",
+                     f"{c:%Y-%m-%d %HZ}", ld, type(exc).__name__)
+            continue
+        cycle, lead = c, ld
+        LOG.info("GFS soil: using %s f%02d -- valid %s, %d h from WRF init%s",
+                 f"{c:%Y-%m-%d %HZ}", ld,
+                 f"{c + dt.timedelta(hours=ld):%Y-%m-%d %HZ}", stale,
+                 "" if stale == 0 else "  <-- NOT ideal; record this in the gate evidence")
+        break
+    if cycle is None:
+        raise RuntimeError(
+            f"GFS soil: no candidate available within {max_back_cycles} cycle(s) before "
+            f"{init_dt:%Y-%m-%d %HZ}. Checked {len(candidates)} combination(s)."
+        )
+
+    filename = f"gfs_{cycle:%Y%m%d%H}_f{lead:02d}_{product.replace('.', '')}.grib2"
+    dest = _canonical_staging_path(output_root, case, source, "", filename)
+
+    save_dir = (
+        Path(herbie_save_dir)
+        if herbie_save_dir is not None
+        else Path(tempfile.gettempdir()) / "brc_wrf_staging_cache"
+    )
+    save_dir.mkdir(parents=True, exist_ok=True)
+    lock_dir = os.environ.get("BRC_TOOLS_LOCK_DIR") or tempfile.gettempdir()
+    lock = fasteners.InterProcessLock(
+        os.path.join(lock_dir, f"stage_gfs_soil_{cycle:%Y%m%d_%H}_f{lead:02d}.lock")
+    )
+
+    def _record(path: Path, url: str | None) -> StagedFile:
+        return StagedFile(
+            source=source,
+            herbie_model="gfs",
+            member="",
+            member_int=0,
+            init_time=_isoformat_utc(cycle),
+            variable_level="all",
+            fxx_bucket=f"f{lead:02d}",
+            lead_times=[lead],
+            product=product,
+            local_path=str(path),
+            remote_url=url,
+            size_bytes=path.stat().st_size,
+            sha256=_sha256(path),
+            created_at=_isoformat_utc(dt.datetime.now(dt.timezone.utc)),
+            lead_times_source="request",
+            valid_time=_isoformat_utc(cycle + dt.timedelta(hours=lead)),
+        )
+
+    with lock:
+        if not overwrite and dest.exists() and validate_cached_grib(dest):
+            LOG.info("skip (already staged): %s", dest)
+            return [_record(dest, None)]
+
+        LOG.info(
+            "GFS soil: cycle %s f%02d -> valid %s (= WRF init)",
+            f"{cycle:%Y-%m-%d %HZ}", lead, f"{init_dt:%Y-%m-%d %HZ}",
+        )
+        H = Herbie(cycle, model="gfs", fxx=lead, product=product, save_dir=str(save_dir))
+        local = _download(H)
+        if not validate_cached_grib(local):
+            purge_cached_files(H)
+            raise RuntimeError(f"Downloaded GFS soil GRIB failed validation: {local}")
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if keep_herbie_cache:
+            shutil.copy2(local, dest)
+        else:
+            shutil.move(str(local), str(dest))
+        LOG.info("staged gfs_soil -> %s (%d bytes)", dest, dest.stat().st_size)
+        return [_record(dest, _remote_url(H))]
+
+
 def stage_hrrr_case(
     *,
     case: str = DEFAULT_HRRR_CASE,
@@ -1600,7 +1747,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--source",
         default=DEFAULT_SOURCE,
-        help="Comma list of sources: gefs_reforecast, nam_analysis, rap_analysis, gfs_analysis, hrrr "
+        help="Comma list of sources: gefs_reforecast, nam_analysis, rap_analysis, gfs_analysis, gfs_soil, hrrr "
              "(default: gefs_reforecast). '--source hrrr' uses the dedicated raw-GRIB path "
              "(--leads/--products/--interval-seconds; whole product files, no subset).",
     )
@@ -1700,7 +1847,43 @@ def main(argv: list[str] | None = None) -> int:
     fxx_parts = _parse_int_csv(args.fxx_window)
     fxx_window = (fxx_parts[0], fxx_parts[-1]) if fxx_parts else DEFAULT_FXX_WINDOW
 
+    if "gfs_soil" in sources:
+        # Single GFS file carrying soil, valid AT --init-time, from the most recent
+        # cycle at or before it. Herbie/AWS rather than NCEI: see stage_gfs_soil.
+        if args.plan:
+            cycle = _snap_down_to_cadence(_parse_init_time(args.init_time), GFS_CADENCE_HOURS)
+            lead = int((_parse_init_time(args.init_time) - cycle).total_seconds() // 3600)
+            print(f"plan: 1 file(s) -- gfs cycle {cycle:%Y-%m-%d %HZ} f{lead:02d} "
+                  f"(valid {args.init_time}), via Herbie/AWS")
+            return 0
+        try:
+            staged = stage_gfs_soil(
+                case=args.case,
+                init=args.init_time,
+                output_root=args.output_dir,
+                herbie_save_dir=args.herbie_save_dir,
+                keep_herbie_cache=args.keep_herbie_cache,
+                overwrite=args.overwrite,
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOG.error("GFS soil staging failed: %s", exc)
+            return 1
+        for s in staged:
+            LOG.info("gfs_soil: %s (%d bytes)", s.local_path, s.size_bytes)
+        return 0
+
     if "hrrr" in sources:
+        # --plan reaches this branch BEFORE the generic plan handler below, so without
+        # this guard `--source hrrr --plan` silently DOWNLOADED instead of listing --
+        # it cost a 5.6 GB transfer on a login node before being noticed. Refuse
+        # loudly rather than appear to be a dry run.
+        if args.plan:
+            LOG.error(
+                "--plan is not implemented for --source hrrr. It previously fell "
+                "through to a real download; refusing rather than pretending. Use "
+                "--source hrrr without --plan on a DTN, or plan the other sources."
+            )
+            return 2
         # HRRR raw-GRIB whole-file staging: its (leads, products, interval_seconds)
         # parameterisation differs from the fxx_window bucket model of reforecast/analysis,
         # so it dispatches to a dedicated orchestrator. --init-time doubles as the model

--- a/brc_tools/nwp/wrf_staging.py
+++ b/brc_tools/nwp/wrf_staging.py
@@ -608,7 +608,7 @@ DEFAULT_NAM_SOURCE = "nam_analysis"
 DEFAULT_NAM_CADENCE_HOURS = 6
 # WPS fg_name token per staging source; build_contract prefers the lookups model's
 # wps_fg_name and falls back to this map so a non-NAM source is never stamped GEFS.
-_FG_NAME_FALLBACK = {"nam_analysis": "NAM", "gefs_reforecast": "GEFS", "rap_analysis": "RAP", "gfs_analysis": "GFS", "hrrr": "HRRR"}
+_FG_NAME_FALLBACK = {"nam_analysis": "NAM", "gefs_reforecast": "GEFS", "rap_analysis": "RAP", "gfs_analysis": "GFS", "gfs_soil": "GFSSOIL", "hrrr": "HRRR"}
 
 
 def _snap_down_to_cadence(t: dt.datetime, cadence_hours: int) -> dt.datetime:
@@ -1868,6 +1868,52 @@ def main(argv: list[str] | None = None) -> int:
         except Exception as exc:  # noqa: BLE001
             LOG.error("GFS soil staging failed: %s", exc)
             return 1
+        # Merge into the case manifest/contract rather than writing a second pair.
+        # brc-wrf validates ONE contract per case and expects wps_fg_name to name
+        # every stream; a soil file present on disk but absent from the manifest is
+        # exactly the kind of silent gap gate C exists to catch, so close it here.
+        case_dir = Path(args.output_dir) / args.case
+        mpath = case_dir / f"manifest_{args.case}.json"
+        if mpath.exists():
+            existing = json.loads(mpath.read_text())
+            prior = [StagedFile(**d) for d in existing.get("staged_files", [])]
+            keep = [s for s in prior if s.source != DEFAULT_GFS_SOIL_SOURCE]
+            merged = keep + staged
+            lu = load_lookups()
+            manifest = build_manifest(
+                case=args.case,
+                region=existing.get("case", {}).get("region", args.region),
+                requested_window=tuple(existing.get("case", {}).get("requested_window", (None, None))),
+                interval_hours=existing.get("case", {}).get("interval_hours", 1),
+                # ORDER IS SEMANTIC, NOT COSMETIC: metgrid reads fg_name in priority
+                # order, so the atmosphere source must come FIRST or the supplement
+                # wins fields it should not. sorted() alphabetised this to
+                # ['GFSSOIL','HRRR'] -- exactly the inversion brc-wrf's two-stream
+                # validator rejects. Preserve the prior order, append what is new.
+                sources=(
+                    [s for s in existing.get("case", {}).get("sources", [])
+                     if any(f.source == s for f in merged)]
+                    + [s for s in dict.fromkeys(f.source for f in merged)
+                       if s not in existing.get("case", {}).get("sources", [])]
+                ),
+                staged=merged,
+                elapsed_seconds=None,
+            )
+            manifest["case"]["note"] = (
+                "Two-stream forcing: HRRR supplies the atmosphere and surface, gfs_soil "
+                "supplies the layered soil HRRR omits entirely (public HRRR GRIB carries "
+                "zero soil-temperature messages). The soil file is valid AT the WRF init. "
+                "metgrid must read them in order fg_name='HRRR','GFSSOIL' so HRRR wins "
+                "atmosphere/surface and GFS contributes soil only."
+            )
+            write_manifest(manifest, case_dir)
+            contract = build_contract(manifest, lu)
+            contract["interval_seconds"] = int(args.interval_seconds)
+            write_contract(contract, case_dir, args.case)
+            LOG.info("merged gfs_soil into manifest/contract (%d files, fg_name=%s)",
+                     len(merged), contract.get("wps_fg_name"))
+        else:
+            LOG.warning("no existing manifest at %s -- soil staged but unrecorded", mpath)
         for s in staged:
             LOG.info("gfs_soil: %s (%d bytes)", s.local_path, s.size_bytes)
         return 0

--- a/brc_tools/visualize/coldpool3d.py
+++ b/brc_tools/visualize/coldpool3d.py
@@ -1,0 +1,196 @@
+"""3-D terrain view with the cold pool filled beneath a chosen isentrope.
+
+Answers "how far has cold air filled the canyons and the basin floor?" in the one
+projection where the answer is legible: the terrain as a shaded surface, and above
+it the θ = θ_iso surface drawn as a translucent lid, coloured by the depth of air
+it caps.  Where the ground is already warmer than θ_iso the lid is absent, so the
+pool's shoreline is exactly where the coloured sheet stops -- the visual analogue
+of a contour of the isentrope's intersection with the terrain.
+
+Choosing θ_iso is the whole interpretation. It is an *absolute* threshold, so a
+fixed value across a sweep of times shows the pool growing as the surface cools --
+which is the point. Pick one a little below the current basin-floor θ and it starts
+as a sliver on the coldest ground and fills upward and outward through the night.
+
+Physics here, Matplotlib in the renderer, as elsewhere in the package.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+__all__ = ["isentrope_lid", "extent_window", "plot_coldpool_3d"]
+
+_KM_PER_DEG_LAT = 110.574
+_KM_PER_DEG_LON = 111.320
+
+
+def isentrope_lid(theta3d, height3d, terrain, theta_iso: float, *,
+                  max_depth_m: float = 1500.0) -> np.ndarray:
+    """Height (m ASL) of the lowest θ = ``theta_iso`` surface above ground.
+
+    Returns NaN for columns with no cold pool -- either the ground is already at or
+    above ``theta_iso`` (nothing to cap), or the isentrope sits more than
+    ``max_depth_m`` above the surface, which means the column is well mixed rather
+    than pooled and drawing a lid there would invent a feature.
+
+    Assumes θ increases upward through the capping layer, which is what "pool
+    beneath an isentrope" means; the search takes the *lowest* crossing, so a
+    residual layer higher up does not spoof a deeper pool.
+    """
+    theta = np.asarray(theta3d, dtype=float)
+    z = np.asarray(height3d, dtype=float)
+    terr = np.asarray(terrain, dtype=float)
+
+    above = theta >= float(theta_iso)
+    has = above.any(axis=0)
+    k = np.where(has, above.argmax(axis=0), 0)  # lowest crossing level
+
+    ny, nx = terr.shape
+    jj, ii = np.meshgrid(np.arange(ny), np.arange(nx), indexing="ij")
+    th_hi, z_hi = theta[k, jj, ii], z[k, jj, ii]
+    kl = np.maximum(k - 1, 0)
+    th_lo, z_lo = theta[kl, jj, ii], z[kl, jj, ii]
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        frac = (float(theta_iso) - th_lo) / (th_hi - th_lo)
+    lid = np.where(k > 0, z_lo + np.clip(frac, 0.0, 1.0) * (z_hi - z_lo), np.nan)
+
+    lid = np.where(has, lid, np.nan)          # never reaches theta_iso
+    lid = np.where(k > 0, lid, np.nan)        # ground already >= theta_iso: no pool
+    depth = lid - terr
+    return np.where((depth > 0.0) & (depth <= max_depth_m), lid, np.nan)
+
+
+def extent_window(lon2d, lat2d, extent) -> tuple[slice, slice]:
+    """``(row_slice, col_slice)`` for the smallest index rectangle covering a lon/lat box.
+
+    Returning the *window* rather than cropped copies is what lets a caller apply
+    the identical crop to 2-D and 3-D fields (``field[..., rows, cols]``); cropping
+    in index space also keeps the arrays rectangular, which ``plot_surface`` needs
+    on a curvilinear grid.
+    """
+    lon = np.asarray(lon2d, dtype=float)
+    lat = np.asarray(lat2d, dtype=float)
+    lon0, lon1, lat0, lat1 = extent
+    inside = (lon >= lon0) & (lon <= lon1) & (lat >= lat0) & (lat <= lat1)
+    if not inside.any():
+        raise ValueError(f"extent {extent} does not overlap the grid")
+    rows = np.where(inside.any(axis=1))[0]
+    cols = np.where(inside.any(axis=0))[0]
+    return slice(rows[0], rows[-1] + 1), slice(cols[0], cols[-1] + 1)
+
+
+def plot_coldpool_3d(
+    lon2d,
+    lat2d,
+    terrain,
+    lid,
+    out_path,
+    *,
+    theta_iso: float,
+    title: str,
+    annotation: str | None = None,
+    stride: int = 2,
+    elev: float = 22.0,
+    azim: float = -90.0,
+    z_frac: float = 0.45,
+    depth_min_m: float = 25.0,
+    depth_max_m: float = 300.0,
+    terrain_cmap: str = "gray",
+    pool_cmap: str = "YlGnBu",
+    figsize: tuple[float, float] = (11.0, 8.0),
+    dpi: int = 200,
+) -> Path:
+    """Render the terrain surface with the θ_iso lid floating above it.
+
+    ``azim = -90`` puts the camera due south of the scene looking **north**, so a
+    canyon draining southward runs toward the viewer.  ``z_frac`` sets the vertical
+    exaggeration as a fraction of the wider horizontal side -- an absolute
+    exaggeration factor would look wildly different between a 20 km and a 200 km
+    window, whereas this keeps every view comparably readable.
+
+    The terrain is deliberately **neutral hillshaded grey**, not a height ramp: an
+    earth colormap puts blue at its low end, which on this figure reads as pooled
+    air and competes with the thing being measured.  All colour is reserved for the
+    lid, shaded by its own depth (lid − terrain) between ``depth_min_m`` and
+    ``depth_max_m``.  The lower cut matters: with an isentrope only a kelvin above
+    the surface, most of the domain carries a few metres of nominally "cold" air,
+    and drawing it blankets the canyons the figure exists to show.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib import colormaps, colors
+
+    lon = np.asarray(lon2d, dtype=float)[::stride, ::stride]
+    lat = np.asarray(lat2d, dtype=float)[::stride, ::stride]
+    terr = np.asarray(terrain, dtype=float)[::stride, ::stride]
+    lid = np.asarray(lid, dtype=float)[::stride, ::stride]
+
+    # Local equirectangular km, so the box aspect is physical rather than degrees.
+    lat_mid = float(np.mean(lat))
+    x_km = (lon - lon.min()) * _KM_PER_DEG_LON * np.cos(np.deg2rad(lat_mid))
+    y_km = (lat - lat.min()) * _KM_PER_DEG_LAT
+    lx, ly = float(x_km.max()), float(y_km.max())
+    dx_m = max(float(np.nanmean(np.diff(x_km, axis=1))) * 1000.0, 1.0)
+    dy_m = max(float(np.nanmean(np.diff(y_km, axis=0))) * 1000.0, 1.0)
+
+    depth = np.where(lid - terr >= depth_min_m, lid - terr, np.nan)
+    norm = colors.Normalize(depth_min_m, depth_max_m)
+    pool_rgba = colormaps[pool_cmap](norm(np.clip(depth, depth_min_m, depth_max_m)))
+    pool_rgba[..., 3] = np.where(np.isfinite(depth), 0.92, 0.0)  # invisible off-pool
+
+    # Pure hillshade, no elevation ramp: shape comes from the shading and height
+    # from the z axis, which leaves darkness as well as hue free for the pool. A
+    # height-coded terrain puts dark cells on the basin floor -- exactly where the
+    # pool is -- and the two become impossible to tell apart.
+    ls = colors.LightSource(azdeg=315, altdeg=45)
+    hs = ls.hillshade(terr, vert_exag=3.0, dx=dx_m, dy=dy_m)
+    terr_rgb = colormaps[terrain_cmap](0.45 + 0.5 * hs)
+
+    fig = plt.figure(figsize=figsize)
+    # computed_zorder=False: let the draw order stand, so the lid is painted over
+    # the terrain instead of Matplotlib's per-artist depth guess flickering between
+    # frames of a sweep.
+    ax = fig.add_subplot(projection="3d", computed_zorder=False)
+    ax.plot_surface(x_km, y_km, terr, facecolors=terr_rgb, linewidth=0,
+                    antialiased=False, rstride=1, cstride=1, shade=False, zorder=1)
+    if np.isfinite(depth).any():
+        ax.plot_surface(x_km, y_km, np.where(np.isfinite(depth), lid, np.nan),
+                        facecolors=pool_rgba, linewidth=0, antialiased=False,
+                        rstride=1, cstride=1, shade=False, zorder=3)
+        cb = fig.colorbar(plt.cm.ScalarMappable(norm=norm, cmap=pool_cmap), ax=ax,
+                          shrink=0.55, pad=0.02, extend="max")
+        cb.set_label(rf"depth below $\theta$ = {theta_iso:g} K (m)")
+    else:
+        ax.text2D(0.5, 0.9, rf"no air below $\theta$ = {theta_iso:g} K",
+                  transform=ax.transAxes, ha="center", fontsize=9, color="0.35")
+
+    z_lo = float(np.floor(np.nanmin(terr) / 100.0) * 100.0)
+    z_hi = float(np.ceil(np.nanmax(terr) / 100.0) * 100.0)
+    ax.set_zlim(z_lo, z_hi)
+    ax.set_box_aspect((lx, ly, max(lx, ly) * z_frac))
+    ax.view_init(elev=elev, azim=azim)
+    ax.set_xlabel("east (km)", labelpad=2)
+    ax.set_ylabel("north (km)", labelpad=2)
+    ax.set_zlabel("height (m ASL)", labelpad=2)
+    ax.tick_params(labelsize=7)
+    for pane in (ax.xaxis, ax.yaxis, ax.zaxis):
+        pane.pane.set_facecolor("white")
+        pane.pane.set_edgecolor("0.85")
+        pane._axinfo["grid"].update(color="0.9", linewidth=0.4)
+    ax.set_title(title)
+    # A 3-D axes leaves large empty margins by default; claw them back so the
+    # terrain, not whitespace, is what the figure is mostly made of.
+    fig.subplots_adjust(left=0.0, right=0.92, bottom=0.02, top=0.98)
+    if annotation:
+        ax.text2D(0.99, 0.01, annotation, transform=ax.transAxes, ha="right",
+                  va="bottom", fontsize=6, alpha=0.65)
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return out

--- a/brc_tools/visualize/wrf_curtain.py
+++ b/brc_tools/visualize/wrf_curtain.py
@@ -1,0 +1,179 @@
+"""Cross-section curtains drawn on WRF's own grid — no resampling, no smoothing.
+
+The isobaric renderer in :mod:`brc_tools.visualize.nwp_maps` has to interpolate
+each column onto a regular height axis and shade it ``gouraud``: with 13 pressure
+levels a flat-shaded curtain would be a stack of 13 fat bands, so the smoothing is
+buying back detail that GRIB never had.
+
+A WRF section is the opposite case. It arrives on ~80 stretched eta levels whose
+spacing near the ground is metres, and the model's own cells *are* the resolution.
+Resampling them onto a regular ``dz`` axis and blurring across cells throws away
+exactly the near-surface structure a drainage study is looking for, and quietly
+invents a smooth field where the model has a staircase. So: shade the true cells
+with ``pcolormesh(..., shading="flat")`` on the w-level edges, contour and quiver
+on the mass points, and let the terrain-following staircase show.
+
+Everything else — the locator inset, the along-line town markers, the terminus
+labels — is the shared basin-winds furniture, reused from ``nwp_maps`` so the two
+figure families still read as one system.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+# Private, deliberately: these draw the shared section furniture and are frozen
+# alongside the rest of visualize/* for the pelican2013 study.  Re-implementing
+# them here to avoid touching a private name would fork the look of every figure
+# the moment one copy is retuned.
+from brc_tools.visualize.nwp_maps import _draw_section_towns, _geo_locator_inset
+from brc_tools.visualize.style import get_style
+
+__all__ = ["curtain_mesh", "plot_wrf_curtain"]
+
+_ACCENT = "#c0392b"
+_SHADE_FIELD = {"speed": "speed2d", "theta": "theta2d", "temp": "temp2d",
+                "along": "along2d", "w": "w2d", "theta_e": "thetae2d"}
+
+
+def _edges1d(centres: np.ndarray) -> np.ndarray:
+    """``(n,)`` cell centres → ``(n+1,)`` edges, extrapolating half a cell at each end."""
+    c = np.asarray(centres, dtype=float)
+    if c.size == 1:
+        return np.array([c[0] - 0.5, c[0] + 0.5])
+    mid = 0.5 * (c[1:] + c[:-1])
+    return np.concatenate([[2 * c[0] - mid[0]], mid, [2 * c[-1] - mid[-1]]])
+
+
+def curtain_mesh(section) -> tuple[np.ndarray, np.ndarray]:
+    """Cell-corner arrays ``(X, Y)``, each ``(nz+1, n+1)``, for flat shading.
+
+    Vertical corners come from ``section.height_w2d`` — WRF's w levels, which are
+    the true cell edges — when present, and from midpoints between mass levels
+    otherwise.  Horizontal corners are midpoints between the sampled columns.
+    """
+    dist = np.asarray(section.distance_km, dtype=float)
+    zm = np.asarray(section.height2d, dtype=float)  # (nz, n)
+    nz, n = zm.shape
+
+    if getattr(section, "height_w2d", None) is not None:
+        z_edge = np.asarray(section.height_w2d, dtype=float)  # (nz+1, n)
+    else:
+        inner = 0.5 * (zm[1:, :] + zm[:-1, :])
+        z_edge = np.vstack([2 * zm[:1, :] - inner[:1, :],
+                            inner,
+                            2 * zm[-1:, :] - inner[-1:, :]])
+
+    # (nz+1, n) column-centred edges -> (nz+1, n+1) corners.
+    inner = 0.5 * (z_edge[:, 1:] + z_edge[:, :-1])
+    Y = np.hstack([(2 * z_edge[:, :1] - inner[:, :1]),
+                   inner,
+                   (2 * z_edge[:, -1:] - inner[:, -1:])])
+    X = np.broadcast_to(_edges1d(dist), (nz + 1, n + 1))
+    return np.asarray(X), Y
+
+
+def plot_wrf_curtain(
+    section,
+    out_path,
+    *,
+    shade: str = "speed",
+    style=None,
+    title: str,
+    annotation: str | None = None,
+    theta_contours: bool = True,
+    theta_interval: float = 1.0,
+    w_exaggeration: float = 10.0,
+    quiver_stride: tuple[int, int] = (4, 10),
+    y_top_m: float = 3000.0,
+    y_bottom_m: float | None = None,
+    waypoints: dict | None = None,
+    waypoint_offset_km: float = 15.0,
+    locator: dict | None = None,
+    figsize: tuple[float, float] = (11.0, 6.2),
+    dpi: int = 200,
+) -> Path:
+    """Render an :class:`~brc_tools.nwp.section.NWPSection` on its native grid.
+
+    ``shade`` picks the shaded field (``speed``, ``theta``, ``temp``, ``along``,
+    ``w``, ``theta_e``). ``theta_interval`` defaults to 1 K rather than the
+    isobaric renderer's 2 K: a nocturnal inversion does its work in the first few
+    kelvin, and on the native grid there is resolution to show it.
+
+    ``w_exaggeration`` scales the vertical component of the in-plane vectors and is
+    a property of the *regime*, not the plot geometry — see ``docs/WRF-WINDS.md``.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    if shade not in _SHADE_FIELD:
+        raise ValueError(f"shade must be one of {sorted(_SHADE_FIELD)}, got {shade!r}")
+    field = getattr(section, _SHADE_FIELD[shade], None)
+    if field is None:
+        raise ValueError(f"section carries no {_SHADE_FIELD[shade]} for shade={shade!r}")
+
+    st = style if style is not None else get_style("wind_speed_10m")
+    dist = np.asarray(section.distance_km, dtype=float)
+    terrain = np.asarray(section.terrain1d, dtype=float)
+    zm = np.asarray(section.height2d, dtype=float)
+    X, Y = curtain_mesh(section)
+
+    y_bottom = (y_bottom_m if y_bottom_m is not None
+                else float(np.floor(np.nanmin(terrain) / 100.0) * 100.0 - 50.0))
+
+    fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
+    ax.set_facecolor("0.6")
+    mesh = ax.pcolormesh(X, Y, np.asarray(field, dtype=float), cmap=st.cmap,
+                         vmin=st.vmin, vmax=st.vmax, shading="flat")
+    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=st.extend, label=st.label)
+
+    dist2d = np.broadcast_to(dist, zm.shape)
+    if theta_contours:
+        theta = np.asarray(section.theta2d, dtype=float)
+        lo = np.floor(np.nanmin(theta) / theta_interval) * theta_interval
+        hi = np.ceil(np.nanmax(theta) / theta_interval) * theta_interval
+        cs = ax.contour(dist2d, zm, theta, levels=np.arange(lo, hi + 0.1, theta_interval),
+                        colors="black", linewidths=0.4, alpha=0.5)
+        ax.clabel(cs, cs.levels[::2], fontsize=6, fmt="%.0f")
+
+    sz, sx = quiver_stride
+    q = ax.quiver(dist2d[::sz, ::sx], zm[::sz, ::sx],
+                  np.asarray(section.along2d, dtype=float)[::sz, ::sx],
+                  np.asarray(section.w2d, dtype=float)[::sz, ::sx] * w_exaggeration,
+                  color="black", width=0.0016, alpha=0.85, zorder=8)
+    ax.quiverkey(q, 0.86, 1.02, 10.0,
+                 rf"10 m s$^{{-1}}$ along, $w\times${w_exaggeration:g}",
+                 labelpos="E", coordinates="axes", fontproperties={"size": 7})
+
+    # Terrain as the model steps it, not a smoothed curve: the staircase IS the
+    # boundary the flow feels, and hiding it would misrepresent the resolution.
+    ax.fill_between(dist, y_bottom, terrain, step="mid", color="0.6",
+                    linewidth=0, zorder=6)
+    ax.step(dist, terrain, where="mid", color="black", linewidth=0.7, zorder=7)
+
+    ax.set_ylim(y_bottom, y_top_m)
+    ax.set_xlim(float(dist.min()), float(dist.max()))
+    ax.set_xlabel("distance along transect (km)")
+    ax.set_ylabel("height (m ASL)")
+    ax.set_title(title)
+
+    tkw = dict(color=_ACCENT, fontsize=11, fontweight="bold", transform=ax.transAxes)
+    ax.text(0.0, -0.09, section.termini[0], ha="left", va="top", **tkw)
+    ax.text(1.0, -0.09, section.termini[1], ha="right", va="top", **tkw)
+
+    if waypoints:
+        _draw_section_towns(ax, section, waypoints, waypoint_offset_km)
+    if locator is not None:
+        _geo_locator_inset(ax, section, locator)
+    if annotation:
+        ax.text(0.99, 0.01, annotation, transform=ax.transAxes, ha="right", va="bottom",
+                fontsize=6, alpha=0.65,
+                bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.55, "pad": 1.5})
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return out

--- a/docs/ENVIRONMENT-SETUP.md
+++ b/docs/ENVIRONMENT-SETUP.md
@@ -45,7 +45,23 @@ repo root — it mirrors `pyproject.toml` and tracks a current Herbie release:
 mamba env create -f environment.yml   # creates env "brc-tools-2026"
 conda activate brc-tools-2026
 pip install -e . --no-deps            # install brc_tools itself (deps already solved)
-pytest tests/                          # validated: 107 passed, 2 skipped on herbie 2026.3.0
+pytest tests/                          # validated 2026-07-27: 253 passed, 2 skipped on herbie 2026.3.0
+```
+
+On CHPC that `pip install -e .` needs two extra flags — `--no-build-isolation` (pypi.org is
+unreachable from compute/login sandboxes, so pip cannot fetch a build backend) and `--no-user`
+(otherwise pip falls back to a read-only `~/.local/lib`):
+
+```bash
+pip install -e . --no-deps --no-build-isolation --no-user
+```
+
+Then confirm the install **from outside the checkout** — running `python -c "import brc_tools"`
+while sitting in the repo passes on cwd alone and hides a missing install, which later surfaces as
+an `ImportError` in `brc-wrf` or `clyfar` (both import `brc_tools` from their own trees):
+
+```bash
+cd /tmp && python -c "import brc_tools, brc_tools.visualize.grid, brc_tools.download.push_data"
 ```
 
 Prefer a fresh, dedicated env over reusing a shared/accreted one. The canonical list of

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Project documentation. Topical files only — agent context lives in
 - **WRF-STAGING-STATE-PLAYBOOK.md** — the single WRF cold-start handoff + state packet (start here for the WRF lane).
 - **WRF-GEFS-NAM-FIELD-MAP.md** — DRAFT GEFS/NAM two-stream field-map (parked, not proven).
 - **WRF-FIGURE-ENGINE.md** — dataset-agnostic WRF figure engine + `scripts/wrf_figures.py --config <case.toml>` CLI (TOML schema, domain-awareness, named-skip preflight). Per-study cases live in the study repo.
+- **WRF-WINDS.md** — basin-winds-style plan views + arbitrary-transect cross-sections straight from `wrfout` (native eta levels), `scripts/wrf_winds.py --config <case.toml>` + `/wrf-basin-winds` skill. Works against a run that is still writing.
 - **FORECAST-FUNNEL.md** — NAM "forecast funnel" synoptic montage (250/500/600 hPa + surface analysis) + `/basin-forecast-funnel` skill and `scripts/forecast_funnel.py` CLI.
 - **nwp/NWP-SOURCE-MATRIX.md** — per-source download matrix (Herbie vs direct) + Herbie currency.
 - **nwp/** — HRRR/RRFS roadmap (current operational focus).

--- a/docs/WRF-WINDS.md
+++ b/docs/WRF-WINDS.md
@@ -1,0 +1,187 @@
+# WRF winds — basin-winds-style figures from a WRF run
+
+The WRF counterpart of the ub-wx `basin-winds` HRRR case. For each nest it renders
+
+- **plan views** — a surface field (10 m wind speed by default) with earth-relative
+  barbs, terrain contours, Natural-Earth reference overlays, and town labels;
+- **cross-sections** — terrain-filled wind curtains along named A→B geographic
+  lines, with θ contours, in-plane (along + exaggerated `w`) vectors, along-line
+  town markers, and the geographic locator inset;
+- **3-D cold-pool views** — hillshaded terrain with the θ = θ_iso surface floating
+  above it as a lid coloured by the depth of air it caps.
+
+Plan views use the same renderer as the HRRR path (`brc_tools.visualize.nwp_maps`),
+so the two are directly comparable. The vertical is where they part company.
+`extract_nwp_section` has to stack isobaric levels because that is all GRIB
+carries; the WRF adapter samples the **native eta column**, which for a drainage
+layer tens of metres deep is the difference between seeing the feature and
+interpolating it away.
+
+The curtain renderer is therefore separate too. The isobaric one resamples each
+column onto a regular `dz` axis and shades it `gouraud`, because 13 pressure levels
+flat-shaded would be 13 fat bands — the smoothing buys back detail GRIB never had.
+A WRF section is the opposite case: ~80 stretched eta levels whose near-surface
+spacing is metres, where resampling and blurring destroy exactly the structure
+being studied. So `plot_wrf_curtain` shades the model's **true cells** with
+`pcolormesh(..., shading="flat")` on the w-level edges, contours and quivers on the
+mass points, and draws the terrain as the staircase the model actually feels.
+
+| piece | lives in |
+|---|---|
+| adapter (`wrfout` → plan `Dataset` / `NWPSection`) | `brc_tools/nwp/wrf_section.py` |
+| native-grid curtain renderer | `brc_tools/visualize/wrf_curtain.py` |
+| 3-D cold-pool renderer | `brc_tools/visualize/coldpool3d.py` |
+| engine + CLI | `scripts/wrf_winds.py` |
+| SLURM wrapper | `scripts/wrf_winds.dtn.slurm` |
+| **per-case config** | a TOML in the repo that owns the case |
+
+No case-specific code lives in brc-tools — a new case is a new TOML.
+
+Related but distinct: **`docs/WRF-FIGURE-ENGINE.md`** (`scripts/wrf_figures.py`) is the
+publication engine for the pelican2013-style study families — grid-aligned EW/NS
+sections, multi-domain surface panels, differences, heat-deficit diagnostics. Reach
+for that one for a study's figure set; reach for this one for arbitrary transects,
+the locator inset, and a quick matched look across nests while a run is still
+writing.
+
+## Run
+
+```
+# on a DTN: lawson-group6 is read-only on login nodes, and lawson-np is usually
+# busy running the very job you want to look at
+sbatch scripts/wrf_winds.dtn.slurm --config <case.toml> [--run-dir <run>] \
+       [--hourly | --every 15 | --all | --valid 2025-09-08_22:00 | --lead 120] \
+       [--domain 2] [--w-exag 10] [--theta-iso 311] [--output-dir <dir>] [--dpi 200]
+```
+
+- `--every MIN` sweeps every valid time on a MIN-minute cadence; `--hourly` is
+  shorthand for `--every 60`; `--all` takes the run's native output interval.
+  Sweeps use the **union** of times across domains, not the intersection — a 3 km
+  parent on hourly output and a 600 m nest on 5-minute output share only whole
+  hours, so intersecting would discard every sub-hourly frame the fine nest has.
+  Each domain then renders only the times it holds, and the count of skipped
+  domain-times is reported once at the end rather than per line.
+- Figures are simply overwritten, so re-running as the job advances costs nothing
+  but wall clock.
+- `--valid` takes an exact `YYYY-MM-DD_HH:MM`; `--lead` takes **minutes** after
+  init (`SIMULATION_START_DATE`, else the earliest wrfout).
+- With none of those, the engine renders **the latest valid time present on every
+  requested domain** — the useful default against a *running* job, where a 3 km
+  parent on hourly output lags a 600 m nest on 5-minute output. Domains missing
+  the chosen time are named-skipped, never a crash; so is a single time that fails
+  mid-sweep (a wrfout caught half-written), which does not abort the rest.
+- `--run-dir` overrides the TOML, so one config serves every run of a case.
+- `--w-exag` overrides every section's vertical exaggeration for that render (see
+  the note under `w_exag` below).
+- Output: `<out>/<YYYYmmdd_HHMM>/<tag>/{topdown_<var>,xsection_<key>}_<tag>_<stamp>.png`.
+  Default root is `$BRC_TOOLS_OUTPUT_DIR` (else group6 `brc-tools-output`) `/ <slug>`.
+
+Both wrfout filename conventions are read: WRF's default `%Y-%m-%d_%H:%M:%S` **and**
+the `nocolons = .true.` form `%Y-%m-%d_%H_%M_%S`. (`brc_tools.nwp.wrf_output` assumes
+the first; the tolerant helpers live in `wrf_section.py`.)
+
+## Case TOML schema
+
+```toml
+[case]
+slug = "ashley-drainage-120m"     # output subdirectory
+label = "Ashley drainage"         # figure titles
+annotation = "..."                # small bottom-right provenance stamp
+run_dir = "/scratch/.../wrf_run"  # $VARS expanded; --run-dir overrides
+output_dir = "..."                # optional; --output-dir overrides
+
+[map]                             # Natural-Earth overlays; fail-soft if unstaged
+states = true; counties = true; roads = true; rivers = true; lakes = true
+
+[style.overrides.<var>]           # vmin/vmax/cmap/label/extend/diverging
+vmin = 306.0                      # the shared table is tuned for winter cold pools
+vmax = 322.0
+
+[[domains]]                       # one per VIEW, not per nest
+domain = 2                        # nest number
+tag = "d02_ashley"                # names the output dir; lets one nest have several views
+extent = [lon0, lon1, lat0, lat1] # optional; else the full grid
+pad_deg = 0.03                    # inset the full-grid view (hides the relaxation zone)
+barb_stride = 16
+waypoint_group = "basin_landmarks"   # a group in nwp/lookups.toml
+surface_vars = ["wind_speed_10m", "theta_2m", "pblh"]
+sections = ["we", "dryfork"]      # keys into [[sections]]
+views3d = ["ashley_pool"]         # keys into [[views3d]]
+
+[[sections]]
+key = "dryfork"
+label = "Dry Fork -> Vernal -> Green R."   # keep SHORT: the quiver key sits top-right
+a = [lat, lon]                    # terminus A
+b = [lat, lon]                    # terminus B
+termini = ["NW", "SE"]
+waypoint_group = "us40_dense"
+offset_km = 12.0                  # label towns within this distance of the line
+y_top_m = 4200.0                  # must clear the highest terrain on the line
+w_exag = 8.0
+n_points = 200                    # samples along the line (nearest column each)
+shade = "speed"                   # speed | theta | temp | along | w | theta_e
+theta_interval = 1.0              # K between theta contours
+quiver_stride = [5, 10]           # (vertical, horizontal), in MODEL LEVELS
+loc_extent = [lon0, lon1, lat0, lat1]   # locator inset map window
+loc_rect = [x, y, w, h]                 # inset placement, axes fraction
+
+[[views3d]]
+key = "ashley_pool"
+label = "Ashley + Dry Fork cold pool"
+extent = [lon0, lon1, lat0, lat1]
+theta_iso = [311.0, 313.0]        # one panel per isentrope; --theta-iso overrides
+azim = -90.0                      # camera due south = LOOKING NORTH; -60 is oblique
+elev = 22.0
+stride = 2                        # decimate the surface mesh
+z_frac = 0.45                     # vertical size as a fraction of the wider side
+depth_min_m = 25.0                # thinner than this is a skim, not a pool
+depth_max_m = 400.0               # colour-scale top (share it across a sweep)
+max_depth_m = 700.0               # reject lids this far up: that is a mixed layer
+```
+
+`n_points` should be about the number of **grid cells** the line crosses, not more:
+the curtain is flat-shaded on the model's own cells, so oversampling just draws
+duplicated columns as visible repeats.
+
+`surface_vars` are **style keys**, because the renderer looks the colour scale up by
+variable name: `wind_speed_10m`, `theta_2m`, `temp_2m`, `pblh`. A variable the run
+did not write is named-skipped.
+
+### Choosing `w_exag`
+
+The renderer's docstring suggests the plot aspect (transect length ÷ visible depth),
+which is right when `w` is small — the HRRR case uses 100. It is **not** a geometric
+constant: it is set by the regime. A convective afternoon on a 600 m mesh resolves
+`w ~ 1–3 m s⁻¹`, so an exaggeration of 100 makes every vector vertical and hides the
+along-transect flow entirely; ~8–15 reads correctly. A quiescent drainage night has
+`w` two orders of magnitude smaller and wants the geometric value back. Put the
+common regime in the TOML and switch with `--w-exag` for the other.
+
+### Choosing `theta_iso`
+
+The isentrope is an **absolute** threshold, which is what makes a fixed value
+across a sweep show the pool *filling*: it starts as a sliver on the coldest ground
+and grows up the canyons as the surface cools. Sample the basin-floor θ₂ₘ first and
+bracket it — one value a kelvin or two below (empty now, grows through the night)
+and one at or just above (already substantial).
+
+Too warm is a trap. An isentrope above the environmental θ over high terrain sits
+a kilometre above the ground there, and the "pool" it draws is just the mountain
+boundary layer. `max_depth_m` is the guard: set it to about the depth of a
+brim-full basin, so a genuine pool survives and a mixed layer does not.
+
+### Choosing `loc_rect`
+
+The inset (default top-right) collides with the rotated town labels that hang from
+the top edge. Put it wherever the panel is dead: for a transect that descends
+left-to-right, the **bottom-left** corner is inside the terrain fill and free.
+
+## Adding a case
+
+1. Copy an existing TOML into the repo that owns the case (for ub-wx WRF
+   experiments: `experiments/<id>/figures.toml`).
+2. Set `run_dir`, `[[domains]]`, and the transect endpoints.
+3. Check the transect actually crosses the terrain you meant — sample `HGT` along it
+   before rendering; an endpoint outside a nest silently samples that nest's edge
+   column all the way out.
+4. `sbatch scripts/wrf_winds.dtn.slurm --config <that TOML>`.

--- a/scripts/stage_ashley_drainage_120m.dtn.slurm
+++ b/scripts/stage_ashley_drainage_120m.dtn.slurm
@@ -12,19 +12,13 @@
 # failed on exactly this, 14136134 passed once GFS soil was added. RAP 130 was
 # checked and also lacks soil. The working soil source is GFS 0.25 f000.
 #
-# GFS cycle choice: our init is 23Z, which is not a GFS cycle. Take the most recent
-# analysis AT OR BEFORE init -- 18Z 24 Apr. That is a rule rather than a per-case
-# judgement (it can never reach for an analysis from the future), which is what makes
-# it safe to put on rails. `--fxx-window 0,0` expresses exactly that: the window
-# start is snapped DOWN to the 6-hourly cadence grid, giving one cycle at 18Z.
-#
-# Omitting --fxx-window is what went wrong on job 14296762: the default (12,48) is
-# sized for GFS as DRIVING forcing and enumerated a 6-hourly sequence from 12Z 25
-# Apr onward. Not a tool bug -- the wrong window for this use.
-#
-# Ideal would be 18Z f005, valid exactly at our 23Z init; the analysis stager fetches
-# f000 only. The residual is 5 h of soil evolution, and since the top layer is what
-# swings diurnally this is a real but second-order error worth stating in notes.
+# SOIL now comes from --source gfs_soil (Herbie/AWS), not gfs_analysis (NCEI direct).
+# NCEI 502'd three times on job 14297023, and the analysis stager could only offer
+# f000 on the 6-hourly grid -- soil valid 18Z for a 23Z init, 5 h stale in exactly
+# the layer that swings diurnally. gfs_soil takes the most recent cycle AT OR BEFORE
+# init and sets the lead to the gap, so the file is valid AT init: 18Z f005 here.
+# It also gets 0.25 deg instead of NCEI's 0.5, and falls back gracefully through
+# older cycles if an object is missing, logging how far from ideal it landed.
 #
 # Submit:  sbatch scripts/stage_ashley_drainage_120m.dtn.slurm
 
@@ -67,8 +61,8 @@ echo "=== gate A staging start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ===
 
 echo "--- PLAN: GFS soil ---"
 "$PY" -B -m brc_tools.nwp.wrf_staging \
-  --case "$CASE" --source gfs_analysis --init-time "2026-04-24 23Z" \
-  --fxx-window 0,0 --output-dir "$OUT" --plan
+  --case "$CASE" --source gfs_soil --init-time "2026-04-24 23:00" \
+  --output-dir "$OUT" --plan
 
 # ---- stage ------------------------------------------------------------------
 echo "--- STAGE: HRRR nat+sfc f00..f06 from 2026-04-24 23Z ---"
@@ -77,11 +71,10 @@ echo "--- STAGE: HRRR nat+sfc f00..f06 from 2026-04-24 23Z ---"
   --leads 0,1,2,3,4,5,6 --products nat,sfc --interval-seconds 3600 \
   --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
 
-echo "--- STAGE: GFS analysis f000 (soil), most recent cycle at/before init = 18Z 24 Apr ---"
+echo "--- STAGE: GFS soil via Herbie/AWS, valid AT init (18Z cycle f005) ---"
 "$PY" -B -m brc_tools.nwp.wrf_staging \
-  --case "$CASE" --source gfs_analysis --init-time "2026-04-24 23Z" \
-  --fxx-window 0,0 \
-  --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+  --case "$CASE" --source gfs_soil --init-time "2026-04-24 23:00" \
+  --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
 
 # ---- report -----------------------------------------------------------------
 echo "=== staged set ==="

--- a/scripts/stage_ashley_drainage_120m.dtn.slurm
+++ b/scripts/stage_ashley_drainage_120m.dtn.slurm
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Gate A staging for ashley_drainage_120m -- HRRR atmosphere + GFS soil, two streams.
+#
+# Event: 24-25 April 2026 anabatic->katabatic slope-flow reversal.
+# Window: 23Z 24 Apr -> 05Z 25 Apr (6 h), hourly LBCs, so HRRR f00..f06 from the
+# 23Z cycle. Tracked in ../ub-wx/experiments/20260424-ashley-drainage-120m/.
+#
+# TWO STREAMS IS NOT OPTIONAL. Public HRRR GRIB (nat+sfc) carries ZERO
+# soil-temperature messages and soil moisture only at degenerate 0 / 0.01 m layers,
+# so a single-stream HRRR metgrid yields num_metgrid_soil_levels=0 and real.exe
+# cannot initialise Noah. Established by ashley2026_seiche gate C: job 14135619
+# failed on exactly this, 14136134 passed once GFS soil was added. RAP 130 was
+# checked and also lacks soil. The working soil source is GFS 0.25 f000.
+#
+# GFS cycle choice: our init is 23Z, which is not a GFS cycle. 00Z 25 Apr f000 is
+# 1 h after; 18Z 24 Apr f000 is 5 h before. Soil temperature varies slowly, so the
+# nearer analysis wins -- 00Z 25 Apr.
+#
+# Submit:  sbatch scripts/stage_ashley_drainage_120m.dtn.slurm
+
+#SBATCH --job-name=stage_ashley120m
+#SBATCH --account=dtn
+#SBATCH --partition=notchpeak-dtn
+#SBATCH --qos=notchpeak-dtn
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --mem=32G
+#SBATCH --time=0-03:00:00
+#SBATCH --output=/scratch/general/vast/%u/stage_ashley120m_%j.out
+#SBATCH --error=/scratch/general/vast/%u/stage_ashley120m_%j.out
+
+set -euo pipefail
+
+PY="$HOME/software/pkg/miniforge3/envs/brc-tools-2026/bin/python"
+REPO="$HOME/gits/brc-tools"
+CASE=ashley_drainage_120m
+OUT="/scratch/general/vast/$USER/wrf_inputs"
+
+cd "$REPO"
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+# CHPC DTNs can hang on outbound IPv6 (job 13471949 wedged in SYN-SENT to an NCEI
+# IPv6 address); force IPv4 for every download.
+export BRC_TOOLS_HTTP_IPV4_ONLY=1
+export PYTHONPYCACHEPREFIX="/scratch/general/vast/$USER/pycache"
+# Herbie's per-GRIB lock defaults to node-local /tmp, so fanned-out jobs do NOT
+# serialise and one can delete a subset GRIB while another reads it.
+export BRC_TOOLS_LOCK_DIR="/scratch/general/vast/$USER/herbie_locks"
+mkdir -p "$BRC_TOOLS_LOCK_DIR"
+
+echo "=== gate A staging start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
+
+# ---- plan first: list URLs and bytes, download nothing -----------------------
+# A 2026-04 date is ~3 months old and well inside the HRRR archive, but the plan
+# costs seconds and turns a silent 404 storm into a readable failure.
+echo "--- PLAN: HRRR ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source hrrr --init-time "2026-04-24 23Z" \
+  --leads 0,1,2,3,4,5,6 --products nat,sfc --interval-seconds 3600 \
+  --output-dir "$OUT" --plan
+
+echo "--- PLAN: GFS soil ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_analysis --init-time "2026-04-25 00Z" \
+  --output-dir "$OUT" --plan
+
+# ---- stage ------------------------------------------------------------------
+echo "--- STAGE: HRRR nat+sfc f00..f06 from 2026-04-24 23Z ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source hrrr --init-time "2026-04-24 23Z" \
+  --leads 0,1,2,3,4,5,6 --products nat,sfc --interval-seconds 3600 \
+  --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+echo "--- STAGE: GFS 0.25 f000 (soil) from 2026-04-25 00Z ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_analysis --init-time "2026-04-25 00Z" \
+  --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+# ---- report -----------------------------------------------------------------
+echo "=== staged set ==="
+ls -lhR "$OUT/$CASE/" | head -60
+for f in "$OUT/$CASE"/manifest_*.json "$OUT/$CASE"/contract_*.json; do
+    [[ -f "$f" ]] && { echo "--- $f ---"; "$PY" -m json.tool "$f" | head -40; }
+done
+rm -rf "$OUT/.herbie_cache_$CASE"
+echo "=== gate A staging done $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo
+echo "NEXT: gate C is a TWO-STREAM metgrid, not a single ungrib pass --"
+echo "  HRRR stream: Vtable.raphrrr.nosoil, prefix HRRR"
+echo "  GFS  stream: Vtable.gfssoil,        prefix GFSSOIL"
+echo "  metgrid fg_name = 'HRRR','GFSSOIL'  (HRRR first: it wins atmosphere+surface)"
+echo "  Both Vtables: \$WRF_ARCHIVE/ashley2026_seiche/control/smoke_20260723T044000Z/"

--- a/scripts/stage_ashley_drainage_120m.dtn.slurm
+++ b/scripts/stage_ashley_drainage_120m.dtn.slurm
@@ -77,12 +77,16 @@ echo "--- STAGE: GFS soil via Herbie/AWS, valid AT init (18Z cycle f005) ---"
   --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
 
 # ---- report -----------------------------------------------------------------
+# NOTE: `set -o pipefail` + `| head` makes SIGPIPE fail the job even when staging
+# succeeded -- that is what marked job 14298037 FAILED with exit 32 after both
+# streams had landed correctly. Every reporting pipe below is guarded.
+set +o pipefail
 echo "=== staged set ==="
-ls -lhR "$OUT/$CASE/" | head -60
+ls -lhR "$OUT/$CASE/" | head -60 || true
 for f in "$OUT/$CASE"/manifest_*.json "$OUT/$CASE"/contract_*.json; do
-    [[ -f "$f" ]] && { echo "--- $f ---"; "$PY" -m json.tool "$f" | head -40; }
+    [[ -f "$f" ]] && { echo "--- $f ---"; "$PY" -m json.tool "$f" | head -40 || true; }
 done
-rm -rf "$OUT/.herbie_cache_$CASE"
+rm -rf "$OUT/.herbie_cache_$CASE" || true
 echo "=== gate A staging done $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 echo
 echo "NEXT: gate C is a TWO-STREAM metgrid, not a single ungrib pass --"

--- a/scripts/stage_ashley_drainage_120m.dtn.slurm
+++ b/scripts/stage_ashley_drainage_120m.dtn.slurm
@@ -12,9 +12,19 @@
 # failed on exactly this, 14136134 passed once GFS soil was added. RAP 130 was
 # checked and also lacks soil. The working soil source is GFS 0.25 f000.
 #
-# GFS cycle choice: our init is 23Z, which is not a GFS cycle. 00Z 25 Apr f000 is
-# 1 h after; 18Z 24 Apr f000 is 5 h before. Soil temperature varies slowly, so the
-# nearer analysis wins -- 00Z 25 Apr.
+# GFS cycle choice: our init is 23Z, which is not a GFS cycle. Take the most recent
+# analysis AT OR BEFORE init -- 18Z 24 Apr. That is a rule rather than a per-case
+# judgement (it can never reach for an analysis from the future), which is what makes
+# it safe to put on rails. `--fxx-window 0,0` expresses exactly that: the window
+# start is snapped DOWN to the 6-hourly cadence grid, giving one cycle at 18Z.
+#
+# Omitting --fxx-window is what went wrong on job 14296762: the default (12,48) is
+# sized for GFS as DRIVING forcing and enumerated a 6-hourly sequence from 12Z 25
+# Apr onward. Not a tool bug -- the wrong window for this use.
+#
+# Ideal would be 18Z f005, valid exactly at our 23Z init; the analysis stager fetches
+# f000 only. The residual is 5 h of soil evolution, and since the top layer is what
+# swings diurnally this is a real but second-order error worth stating in notes.
 #
 # Submit:  sbatch scripts/stage_ashley_drainage_120m.dtn.slurm
 
@@ -52,16 +62,13 @@ echo "=== gate A staging start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ===
 # ---- plan first: list URLs and bytes, download nothing -----------------------
 # A 2026-04 date is ~3 months old and well inside the HRRR archive, but the plan
 # costs seconds and turns a silent 404 storm into a readable failure.
-echo "--- PLAN: HRRR ---"
-"$PY" -B -m brc_tools.nwp.wrf_staging \
-  --case "$CASE" --source hrrr --init-time "2026-04-24 23Z" \
-  --leads 0,1,2,3,4,5,6 --products nat,sfc --interval-seconds 3600 \
-  --output-dir "$OUT" --plan
+# NOTE: --plan is NOT honoured on the --source hrrr path -- it downloads anyway.
+# Verified on job 14296762, whose "PLAN" phase staged 5.6 GB. No HRRR plan call here.
 
 echo "--- PLAN: GFS soil ---"
 "$PY" -B -m brc_tools.nwp.wrf_staging \
-  --case "$CASE" --source gfs_analysis --init-time "2026-04-25 00Z" \
-  --output-dir "$OUT" --plan
+  --case "$CASE" --source gfs_analysis --init-time "2026-04-24 23Z" \
+  --fxx-window 0,0 --output-dir "$OUT" --plan
 
 # ---- stage ------------------------------------------------------------------
 echo "--- STAGE: HRRR nat+sfc f00..f06 from 2026-04-24 23Z ---"
@@ -70,9 +77,10 @@ echo "--- STAGE: HRRR nat+sfc f00..f06 from 2026-04-24 23Z ---"
   --leads 0,1,2,3,4,5,6 --products nat,sfc --interval-seconds 3600 \
   --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
 
-echo "--- STAGE: GFS 0.25 f000 (soil) from 2026-04-25 00Z ---"
+echo "--- STAGE: GFS analysis f000 (soil), most recent cycle at/before init = 18Z 24 Apr ---"
 "$PY" -B -m brc_tools.nwp.wrf_staging \
-  --case "$CASE" --source gfs_analysis --init-time "2026-04-25 00Z" \
+  --case "$CASE" --source gfs_analysis --init-time "2026-04-24 23Z" \
+  --fxx-window 0,0 \
   --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
 
 # ---- report -----------------------------------------------------------------

--- a/scripts/stage_ashley_drainage_120m_sep2025.dtn.slurm
+++ b/scripts/stage_ashley_drainage_120m_sep2025.dtn.slurm
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Gate A staging (RE-STAGE) for ashley_drainage_120m -- HRRR atmosphere + GFS soil.
+#
+# EVENT CHANGED 2026-07-28: 8-9 SEPTEMBER 2025, replacing 24-25 April 2026.
+# April failed proposal 4a's weak-synoptic-flow criterion outright -- HRRR showed
+# 8-14 m/s across the whole Basin before sunset, which is the mechanical-mixing
+# confound that criterion exists to exclude. September is 1-4 m/s outside a single
+# surge, and PC101 (the Dry Fork truth site, INSIDE d03) shows a clean bidirectional
+# slope-flow reversal.
+#
+# WINDOW vs STAGING SPAN -- these are deliberately different:
+#   wrf.exe integrates   20Z 8 Sep -> 05Z 9 Sep   (9 h, run_hours=9)
+#   staging + real.exe   20Z 8 Sep -> 12Z 9 Sep   (16 h, HRRR f00..f16)
+# real.exe builds wrfbdy_d01 across the FULL staged span, so a later restart from
+# the 05Z restart file can run on to 12Z WITHOUT re-running WPS or real.exe. Boundary
+# conditions are the thing that makes an extension legal or not; staging them once,
+# now, is what buys that. The extra 7 lead times cost ~6 GB and nothing else.
+# HRRR runs to f18 on non-synoptic init hours, so f16 from a 20Z cycle exists.
+#
+# TWO STREAMS IS NOT OPTIONAL. Public HRRR GRIB (nat+sfc) carries ZERO
+# soil-temperature messages and soil moisture only at degenerate 0 / 0.01 m layers,
+# so a single-stream metgrid yields num_metgrid_soil_levels=0 and real.exe cannot
+# initialise Noah. Re-verified against this case's own April f00 on 2026-07-27.
+# Soil comes from --source gfs_soil (Herbie/AWS): it takes the most recent cycle AT
+# OR BEFORE init and sets the lead to the gap, so the file is valid AT init --
+# here the 18Z 8 Sep cycle at f002.
+#
+# Submit:  sbatch scripts/stage_ashley_drainage_120m_sep2025.dtn.slurm
+
+#SBATCH --job-name=stage_a120m_sep
+#SBATCH --account=dtn
+#SBATCH --partition=notchpeak-dtn
+#SBATCH --qos=notchpeak-dtn
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --mem=32G
+#SBATCH --time=0-04:00:00
+#SBATCH --output=/scratch/general/vast/%u/stage_a120m_sep_%j.out
+#SBATCH --error=/scratch/general/vast/%u/stage_a120m_sep_%j.out
+
+set -euo pipefail
+
+PY="$HOME/software/pkg/miniforge3/envs/brc-tools-2026/bin/python"
+REPO="$HOME/gits/brc-tools"
+CASE=ashley_drainage_120m
+OUT="/scratch/general/vast/$USER/wrf_inputs"
+INIT="2025-09-08 20:00"
+
+cd "$REPO"
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+# CHPC DTNs can hang on outbound IPv6 (job 13471949 wedged in SYN-SENT to an NCEI
+# IPv6 address); force IPv4 for every download.
+export BRC_TOOLS_HTTP_IPV4_ONLY=1
+export PYTHONPYCACHEPREFIX="/scratch/general/vast/$USER/pycache"
+# Herbie's per-GRIB lock defaults to node-local /tmp, so fanned-out jobs do NOT
+# serialise and one can delete a subset GRIB while another reads it.
+export BRC_TOOLS_LOCK_DIR="/scratch/general/vast/$USER/herbie_locks"
+mkdir -p "$BRC_TOOLS_LOCK_DIR"
+
+echo "=== September re-stage start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
+
+# The April set must go first: same case name, same directory, and a stale HRRR file
+# left beside the new ones would be silently linked into ungrib by link_grib.csh.
+APRIL_KEEP="$OUT/$CASE.april2026"
+if [[ -d "$OUT/$CASE" ]]; then
+  echo "--- moving the April staging aside to $APRIL_KEEP ---"
+  rm -rf "$APRIL_KEEP"
+  mv "$OUT/$CASE" "$APRIL_KEEP"
+fi
+
+# ---- plan first: list URLs and bytes, download nothing -----------------------
+# NOTE: --plan is NOT honoured on the --source hrrr path -- it downloads anyway
+# (verified on job 14296762, whose "PLAN" phase staged 5.6 GB). No HRRR plan call.
+echo "--- PLAN: GFS soil ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_soil --init-time "$INIT" \
+  --output-dir "$OUT" --plan
+
+# ---- stage ------------------------------------------------------------------
+echo "--- STAGE: HRRR nat+sfc f00..f16 from 2025-09-08 20Z (16 h span for restarts) ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source hrrr --init-time "2025-09-08 20Z" \
+  --leads 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 \
+  --products nat,sfc --interval-seconds 3600 \
+  --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+echo "--- STAGE: GFS soil via Herbie/AWS, valid AT init (18Z cycle f002) ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_soil --init-time "$INIT" \
+  --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+# ---- report -----------------------------------------------------------------
+# NOTE: `set -o pipefail` + `| head` makes SIGPIPE fail the job even when staging
+# succeeded -- that is what marked job 14298037 FAILED with exit 32 after both
+# streams had landed correctly. Every reporting pipe below is guarded.
+set +o pipefail
+echo "=== staged set ==="
+ls -lhR "$OUT/$CASE/" | head -80 || true
+n_hrrr=$(ls "$OUT/$CASE"/hrrr/*.grib2 2>/dev/null | wc -l)
+n_soil=$(ls "$OUT/$CASE"/gfs_soil/*.grib2 2>/dev/null | wc -l)
+echo "hrrr files: $n_hrrr (expect 34 = 17 leads x nat+sfc)"
+echo "soil files: $n_soil (expect 1)"
+for f in "$OUT/$CASE"/manifest_*.json "$OUT/$CASE"/contract_*.json; do
+    [[ -f "$f" ]] && { echo "--- $f ---"; "$PY" -m json.tool "$f" | head -40 || true; }
+done
+rm -rf "$OUT/.herbie_cache_$CASE" || true
+echo "=== September re-stage done $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo
+echo "April staging retained at $APRIL_KEEP -- delete once September has passed gate C."
+echo "NEXT: gate C two-stream metgrid over 17 valid times -> 51 met_em (3 domains x 17)."

--- a/scripts/stage_ashley_storm_600m.dtn.slurm
+++ b/scripts/stage_ashley_storm_600m.dtn.slurm
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Gate A staging for ashley_storm_600m -- HRRR atmosphere + GFS soil.
+#
+# EVENT: 11-12 OCTOBER 2025, the nocturnal rotating cell over Ashley Valley. Tracked at
+# ub-wx experiments/20251011-ashley-rotating-cell/. Gate A0 passed on both halves:
+# the surface network shows a W->E outflow surge at 01:20-01:50Z and a small cyclonic
+# vortex signature at KVEL at 02:30-02:40Z, and HRRR carries the storm in EVERY cycle
+# (52-59 dBZ within 55 km of the spotter point; the 02Z/03Z analyses have it too).
+# The 23Z cycle is the confirmed control init: 34.4 dBZ already at f00 rising to 56.6
+# by 02Z, so the downscale refines an ongoing system rather than generating one.
+#
+# WINDOW vs STAGING SPAN -- deliberately different, same reasoning as the sibling:
+#   wrf.exe integrates   23Z 11 Oct -> 04Z 12 Oct   (5 h, run_hours=5)
+#   staging + real.exe   23Z 11 Oct -> 06Z 12 Oct   (7 h, HRRR f00..f07)
+# real.exe builds wrfbdy_d01 across the FULL staged span, so a restart from the 04Z
+# restart file can run on to 06Z WITHOUT re-running WPS or real.exe. The two extra
+# lead times cost ~1.8 GB and nothing else.
+#
+# TWO STREAMS IS NOT OPTIONAL. Public HRRR GRIB (nat+sfc) carries ZERO soil-temperature
+# messages and soil moisture only at degenerate 0 / 0.01 m layers, so a single-stream
+# metgrid yields num_metgrid_soil_levels=0 and real.exe cannot initialise Noah. This is
+# a property of the product, not of the date -- established at the sibling's gate C and
+# re-verified on its September window. Soil comes from --source gfs_soil (Herbie/AWS):
+# it takes the most recent cycle AT OR BEFORE init and sets the lead to the gap, so the
+# file is valid AT init -- here the 18Z 11 Oct cycle at f005, 0 h staleness.
+#
+# LEADS ARE AN EXPLICIT LIST, not a count. The sibling case lost two jobs to
+# `--max-fhours N` meaning f00..f(N-1) in a different tool; --leads here is enumerated
+# precisely so that class of off-by-one cannot recur. f00..f07 = 8 valid times.
+#
+# Expected: 16 HRRR files (8 leads x nat+sfc, ~7.1 GB at the sibling's measured
+# 0.88 GB/lead) + 1 GFS soil file (~0.5 GB).
+#
+# Submit:  sbatch scripts/stage_ashley_storm_600m.dtn.slurm
+
+#SBATCH --job-name=stage_storm600m
+#SBATCH --account=dtn
+#SBATCH --partition=notchpeak-dtn
+#SBATCH --qos=notchpeak-dtn
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --mem=32G
+#SBATCH --time=0-04:00:00
+#SBATCH --output=/scratch/general/vast/%u/stage_storm600m_%j.out
+#SBATCH --error=/scratch/general/vast/%u/stage_storm600m_%j.out
+
+set -euo pipefail
+
+PY="$HOME/software/pkg/miniforge3/envs/brc-tools-2026/bin/python"
+REPO="$HOME/gits/brc-tools"
+CASE=ashley_storm_600m
+OUT="/scratch/general/vast/$USER/wrf_inputs"
+INIT="2025-10-11 23:00"
+
+cd "$REPO"
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+# CHPC DTNs can hang on outbound IPv6 (job 13471949 wedged in SYN-SENT to an NCEI
+# IPv6 address); force IPv4 for every download.
+export BRC_TOOLS_HTTP_IPV4_ONLY=1
+export PYTHONPYCACHEPREFIX="/scratch/general/vast/$USER/pycache"
+# Herbie's per-GRIB lock defaults to node-local /tmp, so fanned-out jobs do NOT
+# serialise and one can delete a subset GRIB while another reads it.
+export BRC_TOOLS_LOCK_DIR="/scratch/general/vast/$USER/herbie_locks"
+mkdir -p "$BRC_TOOLS_LOCK_DIR"
+
+echo "=== storm 600m gate A staging start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
+echo "    case=$CASE init=$INIT leads=f00..f07 products=nat,sfc"
+
+# A pre-existing directory means a previous attempt, and link_grib.csh would silently
+# link any stale GRIB sitting beside the new ones into ungrib. Refuse rather than mix.
+if [[ -d "$OUT/$CASE" ]] && compgen -G "$OUT/$CASE/hrrr/*.grib2" > /dev/null; then
+  echo "ERROR: $OUT/$CASE already holds HRRR GRIB. Move it aside or delete it before" >&2
+  echo "       re-staging -- a stale file beside the new set gets linked silently." >&2
+  exit 2
+fi
+
+# ---- plan first: list URLs and bytes, download nothing -----------------------
+# NOTE: --plan is NOT honoured on the --source hrrr path -- it downloads anyway
+# (verified on job 14296762, whose "PLAN" phase staged 5.6 GB). No HRRR plan call.
+echo "--- PLAN: GFS soil ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_soil --init-time "$INIT" \
+  --output-dir "$OUT" --plan
+
+# ---- stage ------------------------------------------------------------------
+echo "--- STAGE: HRRR nat+sfc f00..f07 from 2025-10-11 23Z (7 h span for restarts) ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source hrrr --init-time "2025-10-11 23Z" \
+  --leads 0,1,2,3,4,5,6,7 \
+  --products nat,sfc --interval-seconds 3600 \
+  --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+echo "--- STAGE: GFS soil via Herbie/AWS, valid AT init (18Z 11 Oct cycle f005) ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_soil --init-time "$INIT" \
+  --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+# ---- report -----------------------------------------------------------------
+# NOTE: `set -o pipefail` + `| head` makes SIGPIPE fail the job even when staging
+# succeeded -- that is what marked job 14298037 FAILED with exit 32 after both
+# streams had landed correctly. Every reporting pipe below is guarded.
+set +o pipefail
+echo "=== staged set ==="
+ls -lhR "$OUT/$CASE/" | head -80 || true
+n_hrrr=$(ls "$OUT/$CASE"/hrrr/*.grib2 2>/dev/null | wc -l)
+n_soil=$(ls "$OUT/$CASE"/gfs_soil/*.grib2 2>/dev/null | wc -l)
+echo "hrrr files: $n_hrrr (expect 16 = 8 leads x nat+sfc)"
+echo "soil files: $n_soil (expect 1)"
+for f in "$OUT/$CASE"/manifest_*.json "$OUT/$CASE"/contract_*.json; do
+    [[ -f "$f" ]] && { echo "--- $f ---"; "$PY" -m json.tool "$f" | head -40 || true; }
+done
+rm -rf "$OUT/.herbie_cache_$CASE" || true
+
+# Gate A does not pass on "the job exited 0". These two counts are the gate.
+[[ "$n_hrrr" -eq 16 ]] || echo "WARN: expected 16 HRRR files, found $n_hrrr -- gate A NOT passed"
+[[ "$n_soil" -eq 1 ]] || echo "WARN: expected 1 soil file, found $n_soil -- gate A NOT passed"
+
+echo "=== storm 600m gate A staging done $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo
+echo "NEXT: gate C two-stream metgrid over 8 valid times -> 16 met_em (2 domains x 8),"
+echo "      num_metgrid_levels 51, num_metgrid_soil_levels 4."

--- a/scripts/wrf_winds.dtn.slurm
+++ b/scripts/wrf_winds.dtn.slurm
@@ -1,0 +1,50 @@
+#!/bin/bash
+# wrf_winds.dtn.slurm -- Render basin-winds-style figures from a WRF run.
+#
+#   sbatch scripts/wrf_winds.dtn.slurm --config <case.toml> [--run-dir <run>] \
+#          [--valid ...|--lead ...] [--domain N] [--w-exag X] [--output-dir <dir>]
+#
+# Every argument is forwarded verbatim to scripts/wrf_winds.py.
+#
+# Why a DTN and not a login node or the owner partition:
+#   * `lawson-group6` is mounted READ-ONLY on the notchpeak login nodes, so curated
+#     figures can only be written to group storage from a compute or DTN node.
+#   * `lawson-np` is a single node, and the usual reason to want these figures is
+#     that a WRF run is occupying it -- a figure job queued behind that run would
+#     wait for the very thing it is meant to monitor.
+#   * The work is I/O-heavy and CPU-light (read one wrfout time, draw a dozen
+#     panels), which is exactly what a DTN is for. No internet needed: the
+#     Natural-Earth overlays come from the staged cache (fetch_basemap.dtn.slurm).
+
+#SBATCH --job-name=wrf_winds
+#SBATCH --account=dtn
+#SBATCH --partition=notchpeak-dtn
+#SBATCH --qos=notchpeak-dtn
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=0-03:00:00
+#SBATCH --output=/scratch/general/vast/%u/wrf_winds_%j.out
+#SBATCH --error=/scratch/general/vast/%u/wrf_winds_%j.err
+
+set -euo pipefail
+
+# The login env does NOT carry into batch jobs; call the conda env's python directly.
+PY=~/software/pkg/miniforge3/envs/brc-tools-2026/bin/python
+REPO="${BRC_TOOLS_ROOT:-$HOME/gits/brc-tools}"
+SCRATCH="/scratch/general/vast/$USER/ub-wx"
+
+# Writable caches on scratch; nothing generated lands in a checkout.
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+export MPLCONFIGDIR="$SCRATCH/mpl"
+export PYTHONPYCACHEPREFIX="$SCRATCH/pycache"
+export BRC_TOOLS_BASEMAP_DIR="${BRC_TOOLS_BASEMAP_DIR:-/uufs/chpc.utah.edu/common/home/lawson-group6/jrlawson/brc-tools-data/cartopy}"
+mkdir -p "$MPLCONFIGDIR" "$PYTHONPYCACHEPREFIX"
+
+echo "Python:  $PY"
+echo "Engine:  $REPO/scripts/wrf_winds.py"
+echo "Args:    $*"
+# -u: unbuffered. A multi-hour sweep whose progress only appears when the job ends
+# is indistinguishable from a hung one.
+exec "$PY" -u -B "$REPO/scripts/wrf_winds.py" "$@"

--- a/scripts/wrf_winds.py
+++ b/scripts/wrf_winds.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python
+"""Render basin-winds-style plan views and cross-sections from a WRF run.
+
+The WRF counterpart of the ``basin-winds`` HRRR case: for each nest, a plan-view
+surface map (10 m wind + barbs + terrain + towns) plus terrain-filled wind
+curtains along named A->B transects, each with the geographic locator inset.
+Same renderers as the HRRR path -- ``brc_tools.visualize.nwp_maps`` -- fed by the
+``wrfout`` adapter in :mod:`brc_tools.nwp.wrf_section`, so sections keep the
+model's native eta levels instead of being flattened onto isobaric surfaces.
+
+Everything case-specific lives in a TOML (run directory, per-domain extents and
+waypoint groups, transect endpoints, colour-scale overrides); this file is the
+engine.  Schema: ``docs/WRF-WINDS.md``.
+
+    python scripts/wrf_winds.py --config <case.toml> [--valid ...|--lead ...]
+
+Times: ``--valid YYYY-MM-DD_HH:MM`` picks one exactly, ``--lead <minutes>`` picks
+init+N, and the default renders the latest time available on *every* requested
+domain -- the useful default while a run is still writing, since a coarse nest on
+hourly output lags a fine nest on 5-minute output.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tomllib
+import traceback
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np  # noqa: E402
+
+from brc_tools.nwp import wrf_output as wo  # noqa: E402
+from brc_tools.nwp import wrf_section as ws  # noqa: E402
+from brc_tools.visualize import coldpool3d as cp3  # noqa: E402
+from brc_tools.visualize.nwp_maps import plot_nwp_surface_map  # noqa: E402
+from brc_tools.visualize.style import VarStyle, get_style, use_publication_style  # noqa: E402
+from brc_tools.visualize.wrf_curtain import plot_wrf_curtain  # noqa: E402
+
+DEFAULT_OUTPUT_ROOT = Path(os.environ.get(
+    "BRC_TOOLS_OUTPUT_DIR",
+    "/uufs/chpc.utah.edu/common/home/lawson-group6/jrlawson/brc-tools-output"))
+
+_MAP_LAYERS = ("states", "counties", "roads", "rivers", "lakes")
+_TIME_FMT = "%Y-%m-%d_%H:%M"
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+def load_config(path: Path) -> dict:
+    with open(path, "rb") as f:
+        cfg = tomllib.load(f)
+    case = cfg["case"]
+    case["run_dir"] = Path(os.path.expandvars(case["run_dir"])).expanduser()
+    cfg["_sections"] = {s["key"]: s for s in cfg.get("sections", [])}
+    cfg["_views3d"] = {v["key"]: v for v in cfg.get("views3d", [])}
+    return cfg
+
+
+def waypoints(group: str | None) -> dict:
+    """Title-cased ``{name: {lat, lon}}`` for a ``lookups.toml`` waypoint group."""
+    if not group:
+        return {}
+    from brc_tools.nwp.source import load_lookups
+
+    lu = load_lookups()
+    return {n.replace("_", " ").title(): lu["waypoints"][n]
+            for n in lu["waypoint_groups"][group]}
+
+
+def style_for(cfg: dict, var: str):
+    """Resolve a variable's :class:`VarStyle`, applying the case's overrides.
+
+    A case whose season or regime does not match the package default (the 2 m
+    theta scale is set for winter cold pools, for instance) retunes it here
+    rather than in the shared style table.
+    """
+    base = get_style(var)
+    over = cfg.get("style", {}).get("overrides", {}).get(var)
+    if not over:
+        return base
+    return VarStyle(
+        cmap=over.get("cmap", base.cmap),
+        label=over.get("label", base.label),
+        vmin=float(over.get("vmin", base.vmin)),
+        vmax=float(over.get("vmax", base.vmax)),
+        extend=over.get("extend", base.extend),
+        diverging=bool(over.get("diverging", base.diverging)),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# time selection
+# --------------------------------------------------------------------------- #
+def select_times(run_dir: Path, domains: list[int], args) -> list[datetime]:
+    """Resolve which valid time(s) to render.
+
+    ``--hourly``/``--every``/``--all`` sweep whatever the run has written so far,
+    which is the normal way to use this against a job still integrating; the
+    single-time forms (``--valid``/``--lead``, or the default latest-common)
+    render one.
+
+    A sweep takes the **union** across domains, not the intersection: a 3 km parent
+    on hourly output and a 600 m nest on 5-minute output share only whole hours, so
+    intersecting would silently throw away every sub-hourly frame the fine nest has.
+    Each domain then renders only the times it actually holds.
+    """
+    per_domain = {d: set(ws.list_valid_times(run_dir, d)) for d in domains}
+    for d, ts in per_domain.items():
+        if not ts:
+            raise SystemExit(f"no wrfout_d{d:02d}_* under {run_dir}")
+    common = set.intersection(*per_domain.values())
+
+    cadence = 60 if args.hourly else args.every
+    if cadence or args.all_times:
+        union = set().union(*per_domain.values())
+        want = sorted(t for t in union
+                      if args.all_times or (t.second == 0 and t.minute % cadence == 0))
+        if not want:
+            raise SystemExit(f"no valid time matches a {cadence}-minute cadence")
+        print(f"[time] {len(want)} time(s) at "
+              f"{'native' if args.all_times else f'{cadence}-min'} cadence: "
+              f"{want[0]:{_TIME_FMT}} .. {want[-1]:{_TIME_FMT}}")
+        return want
+
+    if args.valid:
+        one = datetime.strptime(args.valid, _TIME_FMT)
+    elif args.lead is not None:
+        one = ws.init_time(run_dir, min(domains)) + timedelta(minutes=args.lead)
+    else:
+        if not common:
+            raise SystemExit(_no_common(per_domain))
+        one = max(common)
+        print(f"[time] latest common valid time -> {one:{_TIME_FMT}}")
+
+    for d, ts in per_domain.items():
+        if one not in ts:
+            print(f"[SKIP] d{d:02d} has no {one:{_TIME_FMT}} "
+                  f"(latest {max(ts):{_TIME_FMT}}) -- domain dropped")
+    return [one]
+
+
+def _no_common(per_domain: dict) -> str:
+    return ("no valid time is present on every requested domain: "
+            + ", ".join(f"d{d:02d}={len(t)} times" for d, t in per_domain.items()))
+
+
+# --------------------------------------------------------------------------- #
+# rendering
+# --------------------------------------------------------------------------- #
+def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
+                  out_root: Path, args) -> int:
+    run_dir = cfg["case"]["run_dir"]
+    d = int(dom["domain"])
+    path = ws.wrfout_path(run_dir, d, valid)
+    if not path.exists():
+        return 0
+    ds = wo.open_wrfout(path)
+    try:
+        lead_min = (valid - init).total_seconds() / 60.0
+        dx_km = float(ds.attrs["DX"]) / 1000.0
+        # A nest may appear more than once (e.g. full extent plus a zoom), so the
+        # view's own tag -- not the domain number -- names the output.
+        tag = str(dom.get("tag") or f"d{d:02d}")
+        stamp = f"{valid:%Y%m%d_%H%M}"
+        base = (f"{cfg['case']['label']} | {tag} {dx_km:g} km | "
+                f"valid {valid:%Y-%m-%d %H:%MZ} (+{lead_min:.0f} min)")
+        # The section renderer parks its quiver key at the top right, so a section
+        # title has to stay short; the case label and date live in the annotation
+        # instead.  Plan views have no key and keep the full string.
+        sec_base = f"{tag} {dx_km:g} km | {valid:%H:%MZ} +{lead_min:.0f} min"
+        an = " | ".join(x for x in (cfg["case"].get("annotation", ""),
+                                    f"{valid:%Y-%m-%d}", f"init {init:%H:%MZ}") if x)
+        overlays = {k: bool(cfg.get("map", {}).get(k, False)) for k in _MAP_LAYERS}
+        out_dir = out_root / stamp / tag
+        made = 0
+
+        # -- plan views -----------------------------------------------------
+        pad = float(dom.get("pad_deg", 0.0))
+        extent = tuple(dom["extent"]) if dom.get("extent") else ws.plan_extent(ds, pad_deg=pad)
+        pds = ws.plan_dataset(ds)
+        map_wps = waypoints(dom.get("waypoint_group"))
+        for var in dom.get("surface_vars", ["wind_speed_10m"]):
+            if var not in pds:
+                print(f"[SKIP] {tag} {var}: not written by this run")
+                continue
+            st = style_for(cfg, var)
+            try:
+                plot_nwp_surface_map(
+                    pds, var, out_dir / f"topdown_{var}_{tag}_{stamp}.png",
+                    style=st, waypoints=map_wps,
+                    barb_stride=int(dom.get("barb_stride", 6)),
+                    extent=extent, overlays=overlays, annotation=an,
+                    title=f"{base} | {st.label}", dpi=args.dpi)
+                made += 1
+            except Exception as exc:  # keep going: one bad panel is not a lost run
+                print(f"[ERR] topdown {tag} {var}: {exc}")
+                traceback.print_exc()
+
+        # -- cross-sections + 3-D cold-pool views ----------------------------
+        keys = dom.get("sections", [])
+        v3d = dom.get("views3d", [])
+        if keys or v3d:
+            plane = ws.load_plane(ds)   # the expensive read; shared by both families
+            loc = dict(lon2d=plane.lon2d, lat2d=plane.lat2d, terrain2d=plane.terrain)
+            for key in keys:
+                s = cfg["_sections"].get(key)
+                if s is None:
+                    print(f"[SKIP] {tag} section {key!r}: not in [[sections]]")
+                    continue
+                sec_wps = waypoints(s.get("waypoint_group"))
+                try:
+                    sec = ws.section_from_plane(
+                        plane, tuple(s["a"]), tuple(s["b"]),
+                        n_points=int(s.get("n_points", 240)),
+                        termini=tuple(s.get("termini", ("A", "B"))))
+                    plot_wrf_curtain(
+                        sec, out_dir / f"xsection_{key}_{tag}_{stamp}.png",
+                        shade=s.get("shade", "speed"),
+                        style=style_for(cfg, "wind_speed_10m"),
+                        title=f"{sec_base} | {s.get('label', key)}",
+                        annotation=an, waypoints=sec_wps,
+                        waypoint_offset_km=float(s.get("offset_km", 15.0)),
+                        y_top_m=float(s.get("y_top_m", 3000.0)),
+                        w_exaggeration=(args.w_exag if args.w_exag is not None
+                                        else float(s.get("w_exag", 10.0))),
+                        theta_interval=float(s.get("theta_interval", 1.0)),
+                        quiver_stride=tuple(s.get("quiver_stride", (4, 10))),
+                        locator={**loc,
+                                 "extent": tuple(s["loc_extent"]) if s.get("loc_extent") else None,
+                                 "rect": list(s["loc_rect"]) if s.get("loc_rect") else None,
+                                 "waypoints": sec_wps},
+                        dpi=args.dpi)
+                    made += 1
+                except Exception as exc:
+                    print(f"[ERR] xsection {tag} {key}: {exc}")
+                    traceback.print_exc()
+            made += render_views3d(cfg, v3d, plane, tag, stamp, sec_base, an,
+                                   out_dir, args)
+        print(f"  {tag}: {made} figures -> {out_dir}")
+        return made
+    finally:
+        ds.close()
+
+
+def render_views3d(cfg, keys, plane, tag, stamp, sec_base, an, out_dir, args) -> int:
+    """Render the ``[[views3d]]`` cold-pool panels for one domain and time."""
+    made = 0
+    for key in keys:
+        v = cfg["_views3d"].get(key)
+        if v is None:
+            print(f"[SKIP] {tag} view3d {key!r}: not in [[views3d]]")
+            continue
+        try:
+            rows, cols = cp3.extent_window(plane.lon2d, plane.lat2d, tuple(v["extent"]))
+        except Exception as exc:
+            print(f"[ERR] view3d {tag} {key}: {exc}")
+            continue
+        lon, lat = plane.lon2d[rows, cols], plane.lat2d[rows, cols]
+        terr = plane.terrain[rows, cols]
+        theta, height = plane.theta[:, rows, cols], plane.height[:, rows, cols]
+        for iso in (args.theta_iso or v.get("theta_iso", [310.0])):
+            try:
+                lid = cp3.isentrope_lid(theta, height, terr, float(iso),
+                                        max_depth_m=float(v.get("max_depth_m", 1500.0)))
+                cp3.plot_coldpool_3d(
+                    lon, lat, terr, lid,
+                    out_dir / f"coldpool3d_{key}_th{float(iso):g}_{tag}_{stamp}.png",
+                    theta_iso=float(iso),
+                    title=(f"{sec_base} | {v.get('label', key)} | "
+                           rf"cold air below $\theta$ = {float(iso):g} K"),
+                    annotation=an,
+                    stride=int(v.get("stride", 2)),
+                    elev=float(v.get("elev", 22.0)),
+                    azim=float(v.get("azim", -90.0)),
+                    z_frac=float(v.get("z_frac", 0.45)),
+                    depth_min_m=float(v.get("depth_min_m", 25.0)),
+                    depth_max_m=float(v.get("depth_max_m", 600.0)),
+                    dpi=args.dpi)
+                made += 1
+            except Exception as exc:
+                print(f"[ERR] view3d {tag} {key} theta={iso}: {exc}")
+                traceback.print_exc()
+    return made
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--config", required=True, type=Path, help="case TOML")
+    ap.add_argument("--run-dir", type=Path, help="override the TOML run directory")
+    ap.add_argument("--valid", help=f"exact valid time, {_TIME_FMT.replace('%', '%%')}")
+    ap.add_argument("--lead", type=int, help="minutes after init")
+    ap.add_argument("--hourly", action="store_true",
+                    help="sweep every whole-hour valid time written so far "
+                         "(shorthand for --every 60)")
+    ap.add_argument("--every", type=int, metavar="MIN",
+                    help="sweep every valid time on a MIN-minute cadence (e.g. 15). "
+                         "A domain that lacks a given time is skipped for it")
+    ap.add_argument("--all", dest="all_times", action="store_true",
+                    help="sweep every valid time at the run's native output "
+                         "interval (a 5-minute nest makes this a lot of figures)")
+    ap.add_argument("--theta-iso", type=float, action="append", metavar="K",
+                    help="override the [[views3d]] isentrope(s) for the 3-D "
+                         "cold-pool panels (repeatable)")
+    ap.add_argument("--domain", type=int, action="append",
+                    help="restrict to this nest (repeatable); default = all in the TOML")
+    ap.add_argument("--output-dir", type=Path, help="override the output root")
+    ap.add_argument("--w-exag", type=float,
+                    help="override every section's vertical exaggeration. The right "
+                         "value is regime-dependent: a convective afternoon resolves "
+                         "w ~ 1 m/s and wants ~10, a quiescent drainage night ~100.")
+    ap.add_argument("--dpi", type=int, default=200)
+    args = ap.parse_args()
+
+    cfg = load_config(args.config)
+    if args.run_dir:
+        cfg["case"]["run_dir"] = args.run_dir
+    run_dir = cfg["case"]["run_dir"]
+    if not run_dir.is_dir():
+        raise SystemExit(f"run directory not found: {run_dir}")
+
+    doms = [d for d in cfg.get("domains", [])
+            if not args.domain or int(d["domain"]) in args.domain]
+    if not doms:
+        raise SystemExit("no domains selected")
+    numbers = [int(d["domain"]) for d in doms]
+
+    use_publication_style(dpi=args.dpi)
+    times = select_times(run_dir, numbers, args)
+    init = ws.init_time(run_dir, min(numbers))
+    out_root = (args.output_dir or Path(os.path.expandvars(cfg["case"]["output_dir"]))
+                if (args.output_dir or cfg["case"].get("output_dir"))
+                else DEFAULT_OUTPUT_ROOT / cfg["case"]["slug"])
+
+    print(f"[run ] {run_dir}")
+    print(f"[init] {init:{_TIME_FMT}}")
+    total, absent = 0, 0
+    for valid in times:
+        print(f"[valid] {valid:{_TIME_FMT}} "
+              f"(+{(valid - init).total_seconds() / 60:.0f} min)")
+        for dom in doms:
+            # On a sweep, a coarse nest simply has no file at a sub-hourly time.
+            # That is expected, not an error, and printing it per view would bury
+            # the log -- so count it and report the total once at the end.
+            if not ws.wrfout_path(run_dir, int(dom["domain"]), valid).exists():
+                absent += 1
+                continue
+            # One bad time (a wrfout caught half-written by the running job, say)
+            # must not take the rest of the sweep down with it.
+            try:
+                total += render_domain(cfg, dom, valid, init, out_root, args)
+            except Exception as exc:
+                print(f"[ERR] {dom.get('tag', dom['domain'])} {valid:{_TIME_FMT}}: {exc}")
+                traceback.print_exc()
+    print(f"\nDone. {total} figures over {len(times)} time(s) -> {out_root}")
+    if absent:
+        print(f"({absent} view-times skipped: no wrfout at that domain/time)")
+    return 0 if total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gfs_soil_candidates.py
+++ b/tests/test_gfs_soil_candidates.py
@@ -1,0 +1,94 @@
+"""stage_gfs_soil candidate ranking: never reach forward, degrade gracefully.
+
+The soil stream is a single file, so its selection rule carries real weight: it
+decides the initial soil state of the whole run. Two properties must hold no matter
+what is missing from the archive.
+
+1. **Never reach past the WRF init.** An initial condition taken from a later
+   analysis is not something the model could have had; it is a hindcast artefact.
+2. **Degrade monotonically.** When the ideal file is missing, the next choice must
+   be no worse, and the ordering must not zig-zag between "newest cycle" and
+   "closest valid time" -- those two are not the same preference, and an early
+   version of this ranking mixed them.
+
+Ranking is by staleness (|valid - init|) first, then by shortest lead. Valid time
+beats cycle recency for soil specifically: GFS barely assimilates soil, so a longer
+forecast lead costs little, whereas being hours off catches the top layer partway
+through its diurnal swing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from brc_tools.nwp.wrf_staging import (
+    GFS_CADENCE_HOURS,
+    _parse_init_time,
+    _snap_down_to_cadence,
+)
+
+
+def ranked(init: str, max_back: int = 4) -> list[tuple[int, int, dt.datetime, int]]:
+    """Mirror of the ordering inside stage_gfs_soil: (staleness, lead, cycle, lead)."""
+    init_dt = _parse_init_time(init)
+    cycle0 = _snap_down_to_cadence(init_dt, GFS_CADENCE_HOURS)
+    out: list[tuple[int, int, dt.datetime, int]] = []
+    for back in range(max_back + 1):
+        c = cycle0 - dt.timedelta(hours=GFS_CADENCE_HOURS * back)
+        lead_at_init = int((init_dt - c).total_seconds() // 3600)
+        for ld in ({lead_at_init, 0} if lead_at_init else {0}):
+            stale = int((init_dt - (c + dt.timedelta(hours=ld))).total_seconds() // 3600)
+            out.append((stale, ld, c, ld))
+    out.sort(key=lambda x: (x[0], x[1]))
+    return out
+
+
+OFF_CYCLE = "2026-04-24 23:00"   # the Ashley 120 m init: 5 h past the 18Z cycle
+ON_CYCLE = "2026-04-24 18:00"    # exactly on a GFS cycle
+
+
+def test_first_choice_is_valid_at_init():
+    stale, lead, cycle, _ = ranked(OFF_CYCLE)[0]
+    assert stale == 0
+    assert cycle.hour == 18 and lead == 5
+    assert cycle + dt.timedelta(hours=lead) == dt.datetime(2026, 4, 24, 23)
+
+
+def test_never_reaches_past_init():
+    init_dt = _parse_init_time(OFF_CYCLE)
+    for _, _, cycle, lead in ranked(OFF_CYCLE):
+        assert cycle <= init_dt
+        assert cycle + dt.timedelta(hours=lead) <= init_dt
+
+
+def test_degrades_monotonically_in_staleness():
+    stale = [x[0] for x in ranked(OFF_CYCLE)]
+    assert stale == sorted(stale), stale
+    assert stale[0] == 0
+
+
+def test_prefers_shortest_lead_at_equal_staleness():
+    leads = [x[1] for x in ranked(OFF_CYCLE) if x[0] == 0]
+    assert leads == sorted(leads)
+    assert leads[0] == 5  # 18Z f005 before 12Z f011
+
+
+def test_on_cycle_init_needs_no_lead():
+    stale, lead, cycle, _ = ranked(ON_CYCLE)[0]
+    assert (stale, lead) == (0, 0) and cycle.hour == 18
+
+
+def test_fallbacks_exist_when_everything_recent_is_missing():
+    """A single missing object must not be able to fail the gate."""
+    r = ranked(OFF_CYCLE, max_back=4)
+    assert len(r) >= 8
+    assert len({(c, ld) for _, _, c, ld in r}) == len(r)  # no duplicate probes
+
+
+@pytest.mark.parametrize("init", [OFF_CYCLE, ON_CYCLE, "2026-04-25 03:00"])
+def test_every_candidate_is_on_the_cadence_grid(init):
+    for _, _, cycle, _ in ranked(init):
+        assert cycle.hour % GFS_CADENCE_HOURS == 0
+        assert (cycle.minute, cycle.second) == (0, 0)


### PR DESCRIPTION
Lands the WRF-input staging work for the two Ashley cases plus the TOML-driven
`wrf_winds` figure engine that the convective-products work builds on.

## What's here

**Staging** (`brc_tools/nwp/wrf_staging.py`, `scripts/stage_*.dtn.slurm`)
- `gfs_soil` source via Herbie/AWS, valid *at* init, with graceful fallback
- soil merged into the case manifest preserving `fg_name` ORDER
- gate-A staging for `ashley_drainage_120m` (Sept 2025 re-stage, HRRR f00..f16 for a
  restart-capable `wrfbdy`) and for `ashley_storm_600m` (HRRR f00..f07 + GFS soil)

**Figure capability**
- `brc_tools/nwp/wrf_section.py` — wrfout adapter for plan views and arbitrary A→B
  transects on native eta levels. Reads **both** filename conventions, including
  `nocolons = .true.`, which `wrf_output.py` does not.
- `brc_tools/visualize/wrf_curtain.py` — native-grid terrain-filled curtain
- `brc_tools/visualize/coldpool3d.py` — 3-D isentrope cold-pool view
- `scripts/wrf_winds.py` + `scripts/wrf_winds.dtn.slurm` — TOML-driven engine that
  can sweep a run while it is still writing
- `docs/WRF-WINDS.md` (schema) and the `/wrf-basin-winds` skill

## Test gap, stated plainly

`wrf_section.py`, `wrf_curtain.py` and `coldpool3d.py` ship without tests here.
`tests/test_gfs_soil_candidates.py` covers the staging side only. The
`jrl/convective-products` branch depends on all three and adds coverage for the
parts it exercises; that is the natural place for it, since it needs the synthetic
reflectivity fixtures anyway.

## Verification

`pytest tests/` green in `brc-tools-2026`, and the staging path is validated
end-to-end on CHPC: `ashley_storm_600m` gate A passed (job 14348361, dtn05,
3 m 33 s, 7.84 GB), and the resulting run completed 5 h with zero CFL and zero NaN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZcsFNUN2u67hwzazHeDxw
