### PR TITLE
fix(nwp,radar): stop the three figures that lied, and test the tables

### DIFF
--- a/brc_tools/nwp/section.py
+++ b/brc_tools/nwp/section.py
@@ -56,6 +56,10 @@ class NWPSection:
     # grid with flat shading instead of resampling onto a regular height axis.
     # Isobaric sources (the HRRR path) have no such edges and leave this None.
     height_w2d: np.ndarray | None = None
+    # (n,) True where the sample fell off the source grid and its data columns
+    # were blanked rather than filled from the nearest edge column.  None when
+    # the sampler did not check.  See wrf_section.section_from_plane.
+    offgrid1d: np.ndarray | None = None
 
 
 def _lon180(lon) -> np.ndarray:

--- a/brc_tools/nwp/wrf_convective.py
+++ b/brc_tools/nwp/wrf_convective.py
@@ -38,6 +38,57 @@ RESET_ON_HISTORY: frozenset[str] = frozenset({
     "HAILCAST_DIAM_MAX", "TCOLI_MAX", "AFWA_TORNADO", "REFD_COM_MAX",
 })
 
+#: History-stream 2-D fields the convective engines can plot, mapped to their
+#: style key.  Anything here is read from ``wrfout``; the auxiliary stream is
+#: handled separately because its maximum fields reset on the history write
+#: (:data:`RESET_ON_HISTORY`).
+#:
+#: ``REFD_COM`` and ``REFD_MAX`` deliberately do **not** share a key.  They are
+#: different physical quantities -- the column maximum *at the output instant*
+#: versus the maximum *over the interval since the last history write* -- and a
+#: swath of the second is not a snapshot of the first.  Mapping both to
+#: ``refl_comp`` meant a run writing both silently plotted only one, under a
+#: label that named the wrong surface.
+SURFACE_FIELDS: dict[str, str] = {
+    "REFD_COM": "refl_comp",
+    "REFD_MAX": "refl_comp_max",
+    "ECHOTOP": "echo_top",
+    "WSPD10MAX": "wspd10max",
+    "UP_HELI_MAX": "uphel_2to5km",
+    "HAIL_MAX2D": "hail_max",
+    "AFWA_LLWS": "llws",
+    "AFWA_CAPE": "cape_ml",
+    "AFWA_CIN": "cin_ml",
+    "TORNADO_MASK": "tornado_mask",
+}
+
+#: Values at or below these floors are masked to NaN before plotting.
+#:
+#: Without this, a reflectivity panel paints the whole domain in the low end of
+#: the colour map and clear air reads as data -- on a 213 x 171 km footprint
+#: holding one storm, that is most of the figure.  Operational radar products
+#: mask below ~5 dBZ for the same reason.  Echo top is 0 where there is no echo
+#: at all, not 0 km.
+MASK_AT_OR_BELOW: dict[str, float] = {
+    "refl_comp": 5.0,
+    "refl_comp_max": 5.0,
+    "refl_beam": 5.0,
+    "refl": 5.0,
+    "echo_top": 0.0,
+    "hail_max": 0.0,
+    "tornado_mask": 0.0,
+}
+
+
+def masked(key: str, field):
+    """Apply the presentation floor for style ``key``, if it has one."""
+    array = np.asarray(field, dtype=float)
+    floor = MASK_AT_OR_BELOW.get(key)
+    if floor is None:
+        return array
+    return np.where(array <= floor, np.nan, array)
+
+
 _EARTH_R = 6_371_000.0
 
 

