### PR TITLE
feat(engine): one render chokepoint, so a sweep can say what it did

### DIFF
--- a/brc_tools/nwp/wrf_engine.py
+++ b/brc_tools/nwp/wrf_engine.py
@@ -14,9 +14,13 @@ dataclasses rather than plain dicts.  Two engines, one set of plumbing.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import tomllib
-from datetime import datetime, timedelta
+import traceback
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from brc_tools.nwp import wrf_section as ws
@@ -226,6 +230,274 @@ def select_times(
             print(f"[SKIP] d{dom:02d} has no {one:{TIME_FMT}} "
                   f"(latest {max(stamps):{TIME_FMT}}) -- domain dropped")
     return [one]
+
+
+# --------------------------------------------------------------------------- #
+# the render ledger
+# --------------------------------------------------------------------------- #
+#: Statuses a :class:`FigureRecord` can carry.
+RENDERED, SKIPPED, PLANNED, ERROR, ABSENT = (
+    "rendered", "skipped", "planned", "error", "absent")
+
+
+@dataclass
+class FigureRecord:
+    """One attempted figure: what it was, and what happened to it."""
+
+    family: str
+    status: str
+    path: str | None = None
+    domain: int | None = None
+    valid: str | None = None
+    var: str | None = None
+    detail: str = ""
+
+
+class FigureLedger:
+    """The single chokepoint every figure passes through.
+
+    Each family used to render on its own -- ``try: plot(...); made += 1`` /
+    ``except: print("[ERR]")``, repeated at a dozen sites -- and report only an
+    ``int``.  With no chokepoint there was nowhere to put idempotence, a record
+    of what was produced, an error tally, or a dry run, so those read as four
+    separate gaps when they are one missing seam.
+
+    Robustness is unchanged: a failing figure is still caught and printed, and
+    the sweep still continues.  What changes is that the job can now say what it
+    did.
+    """
+
+    def __init__(self, *, skip_existing: bool = False, dry_run: bool = False):
+        self.skip_existing = bool(skip_existing)
+        self.dry_run = bool(dry_run)
+        self.records: list[FigureRecord] = []
+
+    # -- recording ---------------------------------------------------------- #
+    def emit(
+        self,
+        out_path,
+        render_fn,
+        *,
+        sources=(),
+        family: str,
+        domain: int | None = None,
+        valid: datetime | None = None,
+        var: str | None = None,
+    ) -> int:
+        """Render one figure, or decide not to.  Returns 1 if a file was written.
+
+        ``render_fn`` takes the output path, so the decision to render happens
+        before any work does.  ``sources`` are the files the figure derives from;
+        with ``skip_existing`` a figure at least as new as all of them is kept.
+        """
+        out_path = Path(out_path)
+        common = dict(family=family, domain=domain, var=var,
+                      valid=None if valid is None else valid.strftime(TIME_FMT),
+                      path=str(out_path))
+
+        if self.dry_run:
+            self.records.append(FigureRecord(status=PLANNED, **common))
+            return 0
+        if self.skip_existing and self.is_current(out_path, sources):
+            self.records.append(FigureRecord(status=SKIPPED, **common))
+            return 0
+        try:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            render_fn(out_path)
+        except Exception as exc:  # one bad panel is not a lost run
+            label = " ".join(str(x) for x in (family, var, out_path.name) if x)
+            print(f"[ERR] {label}: {exc}")
+            traceback.print_exc()
+            self.records.append(
+                FigureRecord(status=ERROR, detail=f"{type(exc).__name__}: {exc}", **common)
+            )
+            return 0
+        self.records.append(FigureRecord(status=RENDERED, **common))
+        return 1
+
+    def note(self, status: str, detail: str, *, family: str,
+             domain: int | None = None, valid: datetime | None = None,
+             var: str | None = None) -> None:
+        """Record something that produced no file -- an absent field, a bad key.
+
+        Keeps the manifest honest about coverage: "not in this run" and "failed"
+        are different answers to "where is my figure?", and ``find`` cannot tell
+        them apart.
+        """
+        self.records.append(FigureRecord(
+            family=family, status=status, detail=detail, domain=domain, var=var,
+            valid=None if valid is None else valid.strftime(TIME_FMT),
+        ))
+
+    def is_current(self, out_path, sources) -> bool:
+        """Whether ``out_path`` is at least as new as every source it derives from.
+
+        A source rewritten by a later WRF run is newer than the figure, so the
+        figure regenerates -- which is what makes this safe to use against a run
+        that is still writing.
+        """
+        out_path = Path(out_path)
+        if not out_path.exists():
+            return False
+        out_mtime = out_path.stat().st_mtime
+        for src in sources:
+            src = Path(src)
+            if not src.exists() or src.stat().st_mtime > out_mtime:
+                return False
+        return True
+
+    # -- reporting ---------------------------------------------------------- #
+    def count(self, status: str) -> int:
+        return sum(1 for r in self.records if r.status == status)
+
+    @property
+    def rendered(self) -> int:
+        return self.count(RENDERED)
+
+    @property
+    def errors(self) -> int:
+        return self.count(ERROR)
+
+    def summarise(self) -> str:
+        """The tally, printed last so it is the final line in a ``.err``."""
+        parts = [f"{self.count(s)} {s}"
+                 for s in (RENDERED, SKIPPED, PLANNED, ERROR, ABSENT)
+                 if self.count(s)]
+        return "[tally] " + (", ".join(parts) if parts else "nothing attempted")
+
+    def planned_lines(self) -> list[str]:
+        """One line per figure a dry run would have rendered."""
+        return [f"  {r.family:9s} {r.valid or '-':16s} {r.path}"
+                for r in self.records if r.status == PLANNED]
+
+    def exit_code(self, *, allow_errors: bool = False) -> int:
+        """0 only if the job actually did what it was asked.
+
+        ``return 0 if total else 1`` could not tell 400-of-400 from 100-of-400:
+        a job that failed three quarters of its figures looked like a success
+        because *something* rendered.  Any error is now non-zero unless the
+        caller opts out.
+        """
+        if self.errors and not allow_errors:
+            return 1
+        if self.dry_run:
+            return 0
+        return 0 if (self.rendered or self.count(SKIPPED)) else 1
+
+    def write_manifest(self, out_root, *, config_path=None, run_dir=None,
+                       argv=None, extra: dict | None = None) -> Path:
+        """Write a machine-readable record of this job under ``out_root``.
+
+        Named by ``SLURM_JOB_ID`` when there is one, because the normal way to
+        sweep a case is several jobs into one output root and a single
+        ``manifest.json`` would have them clobber each other.
+        """
+        out_root = Path(out_root)
+        now = datetime.now(UTC)
+        job = os.environ.get("SLURM_JOB_ID") or now.strftime("%Y%m%dT%H%M%SZ")
+        payload = {
+            "job": job,
+            "written_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "config": None if config_path is None else str(config_path),
+            "config_sha256": _sha256(config_path),
+            "run_dir": None if run_dir is None else str(run_dir),
+            "argv": list(argv) if argv is not None else None,
+            "dry_run": self.dry_run,
+            "skip_existing": self.skip_existing,
+            "counts": {s: self.count(s)
+                       for s in (RENDERED, SKIPPED, PLANNED, ERROR, ABSENT)},
+            "figures": [asdict(r) for r in self.records],
+            **(extra or {}),
+        }
+        out_root.mkdir(parents=True, exist_ok=True)
+        path = out_root / f"manifest_{job}.json"
+        path.write_text(json.dumps(payload, indent=2, sort_keys=False), encoding="utf-8")
+        return path
+
+
+def _sha256(path) -> str | None:
+    """Hash a config so a manifest pins the exact settings a sweep ran under."""
+    if path is None:
+        return None
+    try:
+        return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def read_manifests(out_root) -> list[dict]:
+    """Every ``manifest_*.json`` under ``out_root``, oldest first."""
+    out_root = Path(out_root)
+    found = []
+    for path in sorted(out_root.glob("manifest_*.json")):
+        try:
+            found.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, ValueError) as exc:
+            print(f"[SKIP] unreadable manifest {path.name}: {exc}")
+    return found
+
+
+def report_coverage(out_root) -> int:
+    """Print what a sweep actually produced, across every job in ``out_root``.
+
+    This is the answer to "do we have all the plots?", which was previously
+    answerable only by ``find`` -- and ``find`` cannot distinguish a figure that
+    was never asked for from one that failed.
+    """
+    manifests = read_manifests(out_root)
+    if not manifests:
+        print(f"[report] no manifests under {out_root}")
+        return 1
+
+    print(f"[report] {len(manifests)} job(s) under {out_root}")
+    totals: dict[str, int] = {}
+    per_family: dict[str, dict[str, int]] = {}
+    for man in manifests:
+        argv = man.get("argv") or []
+        counts = man.get("counts", {})
+        summary = ", ".join(f"{v} {k}" for k, v in counts.items() if v)
+        print(f"  job {man.get('job', '?')} [{man.get('written_utc', '?')}] "
+              f"{summary or 'nothing'}")
+        if argv:
+            print(f"      argv: {' '.join(str(a) for a in argv)}")
+        for rec in man.get("figures", []):
+            status = rec.get("status", "?")
+            totals[status] = totals.get(status, 0) + 1
+            fam = per_family.setdefault(rec.get("family", "?"), {})
+            fam[status] = fam.get(status, 0) + 1
+
+    print("  per family:")
+    for fam in sorted(per_family):
+        detail = ", ".join(f"{v} {k}" for k, v in sorted(per_family[fam].items()))
+        print(f"    {fam:9s} {detail}")
+    print("  overall: " + (", ".join(f"{v} {k}" for k, v in sorted(totals.items()))
+                           or "nothing"))
+    failed = totals.get(ERROR, 0)
+    if failed:
+        print(f"  {failed} figure(s) errored -- see the job .err files")
+    return 1 if failed else 0
+
+
+def add_output_arguments(parser) -> None:
+    """Flags shared by both engines for idempotence, dry runs and reporting."""
+    parser.add_argument(
+        "--skip-existing", action="store_true",
+        help="keep figures already newer than every file they derive from; "
+             "makes a re-run after adding one family cheap",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="print the figures that would be rendered, then exit",
+    )
+    parser.add_argument(
+        "--allow-errors", action="store_true",
+        help="exit 0 even if some figures failed (default: any failure exits 1)",
+    )
+    parser.add_argument(
+        "--report", action="store_true",
+        help="summarise coverage from the manifests already in the output root, "
+             "then exit; renders nothing",
+    )
 
 
 def check_section_on_grid(plane, key: str, spec: dict, *, tag: str) -> bool:

--- a/docs/VISUAL-SUITE-SOP.md
+++ b/docs/VISUAL-SUITE-SOP.md
@@ -9,6 +9,9 @@ The pattern is settled and works: **capability in `brc-tools`, configuration in 
 case repo, figures outside every checkout, heavy work on a DTN.** What follows is
 the operating procedure plus an honest list of the gaps still in it.
 
+*Updated 2026-07-30: gaps 1–5 and 7–10 are closed (errors 11–16 below). What is left
+open is gap 5's cross-nest provenance half and gap 6, which needs no code.*
+
 ---
 
 ## The procedure
@@ -28,14 +31,27 @@ the operating procedure plus an honest list of the gaps still in it.
    seven families was never smoke-tested.
 4. **Narrow before you sweep.** `--figure` to select families, `--domain` to select
    nests, `--start`/`--end` to bound the window. A 1-minute sweep of a 5 h run is
-   301 times per domain; unbounded, that is thousands of figures.
+   301 times per domain; unbounded, that is thousands of figures. **`--dry-run`
+   prints the exact list a job would render** — cheaper than discovering the count
+   from a queue.
 5. **Submit to the DTN** (`scripts/*.dtn.slurm`). `lawson-group6` is read-only on
    the notchpeak login nodes, and `lawson-np` is the single node a WRF run occupies.
-6. **Check the `.err` before assuming success.** Family-level failures are caught
-   and printed per figure, so a job can exit 0 having rendered nothing useful.
-7. **Promote the keepers** to `$UB_WX_FIGS_KEEP`. Scratch is the mass output; no
+6. **Check the exit code, then the `.err`.** Per-figure failures are still caught
+   and printed so one bad panel cannot lose a run, but **any failure now exits
+   non-zero** and the `[tally]` line is the last thing printed. `--allow-errors`
+   opts out when some families are expected to fail.
+7. **Ask what you actually got: `--report`.** Every job writes
+   `manifest_<jobid>.json` into the output root, and `--report` summarises coverage
+   across all of them — per family, per status. This is the answer to "do we have
+   all the plots?", which `find` cannot give you because it cannot tell a figure
+   that was never asked for from one that failed.
+8. **Re-run with `--skip-existing`** after adding a family. A figure at least as new
+   as every file it derives from is kept; a `wrfout` rewritten by a later run is
+   newer than its figure, so that figure regenerates. Safe against a still-writing
+   job.
+9. **Promote the keepers** to `$UB_WX_FIGS_KEEP`. Scratch is the mass output; no
    figure images in git.
-8. **Write the finding, with its caveats, into the case's `notes.md`.**
+10. **Write the finding, with its caveats, into the case's `notes.md`.**
 
 ## Worked invocation — the Ashley suite
 
@@ -56,6 +72,9 @@ sbatch scripts/wrf_convective.dtn.slurm --config $CFG --output-dir $OUT \
 # window products: verification panels and the centroid table
 sbatch scripts/wrf_convective.dtn.slurm --config $CFG --output-dir $OUT \
     --figure verify --figure track --every 10