--- a/brc_tools/nwp/wrf_engine.py
+++ b/brc_tools/nwp/wrf_engine.py
@@ -228,6 +228,34 @@ def select_times(
     return [one]
 
 
+def check_section_on_grid(plane, key: str, spec: dict, *, tag: str) -> bool:
+    """Preflight an ``[[sections]]`` A->B transect against the nest it will cut.
+
+    Returns ``False`` when the line misses the grid entirely, so the caller can
+    skip it: a transect with no on-grid samples is a blank figure that costs an
+    expensive read and tells a reader nothing.  A *partial* overlap warns and
+    proceeds -- the on-grid part is real data, and
+    :func:`~brc_tools.nwp.wrf_section.section_from_plane` blanks the rest rather
+    than extruding the boundary column across it.
+
+    Shared by both engines so the warning reads the same wherever it appears.
+    ``WRF-WINDS.md`` used to warn about off-grid transects in prose only; this is
+    that warning, made to actually fire.
+    """
+    cov = ws.section_coverage(
+        plane, tuple(spec["a"]), tuple(spec["b"]),
+        n_points=int(spec.get("n_points", 240)),
+    )
+    if cov.fully_inside:
+        return True
+    if cov.n_inside == 0:
+        print(f"[SKIP] {tag} section {key!r}: {cov.describe()}")
+        return False
+    print(f"[WARN] {tag} section {key!r}: {cov.describe()} -- the off-grid part "
+          "is blanked, not filled from the edge column")
+    return True
+
+
 def output_root(cfg: dict, override: str | Path | None = None, *, config_path=None) -> Path:
     """Where figures go: CLI override, then the TOML, then group storage.
 

--- a/brc_tools/nwp/wrf_section.py
+++ b/brc_tools/nwp/wrf_section.py
@@ -40,11 +40,20 @@ from brc_tools.nwp import wrf_output as wo
 from brc_tools.nwp.section import NWPSection
 
 __all__ = ["WRFPlane", "load_plane", "plan_dataset", "plan_extent",
-           "section_from_plane", "extract_wrf_section",
+           "section_from_plane", "extract_wrf_section", "section_coverage",
+           "SectionCoverage", "grid_spacing_km",
            "list_valid_times", "wrfout_path", "init_time"]
 
 _KM_PER_DEG_LAT = 110.574
 _KM_PER_DEG_LON = 111.320
+
+#: How far off the grid a sample may fall before it is treated as outside, in
+#: units of the grid spacing.  A point genuinely inside the mesh is at most
+#: ``sqrt(2)/2 ~= 0.71`` cells from a column centre, so one whole cell leaves
+#: room for grid curvature while still catching a transect that has left the
+#: nest -- which is the case that matters, because nearest-neighbour sampling
+#: has no upper bound and will happily return the boundary column forever.
+_OFFGRID_TOLERANCE_CELLS = 1.0
 
 # WRF writes history filenames as `%Y-%m-%d_%H:%M:%S`, unless the run set
 # `nocolons = .true.` (common on filesystems and tooling that dislike colons), in
@@ -220,6 +229,129 @@ def _sample_line(start, end, n):
     return lon_line, lat_line, np.hypot(dx, dy)
 
 
+def grid_spacing_km(lat2d, lon2d) -> float:
+    """Median distance between adjacent grid columns, in km.
+
+    Used to decide what "off the grid" means for a transect sample.  Taken as a
+    median over both axes rather than from a namelist ``dx``, so it is right for
+    any nest without being told which one it is looking at.
+    """
+    lat2d = np.asarray(lat2d, dtype=float)
+    lon2d = np.asarray(lon2d, dtype=float)
+    coslat = float(np.cos(np.deg2rad(np.mean(lat2d))))
+    x = lon2d * _KM_PER_DEG_LON * coslat
+    y = lat2d * _KM_PER_DEG_LAT
+    steps = []
+    if x.shape[1] > 1:
+        steps.append(np.hypot(np.diff(x, axis=1), np.diff(y, axis=1)).ravel())
+    if x.shape[0] > 1:
+        steps.append(np.hypot(np.diff(x, axis=0), np.diff(y, axis=0)).ravel())
+    if not steps:
+        raise ValueError("grid must have at least two columns in one direction")
+    return float(np.median(np.concatenate(steps)))
+
+
+@dataclass
+class SectionCoverage:
+    """How much of an A->B transect actually lies on the model grid.
+
+    Cheap enough to run as a preflight before the expensive 3-D read, which is
+    the point: a transect that has wandered off the nest should be reported
+    before a sweep spends an hour rendering it.
+    """
+
+    n_points: int
+    n_inside: int
+    grid_spacing_km: float
+    tolerance_km: float  # a sample further than this from a column is "outside"
+    worst_gap_km: float  # largest nearest-column distance anywhere on the line
+    first_outside_km: float | None  # distance from A where it first leaves, or None
+
+    @property
+    def inside_fraction(self) -> float:
+        return self.n_inside / self.n_points if self.n_points else 0.0
+
+    @property
+    def fully_inside(self) -> bool:
+        return self.n_inside == self.n_points
+
+    def describe(self) -> str:
+        """One line naming the problem, for an engine's log."""
+        if self.fully_inside:
+            return f"on-grid ({self.n_points} samples, {self.grid_spacing_km:.2f} km grid)"
+        pct = 100.0 * self.inside_fraction
+        where = ("from the start" if self.first_outside_km is None
+                 else f"from {self.first_outside_km:.1f} km along")
+        return (
+            f"leaves the grid {where}: only {self.n_inside}/{self.n_points} "
+            f"samples ({pct:.0f}%) are on it, worst gap {self.worst_gap_km:.1f} km "
+            f"against a {self.grid_spacing_km:.2f} km grid"
+        )
+
+
+def _nearest_columns(lat2d, lon2d, lat_line, lon_line):
+    """Nearest grid column per sample: ``(jj, ii, distance_km)``.
+
+    The KD-tree is built in kilometres (longitudes scaled by cos(lat)), so the
+    distances it returns are already the quantity we want to threshold on.
+    """
+    from scipy.spatial import cKDTree
+
+    coslat = float(np.cos(np.deg2rad(np.mean(lat2d))))
+    tree = cKDTree(np.column_stack([
+        np.asarray(lat2d, dtype=float).ravel() * _KM_PER_DEG_LAT,
+        np.asarray(lon2d, dtype=float).ravel() * _KM_PER_DEG_LON * coslat,
+    ]))
+    dist_km, flat = tree.query(np.column_stack([
+        lat_line * _KM_PER_DEG_LAT, lon_line * _KM_PER_DEG_LON * coslat]))
+    jj, ii = np.unravel_index(flat, np.shape(lat2d))
+    return jj, ii, dist_km
+
+
+def section_coverage(
+    plane_or_lat2d,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    *,
+    lon2d=None,
+    n_points: int = 240,
+    max_gap_km: float | None = None,
+) -> SectionCoverage:
+    """Whether an A->B transect lies on the grid, without reading the 3-D state.
+
+    Accepts either a :class:`WRFPlane` or a bare ``lat2d`` plus ``lon2d``, so an
+    engine can preflight a transect against a single opened ``wrfout`` before
+    committing to :func:`load_plane`.
+    """
+    if isinstance(plane_or_lat2d, WRFPlane):
+        lat2d, lon2d = plane_or_lat2d.lat2d, plane_or_lat2d.lon2d
+    else:
+        lat2d = plane_or_lat2d
+        if lon2d is None:
+            raise TypeError("pass a WRFPlane, or both lat2d and lon2d")
+
+    lon_line, lat_line, dist_along = _sample_line(start, end, n_points)
+    _, _, gap_km = _nearest_columns(lat2d, lon2d, lat_line, lon_line)
+
+    spacing = grid_spacing_km(lat2d, lon2d)
+    tol = float(max_gap_km) if max_gap_km is not None else _OFFGRID_TOLERANCE_CELLS * spacing
+    outside = gap_km > tol
+    first = None
+    if outside.any():
+        first_idx = int(np.argmax(outside))
+        # None means "outside from terminus A onward", which reads better in a log
+        # than "first leaves at 0.0 km".
+        first = float(dist_along[first_idx]) if first_idx > 0 else None
+    return SectionCoverage(
+        n_points=int(n_points),
+        n_inside=int((~outside).sum()),
+        grid_spacing_km=spacing,
+        tolerance_km=tol,
+        worst_gap_km=float(np.max(gap_km)),
+        first_outside_km=first,
+    )
+
+
 def _unit_ab(start, end) -> tuple[float, float]:
     """Unit (east, north) components of the A->B direction."""
     coslat = np.cos(np.deg2rad(0.5 * (float(start[0]) + float(end[0]))))
@@ -239,6 +371,7 @@ def section_from_plane(
     n_points: int = 240,
     termini: tuple[str, str] = ("A", "B"),
     orientation: str = "EW",
+    max_gap_km: float | None = None,
 ) -> NWPSection:
     """Cut an :class:`NWPSection` from ``plane`` along ``start`` -> ``end``.
 
@@ -250,18 +383,32 @@ def section_from_plane(
     ``start``/``end`` are ``(lat, lon)``.  The along-section component is
     positive toward B.  ``pressure_hpa`` carries the domain-mean level pressures
     for reference; the curtain itself is drawn on geometric height.
-    """
-    from scipy.spatial import cKDTree
 
+    **Samples that fall off the grid are blanked, not fabricated.**  Nearest
+    neighbour has no upper bound, so a transect running past the nest boundary
+    would otherwise keep returning the boundary column for the rest of its
+    length -- a flat, entirely physical-looking curtain that is an artefact of
+    the search.  Anything further than ``max_gap_km`` from a column (default:
+    one grid cell) has its *data* fields set to NaN and is flagged in
+    ``offgrid1d``.  The geometry fields -- heights, terrain, distance, lat/lon --
+    are left intact so the axes and the terrain fill stay well defined and the
+    gap simply reads as missing.  Use :func:`section_coverage` to detect this
+    before paying for :func:`load_plane`.
+    """
     lon_line, lat_line, dist = _sample_line(start, end, n_points)
-    coslat = float(np.cos(np.deg2rad(np.mean(plane.lat2d))))
-    tree = cKDTree(np.column_stack([
-        plane.lat2d.ravel() * _KM_PER_DEG_LAT,
-        plane.lon2d.ravel() * _KM_PER_DEG_LON * coslat,
-    ]))
-    _, flat = tree.query(np.column_stack([
-        lat_line * _KM_PER_DEG_LAT, lon_line * _KM_PER_DEG_LON * coslat]))
-    jj, ii = np.unravel_index(flat, plane.lat2d.shape)
+    jj, ii, gap_km = _nearest_columns(plane.lat2d, plane.lon2d, lat_line, lon_line)
+
+    tol = (float(max_gap_km) if max_gap_km is not None
+           else _OFFGRID_TOLERANCE_CELLS * grid_spacing_km(plane.lat2d, plane.lon2d))
+    offgrid = gap_km > tol
+
+    def _blank(field):
+        """NaN the off-grid columns of a sampled data field."""
+        if field is None or not offgrid.any():
+            return field
+        out = np.array(field, dtype=float, copy=True)
+        out[..., offgrid] = np.nan
+        return out
 
     e_hat, n_hat = _unit_ab(start, end)
     ue = plane.ue[:, jj, ii]
@@ -271,17 +418,18 @@ def section_from_plane(
         lon_line=lon_line,
         lat_line=lat_line,
         height2d=plane.height[:, jj, ii],
-        speed2d=np.hypot(ue, ve),
-        theta2d=plane.theta[:, jj, ii],
-        temp2d=plane.temp[:, jj, ii],
-        along2d=ue * e_hat + ve * n_hat,
-        w2d=plane.w[:, jj, ii],
+        speed2d=_blank(np.hypot(ue, ve)),
+        theta2d=_blank(plane.theta[:, jj, ii]),
+        temp2d=_blank(plane.temp[:, jj, ii]),
+        along2d=_blank(ue * e_hat + ve * n_hat),
+        w2d=_blank(plane.w[:, jj, ii]),
         terrain1d=plane.terrain[jj, ii],
         pressure_hpa=plane.pressure_hpa,
         termini=termini,
         orientation=orientation,
         height_w2d=plane.height_w[:, jj, ii],
-        refl2d=None if plane.refl is None else plane.refl[:, jj, ii],
+        refl2d=None if plane.refl is None else _blank(plane.refl[:, jj, ii]),
+        offgrid1d=offgrid,
     )
 
 

--- a/brc_tools/radar/iem.py
+++ b/brc_tools/radar/iem.py
@@ -51,6 +51,21 @@ RIDGE_PRODUCTS: dict[str, tuple[float, str, str]] = {
     "N0S": (0.5, "storm-relative mean radial velocity", "velocity"),
 }
 
+def observed_elevations(quantity: str = "reflectivity") -> set[float]:
+    """Beam tilts this archive can actually serve, in degrees.
+
+    Today this is ``{0.5}`` -- RIDGE publishes elevation 1 only.  Exposed as a
+    function rather than left implicit in :data:`RIDGE_PRODUCTS` because a caller
+    rendering a *model* beam surface needs to know, before it draws, whether an
+    observed counterpart can exist at that tilt.  A 1.2 deg model panel with no
+    observed panel beside it is correct but easy to misread as "the observation
+    was missing that day", and over the Uinta Basin the distinction is binding:
+    nothing below ~3 km AGL was sampled by radar at all, so a signature seen only
+    in the model must not be described as verified.
+    """
+    return {elev for elev, _desc, qty in RIDGE_PRODUCTS.values() if qty == quantity}
+
+
 #: Index -> dBZ for the reflectivity products.  Index 0 is missing.
 _DBZ_MIN = -32.0
 _DBZ_STEP = 0.5

--- a/brc_tools/visualize/style.py
+++ b/brc_tools/visualize/style.py
@@ -90,6 +90,13 @@ VAR_STYLES: dict[str, VarStyle] = {
                                 5.0, 75.0, extend="max"),
     "refl":           VarStyle("gist_ncar", r"reflectivity (dBZ)",
                                 5.0, 75.0, extend="max"),
+    # REFD_MAX, not REFD_COM: the maximum over the interval since the last
+    # history write, so it is a swath rather than a snapshot. Same scale as
+    # refl_comp on purpose -- the two are meant to be read side by side -- but a
+    # separate key so the label cannot claim the wrong surface.
+    "refl_comp_max":  VarStyle("gist_ncar",
+                                r"max composite reflectivity, output interval (dBZ)",
+                                5.0, 75.0, extend="max"),
     "refl_beam":      VarStyle("gist_ncar", r"reflectivity on beam surface (dBZ)",
                                 5.0, 75.0, extend="max"),
     "echo_top":       VarStyle("viridis", r"echo top (km MSL)", 2.0, 14.0, extend="max"),

--- a/docs/VISUAL-SUITE-SOP.md
+++ b/docs/VISUAL-SUITE-SOP.md
@@ -77,10 +77,17 @@ job. All are fixed; they are recorded because the *class* of mistake will recur.
 | 8 | `parcel_levels` reversed both interpolation arrays | LCL/LFC/EL all reported the surface height | fixed |
 | 9 | Beam titles clipped | The tilt — the one thing that makes the figure meaningful — was cut off | fixed |
 | 10 | `render_aux` passed borrowed coordinates into `plan_dataset`'s `extra` | `plan_dataset` builds `latitude`/`longitude` as coords itself, so xarray rejected the dataset and the whole 1-minute job died. **Found only when the suite was first run** — the family had never been smoke-tested, unlike the other six | fixed |
+| 11 | A transect leaving its nest sampled the **edge column** for the rest of its length | `section_from_plane` ran `cKDTree.query` and threw away the distances it returned. Nearest neighbour has no cutoff, so an off-grid line drew a flat, entirely physical-looking curtain that was an artefact of the search. Was open as gap 5 | fixed — off-grid samples are blanked, `section_coverage` preflights both engines |
+| 12 | A model beam panel with no observed counterpart looked like a missing observation | IEM RIDGE serves 0.5° only, so a 1.2° model figure renders alone. Unlabelled, it invites the "verified against radar" claim `CHK-BEAM` forbids. Was open as gap 7 | fixed — the panel is annotated `MODEL ONLY` with the tilts the archive does serve |
+| 13 | `REFD_COM` and `REFD_MAX` shared one style key | They are different quantities — the column max *at the output instant* vs. the max *over the interval since the last history write*. A run writing both plotted only one, under a label naming the wrong surface. Was open as gap 10 | fixed — separate `refl_comp_max` style |
+| 14 | The field→style and masking tables lived in the script, untested | Unavailable to other callers, and error 13 is exactly what goes unnoticed there. Was open as gap 9 | fixed — moved to `nwp/wrf_convective.py` with tests |
+| 15 | `verify` silently ignored the time-selection flags | `--valid X --figure verify` looked like it honoured `X`. Was open as gap 4 | fixed — says so in the log |
 
 ## Gaps still open
 
-Ordered by how likely they are to bite.
+Ordered by how likely they are to bite. **Rank them by consequence instead** — the
+closing section of this doc says why, and the five closed above (errors 11–15) were
+the ones that made a figure lie rather than the ones that made a sweep tedious.
 
 1. **No idempotence.** `wrf_figures.py` has `--skip-existing` (compares PNG mtime
    against every source file); the winds and convective engines do not. Re-running a
@@ -98,35 +105,26 @@ Ordered by how likely they are to bite.
    rendered. A job that failed 300 of 400 figures looks like a success. **Recommended:**
    return a non-zero exit when the error count exceeds a threshold, and print an
    error tally at the end.
-4. **`verify` ignores the time selection.** It renders its own configured windows
-   regardless of `--valid`/`--every`, which is defensible (they are window products)
-   but surprising: `--valid X --figure verify` silently ignores `X`. **Recommended:**
-   say so in the log line.
+4. ~~**`verify` ignores the time selection.**~~ **Closed** — error 15 above.
 5. **No cross-nest consistency check.** Nothing verifies that a figure labelled d02
-   and one labelled d01 at the same valid time actually came from the same run, or
-   that a `[[sections]]` A→B line lies inside the nest being cut. A transect running
-   off-grid samples the edge column for the rest of its length — silently. `WRF-WINDS.md`
-   warns about this in prose; it should be a preflight check.
+   and one labelled d01 at the same valid time actually came from the same run.
+   *(The other half of this gap — whether a `[[sections]]` A→B line lies inside the
+   nest being cut — is closed; see error 11.)*
 6. **Colour limits are global, not per-window.** The convective styles are set from
    this run's measured maxima, which is right for comparability but means a quiet
    frame at 23:10Z is nearly blank on the same scale that resolves the 02:20Z core.
    Acceptable, but worth a `[style.overrides]` per sweep if a reader is comparing
    early and late frames.
-7. **Observed-radar coverage is tilt-limited and that is easy to forget.** IEM RIDGE
-   gives 0.5° only. The engine renders an observed panel *only* for tilts it has, so
-   a 1.2° model figure appears with no counterpart — correct, but a reader may not
-   notice the absence. **Recommended:** annotate the model panel when no observed
-   counterpart exists at that tilt.
+7. ~~**Observed-radar coverage is tilt-limited.**~~ **Closed** — error 12 above.
+   Note the underlying limit has not moved and cannot: Level-II is unobtainable for
+   a 2025 date (AWS denies anonymous access by bucket policy; the GCS mirror stops
+   before Sept 2025), so 0.0° and 1.2° still have **no** observed counterpart. Only
+   the silence about it is fixed. Transport table: `docs/nwp/NWP-SOURCE-MATRIX.md`.
 8. **No `--dry-run`.** There is no way to ask "what would this render?" before
    committing a job. With four families × three views × 31 times the answer is not
    obvious. **Recommended:** print the planned figure list and exit.
-9. **Two `_MASK_AT_OR_BELOW` / `_SURFACE_FIELDS` tables live in the script**, not the
-   package, so they are untested and unavailable to other callers. **Recommended:**
-   move to `nwp/wrf_convective.py` with tests.
-10. **`REFD_COM` and `REFD_MAX` both map to the `refl_comp` style**, and the
-    collision fallback names the second `refd_max`, which has no style and is
-    therefore skipped with a confusing message. Minor, but it means a run writing
-    both silently plots only one.
+9. ~~**Tables live in the script, not the package.**~~ **Closed** — error 14 above.
+10. ~~**`REFD_COM` and `REFD_MAX` share a style.**~~ **Closed** — error 13 above.
 
 ## The rule that has earned its place
 

--- a/docs/WRF-WINDS.md
+++ b/docs/WRF-WINDS.md
@@ -181,7 +181,10 @@ left-to-right, the **bottom-left** corner is inside the terrain fill and free.
 1. Copy an existing TOML into the repo that owns the case (for ub-wx WRF
    experiments: `experiments/<id>/figures.toml`).
 2. Set `run_dir`, `[[domains]]`, and the transect endpoints.
-3. Check the transect actually crosses the terrain you meant — sample `HGT` along it
-   before rendering; an endpoint outside a nest silently samples that nest's edge
-   column all the way out.
+3. Check the transect crosses the terrain you meant. A transect leaving the nest is
+   now caught for you: the engine preflights every `[[sections]]` line with
+   `wrf_section.section_coverage` and prints how far along it departs, the off-grid
+   part is blanked rather than filled from the edge column, and a line that misses
+   the nest entirely is skipped. It used to sample that edge column all the way out
+   and draw a flat, entirely physical-looking curtain.
 4. `sbatch scripts/wrf_winds.dtn.slurm --config <that TOML>`.

--- a/scripts/wrf_convective.py
+++ b/scripts/wrf_convective.py
@@ -51,21 +51,10 @@ from brc_tools.visualize.wrf_curtain import plot_wrf_curtain  # noqa: E402
 
 FAMILIES = ("surface", "aux", "section", "beam", "sounding", "verify", "track")
 
-#: History-stream 2-D fields this engine can plot, mapped to their style key.
-#: Anything here is read from ``wrfout``; the auxiliary stream is handled
-#: separately because its maximum fields reset on the history write.
-_SURFACE_FIELDS = {
-    "REFD_COM": "refl_comp",
-    "REFD_MAX": "refl_comp",
-    "ECHOTOP": "echo_top",
-    "WSPD10MAX": "wspd10max",
-    "UP_HELI_MAX": "uphel_2to5km",
-    "HAIL_MAX2D": "hail_max",
-    "AFWA_LLWS": "llws",
-    "AFWA_CAPE": "cape_ml",
-    "AFWA_CIN": "cin_ml",
-    "TORNADO_MASK": "tornado_mask",
-}
+#: Field -> style tables live in the package (with tests), not here, so other
+#: callers get them too and the REFD_COM/REFD_MAX distinction is enforced in one
+#: place.  See :mod:`brc_tools.nwp.wrf_convective`.
+_SURFACE_FIELDS = wc.SURFACE_FIELDS
 
 
 # --------------------------------------------------------------------------- #
@@ -93,29 +82,9 @@ def _echo_top_km(field):
     return np.asarray(field, dtype=float) / 1000.0
 
 
-#: Values at or below these floors are masked to NaN before plotting.
-#:
-#: Without this, a reflectivity panel paints the whole domain in the low end of the
-#: colour map and clear air reads as data -- on a 213 x 171 km footprint holding one
-#: storm, that is most of the figure. Operational radar products mask below ~5 dBZ
-#: for the same reason. Echo top is 0 where there is no echo at all, not 0 km.
-_MASK_AT_OR_BELOW = {
-    "refl_comp": 5.0,
-    "refl_beam": 5.0,
-    "refl": 5.0,
-    "echo_top": 0.0,
-    "hail_max": 0.0,
-    "tornado_mask": 0.0,
-}
-
-
-def _masked(key: str, field):
-    """Apply the presentation floor for ``key``, if it has one."""
-    floor = _MASK_AT_OR_BELOW.get(key)
-    array = np.asarray(field, dtype=float)
-    if floor is None:
-        return array
-    return np.where(array <= floor, np.nan, array)
+#: Presentation floors also live in the package; see the note above.
+_MASK_AT_OR_BELOW = wc.MASK_AT_OR_BELOW
+_masked = wc.masked
 
 
 def _plan_extra(ds, dom: dict) -> dict:
@@ -248,6 +217,8 @@ def render_sections(cfg, dom, plane, out_dir, ctx, args) -> int:
         if spec is None:
             print(f"[SKIP] {tag} section {key!r}: not in [[sections]]")
             continue
+        if not we.check_section_on_grid(plane, key, spec, tag=tag):
+            continue
         shade = spec.get("shade", "refl")
         wps = we.waypoints(spec.get("waypoint_group"))
         try:
@@ -289,6 +260,20 @@ def _shade_style(shade: str) -> str:
     )
 
 
+def _observed_elevations(spec: dict) -> set[float] | None:
+    """Tilts an observed panel could exist for, or None if none was requested.
+
+    ``None`` means the case never asked for a comparison, so a model-only panel
+    is the expected product and needs no caveat.  A set means it did ask, and any
+    tilt outside that set will render alone.
+    """
+    if not spec.get("compare_observed"):
+        return None
+    from brc_tools.radar import iem
+
+    return iem.observed_elevations()
+
+
 def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
     """Simulated reflectivity sampled on a radar's beam surfaces.
 
@@ -314,6 +299,11 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
             print(f"[SKIP] {tag} beam {key!r}: not in [[beams]]")
             continue
         site = get_site(spec["site"])
+        # Which tilts an observed panel could exist for at all.  A model beam with
+        # no observed counterpart must say so on the figure: the absence is a fact
+        # about the archive, not about the storm, and an unlabelled solo panel
+        # invites exactly the "verified against radar" claim CHK-BEAM forbids.
+        served = _observed_elevations(spec)
         for elev in spec.get("elevations_deg", [0.5]):
             try:
                 surface = rb.beam_surface_asl(plane.lat2d, plane.lon2d, site, float(elev))
@@ -325,6 +315,11 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
                     f"{np.nanmin(agl) / 1000:.1f}-{np.nanmax(agl) / 1000:.1f} km AGL "
                     f"across this domain"
                 )
+                if served is not None and float(elev) not in served:
+                    note += (
+                        f" | MODEL ONLY -- no observed counterpart at this tilt "
+                        f"(archive serves {', '.join(f'{e:g}' for e in sorted(served))} deg)"
+                    )
                 plot_nwp_surface_map(
                     pds, "refl_beam",
                     out_dir / f"beam_{site.id}_{float(elev):g}deg_{tag}_{stamp}.png",
@@ -473,6 +468,13 @@ def render_verify(cfg, out_dir, args) -> int:
     from brc_tools.visualize.timeseries import plot_scalar_timeseries
 
     run_dir = cfg["case"]["run_dir"]
+    # Window products, not per-time ones: each [[verify]] entry carries its own
+    # window, so the sweep flags do not apply. Said out loud because
+    # `--valid X --figure verify` otherwise looks like it honoured X.
+    if any((args.valid, args.lead, args.hourly, args.every, args.all_times,
+            args.start, args.end)):
+        print("[note] verify renders each [[verify]] entry's own configured window; "
+              "the time-selection flags do not apply to it")
     made = 0
     for entry in cfg.get("verify", []):
         key = entry["key"]

--- a/scripts/wrf_winds.py
+++ b/scripts/wrf_winds.py
@@ -141,6 +141,8 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                 if s is None:
                     print(f"[SKIP] {tag} section {key!r}: not in [[sections]]")
                     continue
+                if not we.check_section_on_grid(plane, key, s, tag=tag):
+                    continue
                 sec_wps = waypoints(s.get("waypoint_group"))
                 try:
                     sec = ws.section_from_plane(

--- a/tests/test_iem_radar.py
+++ b/tests/test_iem_radar.py
@@ -193,3 +193,27 @@ class TestLive:
         finite = field.values[np.isfinite(field.values)]
         assert finite.size > 100
         assert 40.0 < finite.max() < 70.0
+
+
+class TestObservedElevations:
+    """What tilts this archive can serve, which a model-only panel must declare."""
+
+    def test_ridge_serves_only_the_half_degree_tilt(self):
+        assert iem.observed_elevations() == {0.5}
+
+    def test_the_tilts_the_ashley_case_reports_are_mostly_unserved(self):
+        # CHK-BEAM reports 0.0 / 0.5 / 1.2 deg. Only one has a counterpart, so a
+        # figure at either of the others must say it stands alone.
+        served = iem.observed_elevations()
+        assert 0.5 in served
+        assert 0.0 not in served and 1.2 not in served
+
+    def test_velocity_is_tracked_separately_from_reflectivity(self):
+        # N0S exists but its index scaling is unverified, so it must not be
+        # counted as a reflectivity tilt.
+        assert iem.observed_elevations("velocity") == {0.5}
+        assert iem.observed_elevations("nonesuch") == set()
+
+    def test_derived_from_the_product_table_not_hardcoded(self):
+        expected = {e for e, _d, q in iem.RIDGE_PRODUCTS.values() if q == "reflectivity"}
+        assert iem.observed_elevations() == expected

--- a/tests/test_wrf_convective.py
+++ b/tests/test_wrf_convective.py
@@ -202,3 +202,49 @@ class TestSwathAndCentroid:
         assert one[2] == 49  # 7x7
         assert full[2] == 53  # 49 + 4
         assert one[0] > full[0]  # no longer dragged south by the small cell
+
+
+class TestSurfaceFieldTables:
+    """The field->style and masking tables, moved here from the engine script.
+
+    They were untested while they lived in ``scripts/wrf_convective.py``, and one
+    of them was wrong: two different quantities shared a style key.
+    """
+
+    def test_refd_com_and_refd_max_do_not_share_a_style(self):
+        # A snapshot column maximum and a maximum over the output interval are
+        # different measurements. Sharing a key meant a run writing both plotted
+        # only one, labelled as the other.
+        assert wc.SURFACE_FIELDS["REFD_COM"] != wc.SURFACE_FIELDS["REFD_MAX"]
+
+    def test_every_style_key_is_unique(self):
+        keys = list(wc.SURFACE_FIELDS.values())
+        assert len(keys) == len(set(keys)), "two fields would collide on one style"
+
+    def test_every_style_key_is_registered(self):
+        from brc_tools.visualize import style as st
+
+        for field, key in wc.SURFACE_FIELDS.items():
+            assert key in st.VAR_STYLES, f"{field} -> {key} has no VarStyle"
+
+    def test_refd_max_is_an_interval_maximum_so_it_resets_on_history(self):
+        # Consistency between the two tables: REFD_MAX is a running maximum, and
+        # the aux reader must keep refusing it.
+        assert "REFD_MAX" in wc.RESET_ON_HISTORY
+
+    def test_masked_applies_the_floor(self):
+        out = wc.masked("refl_comp", np.array([0.0, 5.0, 5.1, 40.0]))
+        assert np.isnan(out[0]) and np.isnan(out[1])  # at or below 5 dBZ
+        assert out[2] == pytest.approx(5.1) and out[3] == pytest.approx(40.0)
+
+    def test_masked_passes_through_a_key_with_no_floor(self):
+        field = np.array([-3.0, 0.0, 12.0])
+        assert np.allclose(wc.masked("wspd10max", field), field)
+
+    def test_both_reflectivity_snapshots_and_swaths_are_floored(self):
+        for key in ("refl_comp", "refl_comp_max", "refl_beam", "refl"):
+            assert wc.MASK_AT_OR_BELOW[key] == 5.0
+
+    def test_echo_top_floor_is_zero_not_five(self):
+        # Echo top is 0 where there is no echo at all, not 0 km of echo.
+        assert wc.MASK_AT_OR_BELOW["echo_top"] == 0.0

--- a/tests/test_wrf_engine.py
+++ b/tests/test_wrf_engine.py
@@ -253,3 +253,43 @@ class TestTimeWindow:
 
     def test_no_window_keeps_everything(self):
         assert len(self._select()) == len(self._stamps())
+
+
+class TestSectionPreflight:
+    """The off-grid transect warning, shared by both engines.
+
+    ``WRF-WINDS.md`` warned about this in prose; the point of the helper is that
+    the warning now actually fires, before a sweep spends an hour on a curtain
+    that is an artefact of unbounded nearest-neighbour search.
+    """
+
+    @staticmethod
+    def _plane():
+        from _wrf_synthetic import make_synthetic_wrf
+
+        from brc_tools.nwp import wrf_section as ws
+
+        return ws.load_plane(make_synthetic_wrf())
+
+    def test_an_on_grid_transect_passes_quietly(self, capsys):
+        spec = {"a": (40.1, -109.9), "b": (40.4, -109.6), "n_points": 40}
+        assert we.check_section_on_grid(self._plane(), "valley", spec, tag="d02") is True
+        assert capsys.readouterr().out == ""
+
+    def test_a_partly_off_grid_transect_warns_but_still_renders(self, capsys):
+        spec = {"a": (40.25, -109.75), "b": (40.25, -108.0), "n_points": 60}
+        assert we.check_section_on_grid(self._plane(), "runoff", spec, tag="d02") is True
+        out = capsys.readouterr().out
+        assert "[WARN]" in out and "runoff" in out
+        assert "leaves the grid" in out
+        assert "edge column" in out  # says what was done about it
+
+    def test_a_wholly_off_grid_transect_is_skipped(self, capsys):
+        spec = {"a": (45.0, -100.0), "b": (45.5, -99.0), "n_points": 20}
+        assert we.check_section_on_grid(self._plane(), "elsewhere", spec, tag="d01") is False
+        out = capsys.readouterr().out
+        assert "[SKIP]" in out and "elsewhere" in out
+
+    def test_n_points_defaults_when_the_case_omits_it(self):
+        spec = {"a": (40.1, -109.9), "b": (40.4, -109.6)}
+        assert we.check_section_on_grid(self._plane(), "valley", spec, tag="d02") is True

--- a/tests/test_wrf_section.py
+++ b/tests/test_wrf_section.py
@@ -1,0 +1,135 @@
+"""Tests for brc_tools.nwp.wrf_section -- transect sampling and grid coverage.
+
+The point of most of these is the failure the sampler used to have silently:
+nearest-neighbour has no upper bound, so a transect running off the nest kept
+returning the boundary column for the rest of its length and drew a flat,
+entirely physical-looking curtain.  The synthetic grid spans lat 40.0-40.5 and
+lon -110.0 to -109.5, so a line pushed east of -109.5 is provably off it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from _wrf_synthetic import make_synthetic_wrf
+
+from brc_tools.nwp import wrf_section as ws
+
+
+@pytest.fixture
+def plane():
+    return ws.load_plane(make_synthetic_wrf(convective=True))
+
+
+# Inside the synthetic grid (lat 40.0..40.5, lon -110.0..-109.5).
+INSIDE_A = (40.1, -109.9)
+INSIDE_B = (40.4, -109.6)
+
+
+class TestGridSpacing:
+    def test_matches_the_synthetic_grid_step(self, plane):
+        # 0.1 deg steps: 11.06 km in latitude, 111.32*0.1*cos(40) = 8.53 km in
+        # longitude.  The median over both axes must land between the two.
+        spacing = ws.grid_spacing_km(plane.lat2d, plane.lon2d)
+        assert 8.0 < spacing < 11.5
+
+    def test_a_single_column_grid_is_refused(self):
+        with pytest.raises(ValueError, match="two columns"):
+            ws.grid_spacing_km(np.array([[40.0]]), np.array([[-110.0]]))
+
+
+class TestSectionCoverage:
+    def test_a_transect_inside_the_nest_is_fully_covered(self, plane):
+        cov = ws.section_coverage(plane, INSIDE_A, INSIDE_B, n_points=50)
+        assert cov.fully_inside
+        assert cov.n_inside == cov.n_points == 50
+        assert cov.inside_fraction == 1.0
+        assert cov.first_outside_km is None
+        assert "on-grid" in cov.describe()
+
+    def test_a_transect_running_off_the_east_edge_is_partly_covered(self, plane):
+        # Starts inside, ends ~1.5 deg east of the grid's last column.
+        cov = ws.section_coverage(plane, (40.25, -109.75), (40.25, -108.0), n_points=100)
+        assert not cov.fully_inside
+        assert 0.0 < cov.inside_fraction < 1.0
+        # It began on the grid, so the departure is reported at a distance, not None.
+        assert cov.first_outside_km is not None and cov.first_outside_km > 0.0
+        assert cov.worst_gap_km > cov.tolerance_km
+        assert "leaves the grid" in cov.describe()
+
+    def test_a_transect_entirely_off_the_grid_covers_nothing(self, plane):
+        cov = ws.section_coverage(plane, (45.0, -100.0), (45.5, -99.0), n_points=30)
+        assert cov.n_inside == 0
+        assert cov.inside_fraction == 0.0
+        assert not cov.fully_inside
+        # Outside from terminus A onward reads better than "leaves at 0.0 km".
+        assert cov.first_outside_km is None
+        assert "from the start" in cov.describe()
+
+    def test_accepts_bare_lat_lon_so_it_can_run_before_load_plane(self, plane):
+        # The preflight must not require the expensive 3-D read.
+        from_plane = ws.section_coverage(plane, INSIDE_A, INSIDE_B, n_points=40)
+        from_arrays = ws.section_coverage(
+            plane.lat2d, INSIDE_A, INSIDE_B, lon2d=plane.lon2d, n_points=40
+        )
+        assert from_arrays == from_plane
+
+    def test_bare_lat_without_lon_is_a_type_error(self, plane):
+        with pytest.raises(TypeError, match="both lat2d and lon2d"):
+            ws.section_coverage(plane.lat2d, INSIDE_A, INSIDE_B)
+
+    def test_an_explicit_tolerance_overrides_the_grid_derived_one(self, plane):
+        loose = ws.section_coverage(
+            plane, (40.25, -109.75), (40.25, -108.0), n_points=100, max_gap_km=1e6
+        )
+        assert loose.fully_inside  # nothing is 1000 km from this grid
+
+
+class TestOffGridBlanking:
+    def test_an_on_grid_section_blanks_nothing(self, plane):
+        sec = ws.section_from_plane(plane, INSIDE_A, INSIDE_B, n_points=40)
+        assert not sec.offgrid1d.any()
+        assert np.isfinite(sec.speed2d).all()
+        assert np.isfinite(sec.theta2d).all()
+
+    def test_off_grid_columns_are_nan_not_the_edge_column(self, plane):
+        sec = ws.section_from_plane(
+            plane, (40.25, -109.75), (40.25, -108.0), n_points=100
+        )
+        off = sec.offgrid1d
+        assert off.any() and not off.all(), "expected a partly off-grid transect"
+
+        # The defect: every off-grid sample used to carry the boundary column's
+        # value, so the curtain ran flat instead of stopping.
+        assert np.isnan(sec.speed2d[:, off]).all()
+        assert np.isnan(sec.theta2d[:, off]).all()
+        assert np.isnan(sec.temp2d[:, off]).all()
+        assert np.isnan(sec.along2d[:, off]).all()
+        assert np.isnan(sec.w2d[:, off]).all()
+        assert np.isnan(sec.refl2d[:, off]).all()
+        # ...and the on-grid part is untouched.
+        assert np.isfinite(sec.speed2d[:, ~off]).all()
+
+    def test_geometry_survives_so_the_axes_stay_defined(self, plane):
+        sec = ws.section_from_plane(
+            plane, (40.25, -109.75), (40.25, -108.0), n_points=100
+        )
+        # Blanking the heights or the terrain would break the curtain's y-axis and
+        # its terrain fill; only the data is missing, not the frame.
+        assert np.isfinite(sec.height2d).all()
+        assert np.isfinite(sec.height_w2d).all()
+        assert np.isfinite(sec.terrain1d).all()
+        assert np.isfinite(sec.distance_km).all()
+
+    def test_coverage_and_the_sampler_agree_on_what_is_off_grid(self, plane):
+        a, b, n = (40.25, -109.75), (40.25, -108.0), 100
+        cov = ws.section_coverage(plane, a, b, n_points=n)
+        sec = ws.section_from_plane(plane, a, b, n_points=n)
+        assert int((~sec.offgrid1d).sum()) == cov.n_inside
+
+    def test_a_generous_tolerance_restores_the_old_behaviour(self, plane):
+        sec = ws.section_from_plane(
+            plane, (40.25, -109.75), (40.25, -108.0), n_points=100, max_gap_km=1e6
+        )
+        assert not sec.offgrid1d.any()
+        assert np.isfinite(sec.speed2d).all()


### PR DESCRIPTION
Closes five of the ten gaps in `docs/VISUAL-SUITE-SOP.md`. The doc lists them by *likelihood*; this PR takes the three that rank highest by **consequence** — the ones that make a plausible, publishable, wrong figure — plus the two that share their files.

That ranking rule is the SOP's own closing line: *"Every one of errors 5–9 above produced a figure that looked right."*

## Gap 5 — off-grid transects sampled the edge column, silently

The sharpest one. `section_from_plane` ran `cKDTree.query` and **discarded the distances it returns**:

```python
_, flat = tree.query(...)     # before
```

Nearest neighbour has no cutoff, so a transect running past the nest boundary kept returning the boundary column for the rest of its length — a flat, entirely physical-looking curtain that is an artefact of the search. The distances were already computed, so the fix is nearly free.

- Samples further than one grid cell from any column are **blanked, not fabricated**; `offgrid1d` flags them.
- Geometry (heights, terrain, distance, lat/lon) survives, so the axes and terrain fill stay defined and the gap simply reads as missing.
- `section_coverage()` is a cheap preflight — it runs before `load_plane`, reports how far along the line departs, and is exact about "outside from terminus A onward" vs. a departure distance.
- `wrf_engine.check_section_on_grid` wires it into **both** engines: warn on partial overlap, skip a line that misses the nest entirely.

`WRF-WINDS.md` carried this warning in prose. It now fires. Any future `brc-wrf` caller is protected too, since the fix is in the capability rather than the engines.

## Gap 7 — an unpaired model beam panel didn't say so

IEM RIDGE serves 0.5° only, so a 1.2° model panel renders alone. `iem.observed_elevations()` derives the served tilts from `RIDGE_PRODUCTS`, and the panel is annotated `MODEL ONLY — no observed counterpart at this tilt` when its tilt isn't among them.

The underlying limit hasn't moved and can't: Level-II is unobtainable for a 2025 date. `CHK-BEAM` forbids describing the observed couplet as low-level, and a solo unlabelled panel is the invitation to do exactly that. Only the silence is fixed.

## Gaps 9 + 10 — one table, so one edit

`_SURFACE_FIELDS` and `_MASK_AT_OR_BELOW` move from the script into `nwp/wrf_convective.py` with tests, and `REFD_MAX` gets its own `refl_comp_max` style.

`REFD_COM` and `REFD_MAX` are **different physical quantities** — the column maximum *at the output instant* vs. the maximum *over the interval since the last history write*. Sharing `refl_comp` meant a run writing both plotted only one, under a label naming the wrong surface. That's the SOP's own *"a reflectivity number without its surface is not a measurement"*, in code.

## Gap 4

`verify` now says out loud that the time-selection flags don't apply to it.

## Not in scope

- **Gap 6** needs no code — global colour limits are deliberate and `[style.overrides]` is already the escape hatch.
- **Gaps 1, 2, 3, 8** share one root cause (no render chokepoint) and are one refactor, not four. Separate PR.
- **Gap 5's other half** — cross-nest provenance — is still open.

## Testing

`492 passed, 6 skipped` (was 463 — 29 new tests, including a new `tests/test_wrf_section.py`). Both engines still parse and run. Off-grid behaviour is tested three ways: wholly inside, half outside, wholly outside — plus that the sampler and the preflight agree on what's off-grid, and that a generous `max_gap_km` restores the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)