+
+# what did all of that actually produce?
+python scripts/wrf_convective.py --config $CFG --output-dir $OUT --report
 ```
 
 ---
@@ -82,6 +101,7 @@ job. All are fixed; they are recorded because the *class* of mistake will recur.
 | 13 | `REFD_COM` and `REFD_MAX` shared one style key | They are different quantities — the column max *at the output instant* vs. the max *over the interval since the last history write*. A run writing both plotted only one, under a label naming the wrong surface. Was open as gap 10 | fixed — separate `refl_comp_max` style |
 | 14 | The field→style and masking tables lived in the script, untested | Unavailable to other callers, and error 13 is exactly what goes unnoticed there. Was open as gap 9 | fixed — moved to `nwp/wrf_convective.py` with tests |
 | 15 | `verify` silently ignored the time-selection flags | `--valid X --figure verify` looked like it honoured `X`. Was open as gap 4 | fixed — says so in the log |
+| 16 | A sweep could not say what it had done | Four gaps (1, 2, 3, 8) with **one** root cause: every family rendered on its own — `try: plot(...); made += 1` / `except: print("[ERR]")` at a dozen sites — and reported only an `int`. With no chokepoint there was nowhere to put idempotence, a record, an error tally or a dry run, and `return 0 if total else 1` could not tell 400-of-400 from 100-of-400 | fixed — `wrf_engine.FigureLedger`, one seam for all four |
 
 ## Gaps still open
 
@@ -89,22 +109,12 @@ Ordered by how likely they are to bite. **Rank them by consequence instead** —
 closing section of this doc says why, and the five closed above (errors 11–15) were
 the ones that made a figure lie rather than the ones that made a sweep tedious.
 
-1. **No idempotence.** `wrf_figures.py` has `--skip-existing` (compares PNG mtime
-   against every source file); the winds and convective engines do not. Re-running a
-   sweep after adding one family re-renders everything. **Recommended:** lift
-   `_skip_existing` into `wrf_engine.py` and thread it through both engines.
-2. **No manifest of what was produced.** The pelican study keeps
-   `archive-inventory.md` by hand as its SSOT. A sweep that renders 400 figures
-   across four jobs leaves no machine-readable record of which times, families and
-   domains actually succeeded — so "do we have all the plots?" can only be answered
-   by `find`. **Recommended:** emit a `manifest.json` per job (config hash, run dir,
-   times, families, per-figure success/skip/error) and a `--report` mode that
-   summarises coverage.
-3. **Silent per-figure failure.** Each family catches exceptions and prints `[ERR]`,
-   which is right for robustness, but the exit code is 0 as long as *something*
-   rendered. A job that failed 300 of 400 figures looks like a success. **Recommended:**
-   return a non-zero exit when the error count exceeds a threshold, and print an
-   error tally at the end.
+1. ~~**No idempotence.**~~ **Closed** — error 16 below. `--skip-existing` on both
+   engines.
+2. ~~**No manifest of what was produced.**~~ **Closed** — error 16. Each job writes
+   `manifest_<jobid>.json` and `--report` summarises coverage across all of them.
+3. ~~**Silent per-figure failure.**~~ **Closed** — error 16. Any error now exits
+   non-zero (`--allow-errors` opts out) and the tally is the last line printed.
 4. ~~**`verify` ignores the time selection.**~~ **Closed** — error 15 above.
 5. **No cross-nest consistency check.** Nothing verifies that a figure labelled d02
    and one labelled d01 at the same valid time actually came from the same run.
@@ -120,9 +130,7 @@ the ones that made a figure lie rather than the ones that made a sweep tedious.
    a 2025 date (AWS denies anonymous access by bucket policy; the GCS mirror stops
    before Sept 2025), so 0.0° and 1.2° still have **no** observed counterpart. Only
    the silence about it is fixed. Transport table: `docs/nwp/NWP-SOURCE-MATRIX.md`.
-8. **No `--dry-run`.** There is no way to ask "what would this render?" before
-   committing a job. With four families × three views × 31 times the answer is not
-   obvious. **Recommended:** print the planned figure list and exit.
+8. ~~**No `--dry-run`.**~~ **Closed** — error 16.
 9. ~~**Tables live in the script, not the package.**~~ **Closed** — error 14 above.
 10. ~~**`REFD_COM` and `REFD_MAX` share a style.**~~ **Closed** — error 13 above.
 

--- a/docs/WRF-CONVECTIVE.md
+++ b/docs/WRF-CONVECTIVE.md
@@ -69,6 +69,31 @@ Times behave as in `wrf_winds.py`: a sweep takes the **union** across domains (s
 and with no time flag the latest time present on *every* requested domain is used.
 `--figure aux` on its own sweeps the auxiliary stream's own times.
 
+### Idempotence, dry runs and coverage
+
+Shared by both this engine and `wrf_winds.py` (`brc_tools.nwp.wrf_engine.FigureLedger`):
+
+| flag | what it does |
+|---|---|
+| `--dry-run` | print the exact figure list this job would render, then exit. Nothing is written — no PNGs, no manifest |
+| `--skip-existing` | keep a figure at least as new as every file it derives from. A `wrfout` rewritten by a later run is newer than its figure, so that figure regenerates — safe against a still-writing job |
+| `--allow-errors` | exit 0 even if some figures failed. Without it **any** failure exits non-zero |
+| `--report` | summarise coverage from the manifests already in the output root, then exit. Renders nothing |
+
+Every real job writes `manifest_<jobid>.json` into the output root — config path and
+SHA-256, run dir, argv, and one record per attempted figure with its family, domain,
+valid time, variable and status (`rendered` / `skipped` / `error` / `absent`). Named
+by `SLURM_JOB_ID`, so the normal pattern of several jobs sweeping into one output
+root does not clobber itself.
+
+`absent` is a distinct status on purpose: "this run never wrote that field" and
+"this figure failed" are different answers to *where is my figure?*, and `find`
+cannot tell them apart.
+
+Per-figure failures are still caught and printed, so one bad panel cannot lose a
+run. What changed is that the job can no longer *look* like a success — the old
+`return 0 if total else 1` could not distinguish 400-of-400 from 100-of-400.
+
 ## Case TOML schema
 
 Configuration only. A case names capability; it never defines it. In particular

--- a/docs/WRF-WINDS.md
+++ b/docs/WRF-WINDS.md
@@ -61,8 +61,9 @@ sbatch scripts/wrf_winds.dtn.slurm --config <case.toml> [--run-dir <run>] \
   hours, so intersecting would discard every sub-hourly frame the fine nest has.
   Each domain then renders only the times it holds, and the count of skipped
   domain-times is reported once at the end rather than per line.
-- Figures are simply overwritten, so re-running as the job advances costs nothing
-  but wall clock.
+- Figures are overwritten by default, so re-running as the job advances costs
+  nothing but wall clock. `--skip-existing` makes that re-run cheap instead: see
+  "Idempotence, dry runs and coverage" below.
 - `--valid` takes an exact `YYYY-MM-DD_HH:MM`; `--lead` takes **minutes** after
   init (`SIMULATION_START_DATE`, else the earliest wrfout).
 - With none of those, the engine renders **the latest valid time present on every
@@ -79,6 +80,32 @@ sbatch scripts/wrf_winds.dtn.slurm --config <case.toml> [--run-dir <run>] \
 Both wrfout filename conventions are read: WRF's default `%Y-%m-%d_%H:%M:%S` **and**
 the `nocolons = .true.` form `%Y-%m-%d_%H_%M_%S`. (`brc_tools.nwp.wrf_output` assumes
 the first; the tolerant helpers live in `wrf_section.py`.)
+
+### Idempotence, dry runs and coverage
+
+Shared by both this engine and `wrf_convective.py`
+(`brc_tools.nwp.wrf_engine.FigureLedger`):
+
+| flag | what it does |
+|---|---|
+| `--dry-run` | print the exact figure list this job would render, then exit. Nothing is written — no PNGs, no manifest |
+| `--skip-existing` | keep a figure at least as new as every file it derives from. A `wrfout` rewritten by a later run is newer than its figure, so that figure regenerates — safe against a still-writing job |
+| `--allow-errors` | exit 0 even if some figures failed. Without it **any** failure exits non-zero |
+| `--report` | summarise coverage from the manifests already in the output root, then exit. Renders nothing |
+
+Every real job writes `manifest_<jobid>.json` into the output root — config path and
+SHA-256, run dir, argv, and one record per attempted figure with its family, domain,
+valid time, variable and status (`rendered` / `skipped` / `error` / `absent`). Named
+by `SLURM_JOB_ID`, so the normal pattern of several jobs sweeping into one output
+root does not clobber itself.
+
+`absent` is a distinct status on purpose: "this run never wrote that field" and
+"this figure failed" are different answers to *where is my figure?*, and `find`
+cannot tell them apart.
+
+Per-figure failures are still caught and printed, so one bad panel cannot lose a
+run. What changed is that the job can no longer *look* like a success — the old
+`return 0 if total else 1` could not distinguish 400-of-400 from 100-of-400.
 
 ## Case TOML schema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,18 @@ authors = [
     {name = "Michael Davies"},
 ]
 license = {text = "MIT"}
-requires-python = ">=3.9"
+# 3.11+ is not aspirational: brc_tools/nwp/source.py -- which almost everything
+# imports -- has `import tomllib` at module scope, and tomllib landed in 3.11.
+# The package has never been installable on 3.9/3.10; the metadata just said
+# otherwise. Also what lets ruff sort tomllib as the stdlib import it is.
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
@@ -78,7 +81,7 @@ markers = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/scripts/wrf_convective.py
+++ b/scripts/wrf_convective.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import argparse
 import sys
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -111,9 +111,11 @@ def _plan_extra(ds, dom: dict) -> dict:
 # --------------------------------------------------------------------------- #
 # families
 # --------------------------------------------------------------------------- #
-def render_surface(cfg, dom, ds, out_dir, ctx, args, *, extra=None) -> int:
+def render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, *, extra=None,
+                   sources=()) -> int:
     """Plan views of whatever 2-D convective fields the run wrote."""
     tag, stamp, base, _short, annotation = ctx
+    number = int(dom["domain"])
     pds = ws.plan_dataset(ds, extra=extra if extra is not None else _plan_extra(ds, dom))
     extent = tuple(dom["extent"]) if dom.get("extent") else ws.plan_extent(
         ds, pad_deg=float(dom.get("pad_deg", 0.0))
@@ -124,24 +126,27 @@ def render_surface(cfg, dom, ds, out_dir, ctx, args, *, extra=None) -> int:
     for var in dom.get("surface_vars", ["refl_comp"]):
         if var not in pds:
             print(f"[SKIP] {tag} {var}: not written by this run")
+            ledger.note(we.ABSENT, "not written by this run",
+                        family="surface", domain=number, var=var)
             continue
         style = we.style_for(cfg, var)
-        try:
-            plot_nwp_surface_map(
-                pds, var, out_dir / f"plan_{var}_{tag}_{stamp}.png",
+        made += ledger.emit(
+            out_dir / f"plan_{var}_{tag}_{stamp}.png",
+            # var/style bound as defaults: this is a loop, and a late-binding
+            # closure would render the last variable once per iteration.
+            lambda path, var=var, style=style: plot_nwp_surface_map(
+                pds, var, path,
                 style=style, waypoints=wps,
                 barb_stride=int(dom.get("barb_stride", 8)),
                 extent=extent, overlays=overlays, annotation=annotation,
                 title=f"{base} | {style.label}", dpi=args.dpi,
-            )
-            made += 1
-        except Exception as exc:  # one bad panel is not a lost run
-            print(f"[ERR] plan {tag} {var}: {exc}")
-            traceback.print_exc()
+            ),
+            sources=sources, family="surface", domain=number, var=var,
+        )
     return made
 
 
-def render_aux(cfg, dom, valid, init, out_dir, args) -> int:
+def render_aux(cfg, dom, valid, init, out_dir, args, ledger) -> int:
     """Plan views from the high-cadence auxiliary stream.
 
     The point of this family is cadence: a ~3 km swath crossing a point in ~4
@@ -155,11 +160,14 @@ def render_aux(cfg, dom, valid, init, out_dir, args) -> int:
         aux, index = wc.open_auxhist(run_dir, number, valid, stream)
     except FileNotFoundError as exc:
         print(f"[SKIP] aux d{number:02d}: {exc}")
+        ledger.note(we.ABSENT, str(exc), family="aux", domain=number, valid=valid)
         return 0
     try:
         history = _nearest_history(run_dir, number, valid)
         if history is None:
             print(f"[SKIP] aux d{number:02d}: no history file to borrow coordinates from")
+            ledger.note(we.ABSENT, "no history file for coordinates",
+                        family="aux", domain=number, valid=valid)
             return 0
         # attach_grid_coords is called for its GRID-SHAPE CHECK, not for its
         # coordinates: plan_dataset builds latitude/longitude itself from the
@@ -170,11 +178,15 @@ def render_aux(cfg, dom, valid, init, out_dir, args) -> int:
         for name in dom.get("aux_fields", ["REFD_COM"]):
             if name not in aux:
                 print(f"[SKIP] aux d{number:02d} {name}: not in the stream")
+                ledger.note(we.ABSENT, "not in the stream", family="aux",
+                            domain=number, valid=valid, var=name)
                 continue
             try:
                 field = wc.aux_field(aux, name, index)
             except ValueError as exc:  # a *_MAX field: refused on purpose
                 print(f"[SKIP] aux d{number:02d} {name}: {exc}")
+                ledger.note(we.ABSENT, str(exc), family="aux",
+                            domain=number, valid=valid, var=name)
                 continue
             key = _SURFACE_FIELDS.get(name, name.lower())
             extra[key] = _masked(key, _echo_top_km(field) if name == "ECHOTOP" else field)
@@ -186,7 +198,13 @@ def render_aux(cfg, dom, valid, init, out_dir, args) -> int:
             aux_dom["tag"] = f"{ctx[0]}_aux"
             aux_dom["surface_vars"] = list(extra)
             ctx = (aux_dom["tag"], ctx[1], ctx[2], ctx[3], ctx[4])
-            return render_surface(cfg, aux_dom, ds_hist, out_dir, ctx, args, extra=extra)
+            # The aux file this frame came from, for --skip-existing. xarray
+            # records it on the dataset; a stream opened some other way just
+            # loses idempotence rather than breaking.
+            aux_src = aux.encoding.get("source")
+            return render_surface(cfg, aux_dom, ds_hist, out_dir, ctx, args, ledger,
+                                  extra=extra,
+                                  sources=[aux_src] if aux_src else [])
         finally:
             ds_hist.close()
     finally:
@@ -207,7 +225,7 @@ def _nearest_history(run_dir, domain: int, valid: datetime):
     return path if path.exists() else None
 
 
-def render_sections(cfg, dom, plane, out_dir, ctx, args) -> int:
+def render_sections(cfg, dom, plane, out_dir, ctx, args, ledger, *, sources=()) -> int:
     """Curtains along the named A->B transects."""
     tag, stamp, _base, short, annotation = ctx
     locator = dict(lon2d=plane.lon2d, lat2d=plane.lat2d, terrain2d=plane.terrain)
@@ -216,19 +234,23 @@ def render_sections(cfg, dom, plane, out_dir, ctx, args) -> int:
         spec = cfg["_sections"].get(key)
         if spec is None:
             print(f"[SKIP] {tag} section {key!r}: not in [[sections]]")
+            ledger.note(we.ABSENT, "not in [[sections]]", family="section", var=key)
             continue
         if not we.check_section_on_grid(plane, key, spec, tag=tag):
+            ledger.note(we.ABSENT, "transect does not intersect this nest",
+                        family="section", var=key)
             continue
         shade = spec.get("shade", "refl")
         wps = we.waypoints(spec.get("waypoint_group"))
-        try:
+
+        def _draw(path, spec=spec, key=key, shade=shade, wps=wps):
             section = ws.section_from_plane(
                 plane, tuple(spec["a"]), tuple(spec["b"]),
                 n_points=int(spec.get("n_points", 240)),
                 termini=tuple(spec.get("termini", ("A", "B"))),
             )
             plot_wrf_curtain(
-                section, out_dir / f"xsection_{shade}_{key}_{tag}_{stamp}.png",
+                section, path,
                 shade=shade,
                 style=we.style_for(cfg, spec.get("style", _shade_style(shade))),
                 title=f"{short} | {spec.get('label', key)}",
@@ -247,10 +269,12 @@ def render_sections(cfg, dom, plane, out_dir, ctx, args) -> int:
                 },
                 dpi=args.dpi,
             )
-            made += 1
-        except Exception as exc:
-            print(f"[ERR] xsection {tag} {key}: {exc}")
-            traceback.print_exc()
+
+        made += ledger.emit(
+            out_dir / f"xsection_{shade}_{key}_{tag}_{stamp}.png",
+            _draw, sources=sources, family="section",
+            domain=int(dom["domain"]), var=key,
+        )
     return made
 
 
@@ -274,7 +298,7 @@ def _observed_elevations(spec: dict) -> set[float] | None:
     return iem.observed_elevations()
 
 
-def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
+def render_beams(cfg, dom, ds, plane, out_dir, ctx, args, ledger, *, sources=()) -> int:
     """Simulated reflectivity sampled on a radar's beam surfaces.
 
     This is the family that exists so a comparison against a distant WSR-88D is
@@ -285,6 +309,8 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
     tag, stamp, _base, _short, annotation = ctx
     if plane.refl is None:
         print(f"[SKIP] {tag} beams: run has no REFL_10CM (needs do_radar_ref = 1)")
+        ledger.note(we.ABSENT, "run has no REFL_10CM (needs do_radar_ref = 1)",
+                    family="beam", domain=int(dom["domain"]))
         return 0
 
     extent = tuple(dom["extent"]) if dom.get("extent") else ws.plan_extent(
@@ -297,6 +323,7 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
         spec = cfg["_beams"].get(key)
         if spec is None:
             print(f"[SKIP] {tag} beam {key!r}: not in [[beams]]")
+            ledger.note(we.ABSENT, "not in [[beams]]", family="beam", var=key)
             continue
         site = get_site(spec["site"])
         # Which tilts an observed panel could exist for at all.  A model beam with
@@ -305,7 +332,8 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
         # invites exactly the "verified against radar" claim CHK-BEAM forbids.
         served = _observed_elevations(spec)
         for elev in spec.get("elevations_deg", [0.5]):
-            try:
+
+            def _draw(path, elev=elev, site=site, served=served):
                 surface = rb.beam_surface_asl(plane.lat2d, plane.lon2d, site, float(elev))
                 sampled = _masked("refl_beam", rb.sample_on_beam(plane.refl, plane.height, surface))
                 agl = surface - plane.terrain
@@ -331,17 +359,21 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args) -> int:
                     title=f"{_short} | {site.id} {float(elev):g} deg beam surface",
                     dpi=args.dpi,
                 )
-                made += 1
-            except Exception as exc:
-                print(f"[ERR] beam {tag} {site.id} {elev}: {exc}")
-                traceback.print_exc()
+
+            made += ledger.emit(
+                out_dir / f"beam_{site.id}_{float(elev):g}deg_{tag}_{stamp}.png",
+                _draw, sources=sources, family="beam",
+                domain=int(dom["domain"]), var=f"{site.id}_{float(elev):g}deg",
+            )
 
         if spec.get("compare_observed"):
-            made += _render_observed(cfg, spec, site, extent, wps, overlays, ctx, out_dir, args)
+            made += _render_observed(cfg, spec, site, extent, wps, overlays, ctx,
+                                     out_dir, args, ledger)
     return made
 
 
-def _render_observed(cfg, spec, site, extent, wps, overlays, ctx, out_dir, args) -> int:
+def _render_observed(cfg, spec, site, extent, wps, overlays, ctx, out_dir, args,
+                     ledger) -> int:
     """Observed Level-III reflectivity at the same tilt, on the same colour scale.
 
     Uses the Iowa State IEM RIDGE archive, which carries elevation 1 (0.5 deg) for
@@ -364,16 +396,20 @@ def _render_observed(cfg, spec, site, extent, wps, overlays, ctx, out_dir, args)
         )
     except Exception as exc:  # noqa: BLE001 - obs are a bonus, never a precondition
         print(f"[SKIP] observed {site.id} {product}: {type(exc).__name__}: {exc}")
+        ledger.note(we.ABSENT, f"{type(exc).__name__}: {exc}", family="observed",
+                    valid=valid, var=f"{site.id}_{product}")
         return 0
     if field is None:
         print(f"[SKIP] observed {site.id} {product}: no scan within the window of {stamp}")
+        ledger.note(we.ABSENT, "no scan within the window", family="observed",
+                    valid=valid, var=f"{site.id}_{product}")
         return 0
 
     lag = (field.valid_time - valid).total_seconds() / 60.0
-    try:
+
+    def _draw(path, field=field):
         plot_nwp_surface_map(
-            iem.to_plan_dataset(field), "refl_beam",
-            out_dir / f"observed_{site.id}_{product}_{stamp}.png",
+            iem.to_plan_dataset(field), "refl_beam", path,
             style=we.style_for(cfg, "refl_beam"), waypoints=wps,
             extent=extent, overlays=overlays, terrain_contours=False,
             annotation=(
@@ -383,14 +419,16 @@ def _render_observed(cfg, spec, site, extent, wps, overlays, ctx, out_dir, args)
             title=f"OBSERVED {site.id} {product} {field.elevation_deg:g} deg | {short}",
             dpi=args.dpi,
         )
-        return 1
-    except Exception as exc:
-        print(f"[ERR] observed {site.id} {product}: {exc}")
-        traceback.print_exc()
-        return 0
+
+    # No `sources`: this figure derives from an archive fetch, not a local file,
+    # so mtime idempotence cannot apply and --skip-existing keeps any existing one.
+    return ledger.emit(
+        out_dir / f"observed_{site.id}_{product}_{stamp}.png",
+        _draw, family="observed", valid=valid, var=f"{site.id}_{product}",
+    )
 
 
-def render_soundings(cfg, dom, ds, out_dir, ctx, args) -> int:
+def render_soundings(cfg, dom, ds, out_dir, ctx, args, ledger, *, sources=()) -> int:
     """Skew-T with a parcel path, plus a hodograph, at named points."""
     tag, stamp, _base, short, annotation = ctx
     made = 0
@@ -398,9 +436,24 @@ def render_soundings(cfg, dom, ds, out_dir, ctx, args) -> int:
         spec = cfg["_soundings"].get(key)
         if spec is None:
             print(f"[SKIP] {tag} sounding {key!r}: not in [[soundings]]")
+            ledger.note(we.ABSENT, "not in [[soundings]]", family="sounding", var=key)
             continue
         point = we.waypoint(spec["waypoint"])
         parcel = spec.get("parcel", "ml")
+        skewt_png = out_dir / f"skewt_{key}_{tag}_{stamp}.png"
+        hodo_png = out_dir / f"hodograph_{key}_{tag}_{stamp}.png"
+
+        # Both figures come from one expensive column extraction plus a MetPy
+        # parcel lift, so check idempotence BEFORE paying for it rather than
+        # inside emit() -- this is the family where skipping actually saves time.
+        if ledger.skip_existing and all(
+            ledger.is_current(png, sources) for png in (skewt_png, hodo_png)
+        ):
+            for var in (key, f"{key}_hodograph"):
+                ledger.note(we.SKIPPED, "up to date", family="sounding",
+                            domain=int(dom["domain"]), var=var)
+            continue
+
         try:
             column = wo.extract_column(ds, point["lat"], point["lon"], label=key)
             summary = ce.environment_summary(column, parcel)
@@ -414,37 +467,53 @@ def render_soundings(cfg, dom, ds, out_dir, ctx, args) -> int:
                 column, source=f"WRF {tag}", station=key,
                 valid_time=datetime.strptime(stamp, "%Y%m%d_%H%M"),
             )
-            plot_skewt(
-                sounding, out_dir / f"skewt_{key}_{tag}_{stamp}.png",
-                title=f"{short} | {spec.get('label', key)} | {parcel} parcel",
-                annotation=note, parcel=parcel, mark_levels=True, shade_cape=True,
-                p_top_hpa=float(spec.get("p_top_hpa", 150.0)),
-                t_range=tuple(spec.get("t_range", (-50.0, 30.0))),
-                dpi=args.dpi,
+            made += ledger.emit(
+                skewt_png,
+                # Loop variables bound as defaults throughout: emit() calls this
+                # synchronously so late binding would be harmless today, but it is
+                # one refactor away from not being.
+                lambda path, sounding=sounding, spec=spec, key=key,
+                parcel=parcel, note=note: plot_skewt(
+                    sounding, path,
+                    title=f"{short} | {spec.get('label', key)} | {parcel} parcel",
+                    annotation=note, parcel=parcel, mark_levels=True, shade_cape=True,
+                    p_top_hpa=float(spec.get("p_top_hpa", 150.0)),
+                    t_range=tuple(spec.get("t_range", (-50.0, 30.0))),
+                    dpi=args.dpi,
+                ),
+                sources=sources, family="sounding",
+                domain=int(dom["domain"]), var=key,
             )
-            made += 1
 
             motion = ce.bunkers_storm_motion(column)
             observed = spec.get("observed_motion_ms")
-            plot_hodograph(
-                column.u_kt / 1.94384, column.v_kt / 1.94384,
-                column.height_asl - column.terrain_m,
-                out_dir / f"hodograph_{key}_{tag}_{stamp}.png",
-                title=f"{short} | {spec.get('label', key)}",
-                max_height_m=float(spec.get("hodograph_top_m", 9000.0)),
-                storm_motion=(motion.right_u, motion.right_v),
-                observed_motion=tuple(observed) if observed else None,
-                observed_motion_label=spec.get("observed_motion_label", "observed"),
-                annotation=(
-                    f"0-6 km shear {summary['shear_mag_0to6km']:.1f} m/s | "
-                    f"SRH 0-3 km {summary['srh_0to3km']:.0f} m2/s2"
+            made += ledger.emit(
+                hodo_png,
+                lambda path, column=column, spec=spec, key=key, motion=motion,
+                observed=observed, summary=summary: plot_hodograph(
+                    column.u_kt / 1.94384, column.v_kt / 1.94384,
+                    column.height_asl - column.terrain_m, path,
+                    title=f"{short} | {spec.get('label', key)}",
+                    max_height_m=float(spec.get("hodograph_top_m", 9000.0)),
+                    storm_motion=(motion.right_u, motion.right_v),
+                    observed_motion=tuple(observed) if observed else None,
+                    observed_motion_label=spec.get("observed_motion_label", "observed"),
+                    annotation=(
+                        f"0-6 km shear {summary['shear_mag_0to6km']:.1f} m/s | "
+                        f"SRH 0-3 km {summary['srh_0to3km']:.0f} m2/s2"
+                    ),
+                    dpi=args.dpi,
                 ),
-                dpi=args.dpi,
+                sources=sources, family="sounding",
+                domain=int(dom["domain"]), var=f"{key}_hodograph",
             )
-            made += 1
         except Exception as exc:
+            # Setup failed (column extraction or the parcel lift), so neither
+            # figure exists; emit() never saw it.
             print(f"[ERR] sounding {tag} {key}: {exc}")
             traceback.print_exc()
+            ledger.note(we.ERROR, f"{type(exc).__name__}: {exc}", family="sounding",
+                        domain=int(dom["domain"]), var=key)
     return made
 
 
@@ -453,7 +522,7 @@ _PAIR_COLOURS = ("#1f77b4", "#d62728", "#2ca02c", "#9467bd", "#ff7f0e",
                  "#8c564b", "#17becf", "#e377c2")
 
 
-def render_verify(cfg, out_dir, args) -> int:
+def render_verify(cfg, out_dir, args, ledger) -> int:
     """Model surface traces against observations at the named stations.
 
     Model values come from the ``tslist`` traces, written every model time step --
@@ -522,20 +591,30 @@ def render_verify(cfg, out_dir, args) -> int:
                     styles[obs_label] = dict(color=colour, ls="--", lw=1.1, marker="o", ms=3.0)
 
             if not series:
+                ledger.note(we.ABSENT, "no model trace for any station",
+                            family="verify", var=key)
                 continue
             drawn = sorted({s for s in obs if any(
                 st.get("stid") == s for st in entry["stations"])})
             print(f"  verify {key}: observations for {drawn or 'NONE (model only)'}")
-            plot_scalar_timeseries(
-                series, out_dir / f"verify_{key}_{variable}.png",
-                ylabel=_ts_label(cfg, variable),
-                title=f"{cfg['case']['label']} | {entry.get('label', key)}",
-                run_styles=styles, figsize=(10.0, 5.0), dpi=args.dpi,
+            made += ledger.emit(
+                out_dir / f"verify_{key}_{variable}.png",
+                lambda path, series=series, styles=styles, entry=entry,
+                key=key, variable=variable: plot_scalar_timeseries(
+                    series, path,
+                    ylabel=_ts_label(cfg, variable),
+                    title=f"{cfg['case']['label']} | {entry.get('label', key)}",
+                    run_styles=styles, figsize=(10.0, 5.0), dpi=args.dpi,
+                ),
+                # The .TS traces grow while a run integrates, so no mtime
+                # idempotence here: a verify panel is always worth redrawing.
+                family="verify", domain=domain, var=key,
             )
-            made += 1
         except Exception as exc:
             print(f"[ERR] verify {key}: {exc}")
             traceback.print_exc()
+            ledger.note(we.ERROR, f"{type(exc).__name__}: {exc}",
+                        family="verify", var=key)
     return made
 
 
@@ -600,7 +679,7 @@ def _ts_style(variable: str) -> str:
     )
 
 
-def render_track(cfg, dom, times, out_dir, args) -> int:
+def render_track(cfg, dom, times, out_dir, args, ledger) -> int:
     """Reflectivity-centroid track over the window, written as a CSV.
 
     Deliberately a table rather than a figure: this is what sizes a nested domain,
@@ -644,44 +723,52 @@ def render_track(cfg, dom, times, out_dir, args) -> int:
             rows.append((valid, lat, lon, int(cells), float(np.nanmax(field))))
 
     if not rows:
+        ledger.note(we.ABSENT, "no times carried reflectivity", family="track",
+                    domain=number)
         return 0
-    out = out_dir / f"track_d{number:02d}.csv"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    with out.open("w", encoding="utf-8") as handle:
-        handle.write("valid_utc,centroid_lat,centroid_lon,cells_above_threshold,max_dbz\n")
-        for valid, lat, lon, cells, peak in rows:
-            lat_s = "" if lat is None else f"{lat:.5f}"
-            lon_s = "" if lon is None else f"{lon:.5f}"
-            handle.write(f"{valid:%Y-%m-%dT%H:%MZ},{lat_s},{lon_s},{cells},{peak:.1f}\n")
-    print(f"  track: {len(rows)} times -> {out}")
-    return 1
+
+    def _write(path):
+        with path.open("w", encoding="utf-8") as handle:
+            handle.write("valid_utc,centroid_lat,centroid_lon,cells_above_threshold,max_dbz\n")
+            for valid, lat, lon, cells, peak in rows:
+                lat_s = "" if lat is None else f"{lat:.5f}"
+                lon_s = "" if lon is None else f"{lon:.5f}"
+                handle.write(f"{valid:%Y-%m-%dT%H:%MZ},{lat_s},{lon_s},{cells},{peak:.1f}\n")
+        print(f"  track: {len(rows)} times -> {path}")
+
+    return ledger.emit(
+        out_dir / f"track_d{number:02d}.csv", _write,
+        family="track", domain=number,
+    )
 
 
 # --------------------------------------------------------------------------- #
 # driver
 # --------------------------------------------------------------------------- #
-def render_domain(cfg, dom, valid, init, out_root, families, args) -> int:
+def render_domain(cfg, dom, valid, init, out_root, families, args, ledger) -> int:
     run_dir = cfg["case"]["run_dir"]
     number = int(dom["domain"])
     path = ws.wrfout_path(run_dir, number, valid)
 
     if "aux" in families and not path.exists():
         # The auxiliary stream can hold times the history stream does not.
-        return render_aux(cfg, dom, valid, init, out_root / f"{valid:%Y%m%d_%H%M}", args)
+        return render_aux(cfg, dom, valid, init,
+                          out_root / f"{valid:%Y%m%d_%H%M}", args, ledger)
     if not path.exists():
         return 0
 
+    src = [path]  # every history-stream figure derives from this one file
     ds = wo.open_wrfout(path)
     try:
         ctx = _titles(cfg, dom, ds, valid, init)
         out_dir = out_root / ctx[1] / ctx[0]
         made = 0
         if "surface" in families:
-            made += render_surface(cfg, dom, ds, out_dir, ctx, args)
+            made += render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, sources=src)
         if "aux" in families:
-            made += render_aux(cfg, dom, valid, init, out_root / ctx[1], args)
+            made += render_aux(cfg, dom, valid, init, out_root / ctx[1], args, ledger)
         if "sounding" in families:
-            made += render_soundings(cfg, dom, ds, out_dir, ctx, args)
+            made += render_soundings(cfg, dom, ds, out_dir, ctx, args, ledger, sources=src)
 
         wants_plane = ("section" in families and dom.get("sections")) or (
             "beam" in families and dom.get("beams")
@@ -689,9 +776,11 @@ def render_domain(cfg, dom, valid, init, out_root, families, args) -> int:
         if wants_plane:
             plane = ws.load_plane(ds)  # the expensive read, shared by both families
             if "section" in families:
-                made += render_sections(cfg, dom, plane, out_dir, ctx, args)
+                made += render_sections(cfg, dom, plane, out_dir, ctx, args, ledger,
+                                        sources=src)
             if "beam" in families:
-                made += render_beams(cfg, dom, ds, plane, out_dir, ctx, args)
+                made += render_beams(cfg, dom, ds, plane, out_dir, ctx, args, ledger,
+                                     sources=src)
         print(f"  {ctx[0]}: {made} figures -> {out_dir}")
         return made
     finally:
@@ -714,6 +803,7 @@ def main() -> int:
                         help="override every section's vertical exaggeration; a "
                              "convective updraft wants ~5, a drainage night ~100")
     parser.add_argument("--dpi", type=int, default=200)
+    we.add_output_arguments(parser)
     args = parser.parse_args()
 
     cfg = we.load_config(args.config, index=("sections", "beams", "soundings"))
@@ -737,6 +827,12 @@ def main() -> int:
     use_publication_style(dpi=args.dpi)
     out_root = we.output_root(cfg, args.output_dir, config_path=args.config)
 
+    # --report reads what previous jobs recorded; it renders nothing.
+    if args.report:
+        return we.report_coverage(out_root)
+
+    ledger = we.FigureLedger(skip_existing=args.skip_existing, dry_run=args.dry_run)
+
     # Sweeping the auxiliary stream alone needs its times, not the history's.
     aux_only = families == {"aux"}
     times = we.select_times(
@@ -757,10 +853,10 @@ def main() -> int:
     total = 0
     for valid in times:
         for dom in domains:
-            total += render_domain(cfg, dom, valid, init, out_root, families, args)
+            total += render_domain(cfg, dom, valid, init, out_root, families, args, ledger)
 
     if "verify" in families:
-        total += render_verify(cfg, out_root, args)
+        total += render_verify(cfg, out_root, args, ledger)
     if "track" in families:
         # One CSV per NEST, not per view: a nest may appear as several [[domains]]
         # entries (full extent plus a zoom) and they would otherwise overwrite each
@@ -771,10 +867,20 @@ def main() -> int:
             if number in seen_domains:
                 continue
             seen_domains.add(number)
-            total += render_track(cfg, dom, times, out_root, args)
+            total += render_track(cfg, dom, times, out_root, args, ledger)
 
+    if args.dry_run:
+        print(f"[dry ] {ledger.count(we.PLANNED)} figure(s) would be rendered:")
+        for line in ledger.planned_lines():
+            print(line)
+    else:
+        manifest = ledger.write_manifest(
+            out_root, config_path=args.config, run_dir=run_dir, argv=sys.argv[1:],
+        )
+        print(f"[man ] {manifest}")
     print(f"[done] {total} output(s) -> {out_root}")
-    return 0 if total else 1
+    print(ledger.summarise())
+    return ledger.exit_code(allow_errors=args.allow_errors)
 
 
 if __name__ == "__main__":

--- a/scripts/wrf_winds.py
+++ b/scripts/wrf_winds.py
@@ -24,21 +24,19 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-import tomllib
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import numpy as np  # noqa: E402
 
 from brc_tools.nwp import wrf_engine as we  # noqa: E402
 from brc_tools.nwp import wrf_output as wo  # noqa: E402
 from brc_tools.nwp import wrf_section as ws  # noqa: E402
 from brc_tools.visualize import coldpool3d as cp3  # noqa: E402
 from brc_tools.visualize.nwp_maps import plot_nwp_surface_map  # noqa: E402
-from brc_tools.visualize.style import VarStyle, get_style, use_publication_style  # noqa: E402
+from brc_tools.visualize.style import use_publication_style  # noqa: E402
 from brc_tools.visualize.wrf_curtain import plot_wrf_curtain  # noqa: E402
 
 # Config, waypoints, colour scales and time selection are shared with the
@@ -82,7 +80,7 @@ def select_times(run_dir: Path, domains: list[int], args) -> list[datetime]:
 # rendering
 # --------------------------------------------------------------------------- #
 def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
-                  out_root: Path, args) -> int:
+                  out_root: Path, args, ledger) -> int:
     run_dir = cfg["case"]["run_dir"]
     d = int(dom["domain"])
     path = ws.wrfout_path(run_dir, d, valid)
@@ -107,6 +105,7 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
         overlays = {k: bool(cfg.get("map", {}).get(k, False)) for k in _MAP_LAYERS}
         out_dir = out_root / stamp / tag
         made = 0
+        src = [path]  # every figure for this view derives from this one file
 
         # -- plan views -----------------------------------------------------
         pad = float(dom.get("pad_deg", 0.0))
@@ -116,19 +115,20 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
         for var in dom.get("surface_vars", ["wind_speed_10m"]):
             if var not in pds:
                 print(f"[SKIP] {tag} {var}: not written by this run")
+                ledger.note(we.ABSENT, "not written by this run",
+                            family="topdown", domain=d, var=var)
                 continue
             st = style_for(cfg, var)
-            try:
-                plot_nwp_surface_map(
-                    pds, var, out_dir / f"topdown_{var}_{tag}_{stamp}.png",
+            made += ledger.emit(
+                out_dir / f"topdown_{var}_{tag}_{stamp}.png",
+                lambda path, var=var, st=st: plot_nwp_surface_map(
+                    pds, var, path,
                     style=st, waypoints=map_wps,
                     barb_stride=int(dom.get("barb_stride", 6)),
                     extent=extent, overlays=overlays, annotation=an,
-                    title=f"{base} | {st.label}", dpi=args.dpi)
-                made += 1
-            except Exception as exc:  # keep going: one bad panel is not a lost run
-                print(f"[ERR] topdown {tag} {var}: {exc}")
-                traceback.print_exc()
+                    title=f"{base} | {st.label}", dpi=args.dpi),
+                sources=src, family="topdown", domain=d, var=var,
+            )
 
         # -- cross-sections + 3-D cold-pool views ----------------------------
         keys = dom.get("sections", [])
@@ -140,17 +140,22 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                 s = cfg["_sections"].get(key)
                 if s is None:
                     print(f"[SKIP] {tag} section {key!r}: not in [[sections]]")
+                    ledger.note(we.ABSENT, "not in [[sections]]",
+                                family="section", domain=d, var=key)
                     continue
                 if not we.check_section_on_grid(plane, key, s, tag=tag):
+                    ledger.note(we.ABSENT, "transect does not intersect this nest",
+                                family="section", domain=d, var=key)
                     continue
                 sec_wps = waypoints(s.get("waypoint_group"))
-                try:
+
+                def _draw(path, s=s, key=key, sec_wps=sec_wps):
                     sec = ws.section_from_plane(
                         plane, tuple(s["a"]), tuple(s["b"]),
                         n_points=int(s.get("n_points", 240)),
                         termini=tuple(s.get("termini", ("A", "B"))))
                     plot_wrf_curtain(
-                        sec, out_dir / f"xsection_{key}_{tag}_{stamp}.png",
+                        sec, path,
                         shade=s.get("shade", "speed"),
                         style=style_for(cfg, "wind_speed_10m"),
                         title=f"{sec_base} | {s.get('label', key)}",
@@ -166,41 +171,48 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                                  "rect": list(s["loc_rect"]) if s.get("loc_rect") else None,
                                  "waypoints": sec_wps},
                         dpi=args.dpi)
-                    made += 1
-                except Exception as exc:
-                    print(f"[ERR] xsection {tag} {key}: {exc}")
-                    traceback.print_exc()
+
+                made += ledger.emit(
+                    out_dir / f"xsection_{key}_{tag}_{stamp}.png",
+                    _draw, sources=src, family="section", domain=d, var=key,
+                )
             made += render_views3d(cfg, v3d, plane, tag, stamp, sec_base, an,
-                                   out_dir, args)
+                                   out_dir, args, ledger, domain=d, sources=src)
         print(f"  {tag}: {made} figures -> {out_dir}")
         return made
     finally:
         ds.close()
 
 
-def render_views3d(cfg, keys, plane, tag, stamp, sec_base, an, out_dir, args) -> int:
+def render_views3d(cfg, keys, plane, tag, stamp, sec_base, an, out_dir, args,
+                   ledger, *, domain=None, sources=()) -> int:
     """Render the ``[[views3d]]`` cold-pool panels for one domain and time."""
     made = 0
     for key in keys:
         v = cfg["_views3d"].get(key)
         if v is None:
             print(f"[SKIP] {tag} view3d {key!r}: not in [[views3d]]")
+            ledger.note(we.ABSENT, "not in [[views3d]]", family="view3d",
+                        domain=domain, var=key)
             continue
         try:
             rows, cols = cp3.extent_window(plane.lon2d, plane.lat2d, tuple(v["extent"]))
         except Exception as exc:
             print(f"[ERR] view3d {tag} {key}: {exc}")
+            ledger.note(we.ERROR, f"{type(exc).__name__}: {exc}", family="view3d",
+                        domain=domain, var=key)
             continue
         lon, lat = plane.lon2d[rows, cols], plane.lat2d[rows, cols]
         terr = plane.terrain[rows, cols]
         theta, height = plane.theta[:, rows, cols], plane.height[:, rows, cols]
         for iso in (args.theta_iso or v.get("theta_iso", [310.0])):
-            try:
+
+            def _draw(path, iso=iso, v=v, key=key, lon=lon, lat=lat, terr=terr,
+                      theta=theta, height=height):
                 lid = cp3.isentrope_lid(theta, height, terr, float(iso),
                                         max_depth_m=float(v.get("max_depth_m", 1500.0)))
                 cp3.plot_coldpool_3d(
-                    lon, lat, terr, lid,
-                    out_dir / f"coldpool3d_{key}_th{float(iso):g}_{tag}_{stamp}.png",
+                    lon, lat, terr, lid, path,
                     theta_iso=float(iso),
                     title=(f"{sec_base} | {v.get('label', key)} | "
                            rf"cold air below $\theta$ = {float(iso):g} K"),
@@ -212,10 +224,12 @@ def render_views3d(cfg, keys, plane, tag, stamp, sec_base, an, out_dir, args) ->
                     depth_min_m=float(v.get("depth_min_m", 25.0)),
                     depth_max_m=float(v.get("depth_max_m", 600.0)),
                     dpi=args.dpi)
-                made += 1
-            except Exception as exc:
-                print(f"[ERR] view3d {tag} {key} theta={iso}: {exc}")
-                traceback.print_exc()
+
+            made += ledger.emit(
+                out_dir / f"coldpool3d_{key}_th{float(iso):g}_{tag}_{stamp}.png",
+                _draw, sources=sources, family="view3d", domain=domain,
+                var=f"{key}_th{float(iso):g}",
+            )
     return made
 
 
@@ -245,6 +259,7 @@ def main() -> int:
                          "value is regime-dependent: a convective afternoon resolves "
                          "w ~ 1 m/s and wants ~10, a quiescent drainage night ~100.")
     ap.add_argument("--dpi", type=int, default=200)
+    we.add_output_arguments(ap)
     args = ap.parse_args()
 
     cfg = load_config(args.config)
@@ -267,6 +282,12 @@ def main() -> int:
                 if (args.output_dir or cfg["case"].get("output_dir"))
                 else DEFAULT_OUTPUT_ROOT / cfg["case"]["slug"])
 
+    # --report reads what previous jobs recorded; it renders nothing.
+    if args.report:
+        return we.report_coverage(out_root)
+
+    ledger = we.FigureLedger(skip_existing=args.skip_existing, dry_run=args.dry_run)
+
     print(f"[run ] {run_dir}")
     print(f"[init] {init:{_TIME_FMT}}")
     total, absent = 0, 0
@@ -279,18 +300,33 @@ def main() -> int:
             # the log -- so count it and report the total once at the end.
             if not ws.wrfout_path(run_dir, int(dom["domain"]), valid).exists():
                 absent += 1
+                ledger.note(we.ABSENT, "no wrfout at this domain/time",
+                            family="domain", domain=int(dom["domain"]), valid=valid)
                 continue
             # One bad time (a wrfout caught half-written by the running job, say)
             # must not take the rest of the sweep down with it.
             try:
-                total += render_domain(cfg, dom, valid, init, out_root, args)
+                total += render_domain(cfg, dom, valid, init, out_root, args, ledger)
             except Exception as exc:
                 print(f"[ERR] {dom.get('tag', dom['domain'])} {valid:{_TIME_FMT}}: {exc}")
                 traceback.print_exc()
+                ledger.note(we.ERROR, f"{type(exc).__name__}: {exc}",
+                            family="domain", domain=int(dom["domain"]), valid=valid)
+
+    if args.dry_run:
+        print(f"\n[dry ] {ledger.count(we.PLANNED)} figure(s) would be rendered:")
+        for line in ledger.planned_lines():
+            print(line)
+    else:
+        manifest = ledger.write_manifest(
+            out_root, config_path=args.config, run_dir=run_dir, argv=sys.argv[1:],
+        )
+        print(f"[man ] {manifest}")
     print(f"\nDone. {total} figures over {len(times)} time(s) -> {out_root}")
     if absent:
         print(f"({absent} view-times skipped: no wrfout at that domain/time)")
-    return 0 if total else 1
+    print(ledger.summarise())
+    return ledger.exit_code(allow_errors=args.allow_errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_wrf_engine.py
+++ b/tests/test_wrf_engine.py
@@ -4,6 +4,8 @@ Covers the parts both the winds and convective engines depend on, so a change th
 breaks one is caught rather than discovered on a compute node.
 """
 
+import json
+import os
 from datetime import datetime, timedelta
 
 import pytest
@@ -293,3 +295,177 @@ class TestSectionPreflight:
     def test_n_points_defaults_when_the_case_omits_it(self):
         spec = {"a": (40.1, -109.9), "b": (40.4, -109.6)}
         assert we.check_section_on_grid(self._plane(), "valley", spec, tag="d02") is True
+
+
+class TestFigureLedger:
+    """The render chokepoint: idempotence, manifest, tally and dry run.
+
+    These were four separate gaps in the SOP because each family rendered on its
+    own and reported an int. They are one seam.
+    """
+
+    @staticmethod
+    def _ok(text="fig"):
+        def render(path):
+            path.write_text(text, encoding="utf-8")
+        return render
+
+    @staticmethod
+    def _boom(path):
+        raise RuntimeError("renderer exploded")
+
+    # -- rendering ---------------------------------------------------------- #
+    def test_a_successful_render_writes_and_counts(self, tmp_path):
+        led = we.FigureLedger()
+        out = tmp_path / "sub" / "a.png"
+        assert led.emit(out, self._ok(), family="surface") == 1
+        assert out.read_text() == "fig"          # parent dir created for it
+        assert led.rendered == 1 and led.errors == 0
+
+    def test_a_failing_render_is_caught_and_recorded_not_raised(self, tmp_path):
+        led = we.FigureLedger()
+        assert led.emit(tmp_path / "a.png", self._boom, family="beam") == 0
+        assert led.errors == 1 and led.rendered == 0
+        assert "RuntimeError" in led.records[0].detail
+
+    def test_one_bad_figure_does_not_stop_the_others(self, tmp_path):
+        led = we.FigureLedger()
+        led.emit(tmp_path / "a.png", self._boom, family="beam")
+        led.emit(tmp_path / "b.png", self._ok(), family="beam")
+        assert (led.rendered, led.errors) == (1, 1)
+
+    # -- idempotence (gap 1) ------------------------------------------------ #
+    def test_without_skip_existing_it_re_renders(self, tmp_path):
+        out, src = tmp_path / "a.png", tmp_path / "wrfout"
+        src.write_text("x")
+        out.write_text("old")
+        we.FigureLedger().emit(out, self._ok("new"), sources=[src], family="surface")
+        assert out.read_text() == "new"
+
+    def test_skip_existing_keeps_a_figure_newer_than_its_source(self, tmp_path):
+        out, src = tmp_path / "a.png", tmp_path / "wrfout"
+        src.write_text("x")
+        out.write_text("old")
+        os.utime(src, (1000, 1000))
+        os.utime(out, (2000, 2000))
+        led = we.FigureLedger(skip_existing=True)
+        assert led.emit(out, self._ok("new"), sources=[src], family="surface") == 0
+        assert out.read_text() == "old"
+        assert led.count(we.SKIPPED) == 1
+
+    def test_a_source_rewritten_later_forces_a_re_render(self, tmp_path):
+        # The run is still writing: a newer wrfout must beat an older figure.
+        out, src = tmp_path / "a.png", tmp_path / "wrfout"
+        out.write_text("old")
+        src.write_text("x")
+        os.utime(out, (1000, 1000))
+        os.utime(src, (2000, 2000))
+        led = we.FigureLedger(skip_existing=True)
+        assert led.emit(out, self._ok("new"), sources=[src], family="surface") == 1
+        assert out.read_text() == "new"
+
+    def test_a_missing_source_is_not_current(self, tmp_path):
+        out = tmp_path / "a.png"
+        out.write_text("old")
+        led = we.FigureLedger(skip_existing=True)
+        assert not led.is_current(out, [tmp_path / "gone"])
+
+    # -- dry run (gap 8) ---------------------------------------------------- #
+    def test_dry_run_plans_without_writing(self, tmp_path):
+        led = we.FigureLedger(dry_run=True)
+        out = tmp_path / "a.png"
+        assert led.emit(out, self._ok(), family="surface") == 0
+        assert not out.exists()
+        assert led.count(we.PLANNED) == 1
+        assert any("a.png" in line for line in led.planned_lines())
+
+    def test_a_dry_run_that_planned_nothing_still_exits_zero(self):
+        assert we.FigureLedger(dry_run=True).exit_code() == 0
+
+    # -- exit code (gap 3) -------------------------------------------------- #
+    def test_any_error_exits_non_zero_even_when_most_succeeded(self, tmp_path):
+        # The whole complaint: `return 0 if total else 1` could not tell
+        # 400-of-400 from 399-of-400.
+        led = we.FigureLedger()
+        for i in range(9):
+            led.emit(tmp_path / f"ok{i}.png", self._ok(), family="surface")
+        led.emit(tmp_path / "bad.png", self._boom, family="surface")
+        assert led.rendered == 9
+        assert led.exit_code() == 1
+
+    def test_allow_errors_opts_out(self, tmp_path):
+        led = we.FigureLedger()
+        led.emit(tmp_path / "ok.png", self._ok(), family="surface")
+        led.emit(tmp_path / "bad.png", self._boom, family="surface")
+        assert led.exit_code(allow_errors=True) == 0
+
+    def test_rendering_nothing_at_all_exits_non_zero(self):
+        assert we.FigureLedger().exit_code() == 1
+
+    def test_a_run_that_only_skipped_is_a_success(self, tmp_path):
+        out = tmp_path / "a.png"
+        out.write_text("old")
+        led = we.FigureLedger(skip_existing=True)
+        led.emit(out, self._ok(), family="surface")
+        assert led.exit_code() == 0  # everything was already up to date
+
+    def test_summarise_names_each_status(self, tmp_path):
+        led = we.FigureLedger()
+        led.emit(tmp_path / "ok.png", self._ok(), family="surface")
+        led.emit(tmp_path / "bad.png", self._boom, family="surface")
+        led.note(we.ABSENT, "not written by this run", family="surface", var="hail_max")
+        text = led.summarise()
+        assert "1 rendered" in text and "1 error" in text and "1 absent" in text
+
+    # -- manifest (gap 2) --------------------------------------------------- #
+    def test_manifest_records_what_happened(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        cfg = tmp_path / "case.toml"
+        cfg.write_text("[case]\n")
+        led = we.FigureLedger()
+        led.emit(tmp_path / "a.png", self._ok(), family="surface",
+                 domain=2, valid=datetime(2025, 10, 12, 2, 20), var="refl_comp")
+        path = led.write_manifest(tmp_path / "out", config_path=cfg,
+                                  run_dir=tmp_path, argv=["--figure", "surface"])
+        assert path.name == "manifest_12345.json"
+        man = json.loads(path.read_text())
+        assert man["counts"]["rendered"] == 1
+        assert man["argv"] == ["--figure", "surface"]
+        assert len(man["config_sha256"]) == 64      # config pinned by hash
+        fig = man["figures"][0]
+        assert fig["family"] == "surface" and fig["domain"] == 2
+        assert fig["var"] == "refl_comp" and fig["valid"] == "2025-10-12_02:20"
+
+    def test_each_slurm_job_gets_its_own_manifest(self, tmp_path, monkeypatch):
+        # Four jobs sweeping into one output root must not clobber each other.
+        root = tmp_path / "out"
+        for job in ("111", "222"):
+            monkeypatch.setenv("SLURM_JOB_ID", job)
+            led = we.FigureLedger()
+            led.emit(tmp_path / f"{job}.png", self._ok(), family="aux")
+            led.write_manifest(root)
+        assert len(list(root.glob("manifest_*.json"))) == 2
+        assert len(we.read_manifests(root)) == 2
+
+    def test_report_reads_every_job_and_flags_failures(self, tmp_path, monkeypatch, capsys):
+        root = tmp_path / "out"
+        monkeypatch.setenv("SLURM_JOB_ID", "777")
+        led = we.FigureLedger()
+        led.emit(tmp_path / "ok.png", self._ok(), family="surface")
+        led.emit(tmp_path / "bad.png", self._boom, family="beam")
+        led.write_manifest(root)
+        capsys.readouterr()
+
+        assert we.report_coverage(root) == 1  # non-zero because one errored
+        out = capsys.readouterr().out
+        assert "1 job(s)" in out and "surface" in out and "beam" in out
+        assert "errored" in out
+
+    def test_report_on_an_empty_root_says_so(self, tmp_path, capsys):
+        assert we.report_coverage(tmp_path) == 1
+        assert "no manifests" in capsys.readouterr().out
+
+    def test_an_unreadable_manifest_is_skipped_not_fatal(self, tmp_path, capsys):
+        (tmp_path / "manifest_bad.json").write_text("{not json")
+        assert we.read_manifests(tmp_path) == []
+        assert "unreadable manifest" in capsys.readouterr().out


### PR DESCRIPTION
> Reopened as a new PR: the original #45 auto-closed when its base branch
> `jrl/figure-truth` was deleted on merging #44. Same commit, rebased onto `main`.

Closes the remaining actionable gaps in `docs/VISUAL-SUITE-SOP.md` — 1, 2, 3 and 8.

**Stacked on #44.** Base is `jrl/figure-truth`; it retargets to `main` when that merges.

## Four gaps, one root cause

They read as four items but they are one missing seam. Every family rendered on its own —

```python
try:
    plot(...)
    made += 1
except Exception as exc:
    print(f"[ERR] ...: {exc}")
```

— repeated at a dozen sites across the two engines, each returning only an `int`. With no chokepoint there was nowhere to put idempotence, a record of what was produced, an error tally, or a dry run. Fixing them separately would have been four scattered edits.

`FigureLedger.emit(path, render_fn, sources=..., family=...)` decides **before** any work happens. Robustness is unchanged — a bad panel is still caught, printed, and the sweep continues — but the job can now report.

| gap | flag | behaviour |
|---|---|---|
| 1 | `--skip-existing` | keep a figure at least as new as every source; a `wrfout` rewritten by a later run beats its figure, so it regenerates. Safe against a still-writing job |
| 2 | `--report` | `manifest_<jobid>.json` per job — config path + SHA-256, run dir, argv, one record per figure. Named by `SLURM_JOB_ID` because the normal pattern is four jobs into one output root |
| 3 | `--allow-errors` | any error exits non-zero by default; tally printed last |
| 8 | `--dry-run` | print the exact list, write nothing |

`absent` is a distinct status on purpose: *"this run never wrote that field"* and *"this figure failed"* are different answers to **where is my figure?**, and `find` cannot tell them apart. That is what makes `--report` worth having over a shell loop.

## Two things worth flagging

**`wrf_figures.py` was deliberately NOT touched.** Sharing its `_skip_existing` was the obvious move and I planned to do it — but `CLAUDE.md` freezes that module and the pelican evidence packet pins an exact brc-tools SHA. Eight lines are reimplemented in `wrf_engine.py` instead. Duplication beats perturbing a pinned module.

**`requires-python` was wrong, and pre-existing.** It claimed `>=3.9` while `nwp/source.py` — which nearly everything imports — has had `import tomllib` at module scope, i.e. 3.11+. The package has never been installable on 3.9/3.10; only the metadata said otherwise. Bumped to `>=3.11`, which is also what stops ruff sorting `tomllib` as third-party. This is the issue Copilot raised on #42.

## Testing

`511 passed, 6 skipped` (was 492). Ruff clean on every touched file.

Ruff `B023` caught **27 late-binding closures** in the new `lambda`s — exactly the failure mode flagged as the likeliest bug in this refactor. Harmless today because `emit` calls synchronously, but one refactor from real; all now bind loop variables as defaults.

Both engines verified end to end against a synthetic run:

```
1. --dry-run          6 planned, 0 PNGs, 0 manifests written
2. render             9 rendered, exit 0
3. --skip-existing    0 rendered, 9 skipped
4. touch one wrfout   3 re-rendered, 6 skipped   <- exactly that time's figures
5. errors present     6 rendered, 3 error -> exit 1
   --allow-errors     same tally           -> exit 0
6. --report           per-family breakdown across both jobs -> exit 1
```

Step 4 is the one that matters: idempotence that is safe against a run still writing.

The gap-5 preflight from #44 also fired for real during this, on a deliberately off-grid transect:

```
[WARN] d02 section 'runs_off': leaves the grid from 78.2 km along:
       only 47/240 samples (20%) are on it, worst gap 329.9 km
       against a 9.76 km grid -- the off-grid part is blanked,
       not filled from the edge column
```

## Still open after this

Only gap 5's cross-nest provenance half (nothing verifies a d01 and a d02 figure at the same valid time came from the same run) and gap 6, which needs no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)