### PR TITLE
fix(visualize,nwp): make a curtain say which wind it is drawing

### DIFF
--- a/brc_tools/nwp/section.py
+++ b/brc_tools/nwp/section.py
@@ -44,6 +44,11 @@ class NWPSection:
     w2d: np.ndarray  # (nz, n) vertical velocity, m/s
     terrain1d: np.ndarray  # (n,) m ASL
     pressure_hpa: np.ndarray  # (nz,)
+    # (nz, n) horizontal wind NORMAL to the transect, + INTO THE PAGE, m/s.  The
+    # component the in-plane vectors necessarily discard, and the only one that
+    # answers "is the flow crossing this line?".  For a west-to-east transect it
+    # is the northerly (+v) component.  None for sources that did not compute it.
+    normal2d: np.ndarray | None = None
     thetae2d: np.ndarray | None = None  # (nz, n) equiv. potential temp, K (needs dewpoint)
     # (nz, n) simulated reflectivity, dBZ. Present only when the source carries a
     # 3-D reflectivity field (WRF's REFL_10CM, i.e. do_radar_ref = 1); None
@@ -180,12 +185,17 @@ def extract_nwp_section(
     tnorm = np.hypot(tx, ty) or 1.0
     tx, ty = tx / tnorm, ty / tnorm
     along = u * tx + v * ty
+    # Normal component, + into the page: the LEFT-hand normal of A->B, so a
+    # west-to-east line makes northerly flow positive.  Same convention as
+    # wrf_section.section_from_plane -- see its docstring for why it is the
+    # opposite sign to the outward normal used for boundary fluxes.
+    normal = u * (-ty) + v * tx
 
     # Mask fields below the terrain surface (isobaric levels under ground are
     # extrapolated); keep height2d valid so pcolormesh can still place the cells,
     # and let the terrain fill cover them.
     below = hgt < terrain1d[None, :]
-    for a in (speed, theta, temp, along, w) + ((thetae,) if thetae is not None else ()):
+    for a in (speed, theta, temp, along, normal, w) + ((thetae,) if thetae is not None else ()):
         a[below] = np.nan
 
     return NWPSection(
@@ -197,6 +207,7 @@ def extract_nwp_section(
         theta2d=theta,
         temp2d=temp,
         along2d=along,
+        normal2d=normal,
         w2d=w,
         terrain1d=terrain1d,
         pressure_hpa=np.array(levels, dtype=float),

--- a/brc_tools/nwp/wrf_convective.py
+++ b/brc_tools/nwp/wrf_convective.py
@@ -69,6 +69,13 @@ SURFACE_FIELDS: dict[str, str] = {
 #: holding one storm, that is most of the figure.  Operational radar products
 #: mask below ~5 dBZ for the same reason.  Echo top is 0 where there is no echo
 #: at all, not 0 km.
+#:
+#: Updraft helicity is the same problem in a field that looked exempt: it is near
+#: zero over almost every cell of almost every frame, so an unmasked panel is a
+#: domain-wide pale red wash with the storm somewhere inside it.  The 5 m2 s-2
+#: floor matches the bottom of its colour scale (:data:`~brc_tools.visualize.style
+#: .VAR_STYLES`), so masked and merely-weak are the same thing rather than two
+#: indistinguishable shades.
 MASK_AT_OR_BELOW: dict[str, float] = {
     "refl_comp": 5.0,
     "refl_comp_max": 5.0,
@@ -77,6 +84,8 @@ MASK_AT_OR_BELOW: dict[str, float] = {
     "echo_top": 0.0,
     "hail_max": 0.0,
     "tornado_mask": 0.0,
+    "uphel_2to5km": 5.0,
+    "uphel_0to3km": 5.0,
 }
 
 

--- a/brc_tools/nwp/wrf_engine.py
+++ b/brc_tools/nwp/wrf_engine.py
@@ -110,7 +110,37 @@ def style_for(cfg: dict, var: str) -> VarStyle:
         vmax=float(over["vmax"]) if "vmax" in over else base.vmax,
         extend=over.get("extend", base.extend),
         diverging=bool(over.get("diverging", base.diverging)),
+        # `gamma = 0` would be a silently broken PowerNorm, so an explicit falsy
+        # value means "make this linear again" rather than "use exponent zero".
+        gamma=(float(over["gamma"]) or None) if "gamma" in over else base.gamma,
     )
+
+
+# --------------------------------------------------------------------------- #
+# figure provenance
+# --------------------------------------------------------------------------- #
+#: Leading token on a title, naming where the numbers came from.
+#:
+#: Only one figure in the suite ever said: the IEM RIDGE panel was prefixed
+#: ``OBSERVED``, and the *model* beam panel rendered beside it said nothing at
+#: all.  Two reflectivity plan views on one colour scale, one simulated and one
+#: measured, distinguished only by which file they were written to -- and the
+#: whole argument for the beam family is that model and observation are being
+#: compared on a matched surface.  A reader who cannot tell which is which cannot
+#: read the comparison, and a figure that omits it invites the claim that the
+#: model was verified when it was only plotted.
+SOURCE_WRF = "WRF"
+SOURCE_OBSERVED = "OBSERVED"
+SOURCE_COMPARISON = "WRF vs OBS"
+
+
+def compose_title(source: str, *parts: str) -> str:
+    """``'WRF | d02 0.6 km | valid ... | composite reflectivity'``.
+
+    ``source`` leads because it is the first thing that has to be true; empty
+    parts are dropped so callers can pass optional fragments straight through.
+    """
+    return " | ".join(str(p) for p in (source, *parts) if p)
 
 
 def add_time_arguments(parser) -> None:

--- a/brc_tools/nwp/wrf_section.py
+++ b/brc_tools/nwp/wrf_section.py
@@ -380,9 +380,25 @@ def section_from_plane(
     Nearest is measured in kilometres (longitudes scaled by cos(lat)), so the
     pick does not drift east-west the way a raw-degree distance would.
 
-    ``start``/``end`` are ``(lat, lon)``.  The along-section component is
-    positive toward B.  ``pressure_hpa`` carries the domain-mean level pressures
-    for reference; the curtain itself is drawn on geometric height.
+    ``start``/``end`` are ``(lat, lon)``.  ``pressure_hpa`` carries the
+    domain-mean level pressures for reference; the curtain itself is drawn on
+    geometric height.
+
+    **Two wind components, two conventions, both signed:**
+
+    * ``along2d`` is positive **toward B** -- the in-plane horizontal flow, the
+      component the section's vectors draw.
+    * ``normal2d`` is positive **into the page**: the left-hand normal of A->B,
+      which for a west-to-east transect is the northerly (``+v``) component.
+      This is the flow *crossing* the line, which the in-plane vectors discard
+      entirely, so a curtain that shades ``speed`` can show a strong wind whose
+      direction is invisible.
+
+    The into-the-page sign is deliberately the **opposite** of the rightward
+    normal in :func:`brc_tools.nwp.wrf_output.integrate_flux_transect`.  That one
+    orients a boundary so a flux integral has a consistent outward sense; this one
+    orients a *viewer* standing at A looking toward B.  Neither is more correct;
+    they answer different questions, and the figure states which it is showing.
 
     **Samples that fall off the grid are blanked, not fabricated.**  Nearest
     neighbour has no upper bound, so a transect running past the nest boundary
@@ -411,6 +427,11 @@ def section_from_plane(
         return out
 
     e_hat, n_hat = _unit_ab(start, end)
+    # Left-hand normal of A->B, so +normal points INTO THE PAGE for a curtain
+    # drawn with A on the left.  NB this is the opposite sign to the rightward
+    # normal in wrf_output.integrate_flux_transect: that one orients a boundary
+    # for a flux integral, this one orients a viewer looking at a figure.
+    e_nrm, n_nrm = -n_hat, e_hat
     ue = plane.ue[:, jj, ii]
     ve = plane.ve[:, jj, ii]
     return NWPSection(
@@ -422,6 +443,7 @@ def section_from_plane(
         theta2d=_blank(plane.theta[:, jj, ii]),
         temp2d=_blank(plane.temp[:, jj, ii]),
         along2d=_blank(ue * e_hat + ve * n_hat),
+        normal2d=_blank(ue * e_nrm + ve * n_nrm),
         w2d=_blank(plane.w[:, jj, ii]),
         terrain1d=plane.terrain[jj, ii],
         pressure_hpa=plane.pressure_hpa,

--- a/brc_tools/visualize/nwp_maps.py
+++ b/brc_tools/visualize/nwp_maps.py
@@ -101,9 +101,28 @@ def plot_nwp_surface_map(
         vmax = st.vmax
     label = st.label if st is not None else field
 
+    # A style carrying `gamma` shades on a PowerNorm instead of a linear ramp.
+    # matplotlib raises if handed both a norm and vmin/vmax, so the limits move
+    # into the norm and the direct kwargs go to None.  Explicit vmin/vmax from the
+    # caller still win -- they are resolved above and feed the norm.
+    norm, ticks = None, None
+    if st is not None and st.gamma is not None:
+        from matplotlib.colors import PowerNorm
+        from matplotlib.ticker import MaxNLocator
+
+        norm = PowerNorm(float(st.gamma), vmin=vmin, vmax=vmax)
+        if vmin is not None and vmax is not None:
+            # Ticks at round values, not at even distances along the bar: their
+            # uneven spacing is what tells the reader the scale is not linear.
+            ticks = MaxNLocator(nbins=6, steps=[1, 2, 5, 10]).tick_values(vmin, vmax)
+            ticks = [t for t in ticks if vmin <= t <= vmax]
+        vmin = vmax = None
+
     fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
-    mesh = ax.pcolormesh(lon2d, lat2d, fld, cmap=cmap, vmin=vmin, vmax=vmax, shading="auto")
-    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=(st.extend if st else "neither"), label=label)
+    mesh = ax.pcolormesh(lon2d, lat2d, fld, cmap=cmap, vmin=vmin, vmax=vmax,
+                         norm=norm, shading="auto")
+    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=(st.extend if st else "neither"),
+                 label=label, ticks=ticks)
 
     if terrain_contours and terrain_var and terrain_var in ds:
         terr = _sel(ds, terrain_var, time_index)

--- a/brc_tools/visualize/style.py
+++ b/brc_tools/visualize/style.py
@@ -25,9 +25,21 @@ class VarStyle:
     label: str
     vmin: float | None = None
     vmax: float | None = None
+    #: Accepted from a pelican case TOML (``wrf_figures._varstyle_from_dict``) and
+    #: **read by nothing** -- no renderer builds a BoundaryNorm from it.  Kept
+    #: because that constructor passes it unconditionally, so dropping the field
+    #: would raise on any study style override; do not reach for it expecting
+    #: discrete bands.  ``gamma`` below is the norm that is actually wired.
     levels: tuple[float, ...] | None = None
     extend: str = "both"
     diverging: bool = False
+    #: Exponent for a :class:`~matplotlib.colors.PowerNorm` ramp between ``vmin``
+    #: and ``vmax``.  ``None`` (the default) is the ordinary linear scale, so an
+    #: entry that does not set it renders exactly as it always has.  ``gamma < 1``
+    #: spends more of the colour range on low values -- the right shape for a
+    #: field whose interesting signal sits just above its floor while rare cores
+    #: run an order of magnitude higher.  See :func:`build_norm`.
+    gamma: float | None = None
 
 
 # Fixed ranges tuned for a February Uinta Basin cold-air pool and validated
@@ -55,6 +67,21 @@ VAR_STYLES: dict[str, VarStyle] = {
     "pblh":           VarStyle("YlOrRd", "PBLH (m)", 0.0, 1000.0, extend="max"),
     "tsk_minus_t2":   VarStyle("RdBu_r", r"$T_{\mathrm{skin}}-T_{2\,\mathrm{m}}$ (K)", -8.0, 8.0, diverging=True),
     "w":              VarStyle("RdBu_r", r"$w$ (m s$^{-1}$)", -0.5, 0.5, diverging=True),
+    # --- Cross-section wind components -----------------------------------------
+    # Three different quantities that a curtain could shade, and the labels say
+    # which, because they are not interchangeable and the figure is the only place
+    # a reader can find out. `wind_speed_10m` covers the fourth (bare magnitude).
+    #
+    # The normal component is the one that needs a diverging map: it is signed by
+    # construction, and a sequential ramp would render flow into the page and flow
+    # out of it as the same colour. Positive is INTO THE PAGE -- for a west-to-east
+    # transect that is the northerly (+v) component. See wrf_section.section_from_plane.
+    "wind_normal":    VarStyle("RdBu_r",
+                                r"section-normal wind (m s$^{-1}$, $+$ into page)",
+                                -10.0, 10.0, diverging=True),
+    "wind_along":     VarStyle("RdBu_r",
+                                r"along-transect wind (m s$^{-1}$, $+$ toward B)",
+                                -15.0, 15.0, diverging=True),
     "theta_crest":    VarStyle("RdYlBu_r", r"$\theta$ (K)", 285.0, 300.0),
     "temp_adv":       VarStyle("RdBu_r", r"T adv (K h$^{-1}$)", -3.0, 3.0, diverging=True),
     # Air temperature on a mid-tropospheric pressure surface (default 600 hPa), for the
@@ -100,13 +127,24 @@ VAR_STYLES: dict[str, VarStyle] = {
     "refl_beam":      VarStyle("gist_ncar", r"reflectivity on beam surface (dBZ)",
                                 5.0, 75.0, extend="max"),
     "echo_top":       VarStyle("viridis", r"echo top (km MSL)", 2.0, 14.0, extend="max"),
-    # Updraft helicity: 2-5 km peaked at ~19.5 m2 s-2 in the gate-A0 HRRR table,
-    # so a supercell-tuned 0-300 scale would be empty. Kept generous for the
-    # 600 m run, which resolves more than 3 km HRRR can.
+    # Updraft helicity, on a floor-to-core scale rather than a linear one.
+    #
+    # Three choices, none of them cosmetic. The floor is 5 because UH is near zero
+    # over most of any domain and a linear ramp from 0 paints all of it a pale red
+    # that reads as weak signal -- the same failure the reflectivity floor exists
+    # to prevent. Below 5 is masked (see wrf_convective.MASK_AT_OR_BELOW), so clear
+    # air stays unpainted. The top is 50 because the 600 m nest resolves cores an
+    # order of magnitude above the ~19.5 m2 s-2 the 3 km gate-A0 HRRR table peaked
+    # at, and a scale ending near that peak saturates on every real updraft.
+    #
+    # gamma = 0.6 is what makes the pair work: a linear 5-50 scale would spend
+    # most of its colour on values a Basin storm rarely reaches and leave the
+    # 5-20 band -- where the mesocyclone signal actually lives -- crushed into
+    # two shades. The ramp is slow at the bottom and coarse at the top.
     "uphel_2to5km":   VarStyle("Reds", r"2-5 km updraft helicity (m$^2$ s$^{-2}$)",
-                                0.0, 60.0, extend="max"),
+                                5.0, 50.0, extend="max", gamma=0.6),
     "uphel_0to3km":   VarStyle("Reds", r"0-3 km updraft helicity (m$^2$ s$^{-2}$)",
-                                0.0, 40.0, extend="max"),
+                                5.0, 50.0, extend="max", gamma=0.6),
     # Vertical vorticity, diverging about zero: the landspout test is whether a
     # cyclonic shear line exists on the floor BEFORE the updraft arrives, so
     # anticyclonic values must stay legible rather than being clipped away.
@@ -197,6 +235,35 @@ def use_publication_style(*, dpi: int = 300) -> None:
 def get_style(var: str) -> VarStyle:
     """Return the fixed :class:`VarStyle` for a variable key (KeyError if unknown)."""
     return VAR_STYLES[var]
+
+
+def build_norm(st: VarStyle):
+    """A :class:`~matplotlib.colors.Normalize` for ``st``, or ``None`` if linear.
+
+    Returns ``None`` unless the style sets ``gamma``, so every existing variable
+    keeps passing plain ``vmin``/``vmax`` and renders unchanged.
+
+    Callers must pass the result as ``norm=`` **instead of** ``vmin``/``vmax``:
+    matplotlib raises if given both.  :func:`norm_kwargs` does that bookkeeping.
+    """
+    if st.gamma is None:
+        return None
+    from matplotlib.colors import PowerNorm
+
+    return PowerNorm(float(st.gamma), vmin=st.vmin, vmax=st.vmax)
+
+
+def norm_kwargs(st: VarStyle) -> dict:
+    """The colour-limit kwargs for a mappable: either ``norm`` or ``vmin``/``vmax``.
+
+    One helper because the choice is exclusive and getting it wrong is a
+    ``ValueError`` at render time, inside a per-figure try/except, on a compute
+    node -- i.e. a figure silently missing from a sweep.
+    """
+    norm = build_norm(st)
+    if norm is not None:
+        return {"norm": norm}
+    return {"vmin": st.vmin, "vmax": st.vmax}
 
 
 def resolve_style(

--- a/brc_tools/visualize/wrf_curtain.py
+++ b/brc_tools/visualize/wrf_curtain.py
@@ -28,14 +28,80 @@ import numpy as np
 # them here to avoid touching a private name would fork the look of every figure
 # the moment one copy is retuned.
 from brc_tools.visualize.nwp_maps import _draw_section_towns, _geo_locator_inset
-from brc_tools.visualize.style import get_style
+from brc_tools.visualize.style import get_style, norm_kwargs
 
-__all__ = ["curtain_mesh", "plot_wrf_curtain"]
+__all__ = ["curtain_mesh", "plot_wrf_curtain", "shade_style_key", "SHADE_FIELD"]
 
 _ACCENT = "#c0392b"
-_SHADE_FIELD = {"speed": "speed2d", "theta": "theta2d", "temp": "temp2d",
-                "along": "along2d", "w": "w2d", "theta_e": "thetae2d",
-                "refl": "refl2d"}
+
+#: Shade name -> the :class:`~brc_tools.nwp.section.NWPSection` attribute it draws.
+SHADE_FIELD = {"speed": "speed2d", "theta": "theta2d", "temp": "temp2d",
+               "along": "along2d", "normal": "normal2d", "w": "w2d",
+               "theta_e": "thetae2d", "refl": "refl2d"}
+_SHADE_FIELD = SHADE_FIELD  # back-compat for existing importers
+
+#: Shade name -> the default ``VAR_STYLES`` key used to colour it.
+#:
+#: This table exists because the engines used to guess.  One passed
+#: ``wind_speed_10m`` for *every* shade, so a theta curtain came out on a
+#: 0-15 m/s wind ramp under a wind colourbar label; the other fell back to
+#: ``refl``, which did the same thing to theta-e with a reflectivity scale.  The
+#: mapping is keyed on the same names as :data:`SHADE_FIELD` and tested against
+#: it, so a shade can no longer exist without a scale that means something.
+SHADE_STYLE = {"speed": "wind_speed_10m", "theta": "theta", "temp": "temp_2m",
+               "along": "wind_along", "normal": "wind_normal", "w": "w",
+               "theta_e": "theta", "refl": "refl"}
+
+
+def shade_style_key(shade: str) -> str:
+    """The default style key for ``shade`` (``KeyError`` if it is not a shade)."""
+    return SHADE_STYLE[shade]
+
+
+#: Shade name -> the colourbar label, which is the *definition* of what is drawn.
+#:
+#: These override the style's own label on a curtain, on purpose.  A style label
+#: describes a variable ("10 m wind"); a curtain needs the label to describe a
+#: *measurement on a plane* -- whether the number is a magnitude, a component
+#: along the cut, or the flow crossing it -- and those three are indistinguishable
+#: once painted.  A reader given "wind (m/s)" over a vertical section cannot tell
+#: a 12 m/s along-valley jet from 12 m/s of cross-valley flow, and nothing else in
+#: the figure disambiguates it.
+SHADE_LABEL = {
+    "speed": r"horizontal wind speed $|V|$ (m s$^{-1}$) -- magnitude, no direction",
+    "along": r"along-transect wind (m s$^{-1}$), $+$ toward B",
+    "normal": r"section-normal wind (m s$^{-1}$), $+$ into page",
+    "w": r"vertical velocity $w$ (m s$^{-1}$), $+$ upward",
+    "theta": r"$\theta$ (K)",
+    "theta_e": r"$\theta_e$ (K)",
+    "temp": r"$T$ (K)",
+    "refl": "reflectivity (dBZ)",
+}
+
+_COMPASS = ("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+
+
+def _cardinal(bearing_deg: float) -> str:
+    """Nearest 8-point compass name for a bearing in degrees from north."""
+    return _COMPASS[int(round((bearing_deg % 360.0) / 45.0)) % 8]
+
+
+def orientation_note(section) -> str:
+    """``'A->B 090 deg (W-E) | into page = N'`` for one section.
+
+    The single line that makes a signed fill readable: without knowing which way
+    the viewer faces, "into the page" names no direction at all.
+    """
+    lat = np.asarray(section.lat_line, dtype=float)
+    lon = np.asarray(section.lon_line, dtype=float)
+    coslat = np.cos(np.deg2rad(0.5 * (lat[0] + lat[-1])))
+    east, north = (lon[-1] - lon[0]) * coslat, lat[-1] - lat[0]
+    bearing = float(np.degrees(np.arctan2(east, north))) % 360.0
+    # +normal is the LEFT-hand normal of A->B, i.e. 90 degrees anticlockwise.
+    into_page = _cardinal(bearing - 90.0)
+    return (f"A$\\rightarrow$B {bearing:03.0f}$\\degree$ "
+            f"({_cardinal(bearing + 180.0)}$\\rightarrow${_cardinal(bearing)})"
+            f"  |  into page = {into_page}")
 
 
 def _edges1d(centres: np.ndarray) -> np.ndarray:
@@ -81,8 +147,10 @@ def plot_wrf_curtain(
     *,
     shade: str = "speed",
     style=None,
+    cbar_label: str | None = None,
     title: str,
     annotation: str | None = None,
+    show_orientation: bool = True,
     theta_contours: bool = True,
     theta_interval: float = 1.0,
     w_exaggeration: float = 10.0,
@@ -97,10 +165,26 @@ def plot_wrf_curtain(
 ) -> Path:
     """Render an :class:`~brc_tools.nwp.section.NWPSection` on its native grid.
 
-    ``shade`` picks the shaded field (``speed``, ``theta``, ``temp``, ``along``,
-    ``w``, ``theta_e``). ``theta_interval`` defaults to 1 K rather than the
-    isobaric renderer's 2 K: a nocturnal inversion does its work in the first few
-    kelvin, and on the native grid there is resolution to show it.
+    ``shade`` picks the shaded field — see :data:`SHADE_FIELD`. Three of them are
+    winds and they are *different measurements on the same plane*:
+
+    * ``speed`` — horizontal magnitude :math:`|V|`. Carries no direction at all,
+      so a cross-valley gale and an along-valley jet look identical.
+    * ``along`` — the in-plane horizontal component, positive toward B. This is
+      the component the vectors draw.
+    * ``normal`` — the flow *crossing* the section, positive **into the page**,
+      on a diverging map because it is signed. For a west-to-east transect this
+      is the north-south component.
+
+    The colourbar label comes from :data:`SHADE_LABEL` rather than the style, and
+    an orientation stamp names the bearing and which compass direction "into the
+    page" is, because a signed field without a stated viewing direction is not
+    interpretable. Pass ``cbar_label`` to override, ``show_orientation=False`` to
+    drop the stamp.
+
+    ``theta_interval`` defaults to 1 K rather than the isobaric renderer's 2 K: a
+    nocturnal inversion does its work in the first few kelvin, and on the native
+    grid there is resolution to show it.
 
     ``w_exaggeration`` scales the vertical component of the in-plane vectors and is
     a property of the *regime*, not the plot geometry — see ``docs/WRF-WINDS.md``.
@@ -115,7 +199,7 @@ def plot_wrf_curtain(
     if field is None:
         raise ValueError(f"section carries no {_SHADE_FIELD[shade]} for shade={shade!r}")
 
-    st = style if style is not None else get_style("wind_speed_10m")
+    st = style if style is not None else get_style(shade_style_key(shade))
     dist = np.asarray(section.distance_km, dtype=float)
     terrain = np.asarray(section.terrain1d, dtype=float)
     zm = np.asarray(section.height2d, dtype=float)
@@ -127,8 +211,10 @@ def plot_wrf_curtain(
     fig, ax = plt.subplots(figsize=figsize, constrained_layout=True)
     ax.set_facecolor("0.6")
     mesh = ax.pcolormesh(X, Y, np.asarray(field, dtype=float), cmap=st.cmap,
-                         vmin=st.vmin, vmax=st.vmax, shading="flat")
-    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=st.extend, label=st.label)
+                         shading="flat", **norm_kwargs(st))
+    fig.colorbar(mesh, ax=ax, shrink=0.85, extend=st.extend,
+                 label=cbar_label if cbar_label is not None
+                 else SHADE_LABEL.get(shade, st.label))
 
     dist2d = np.broadcast_to(dist, zm.shape)
     if theta_contours:
@@ -139,11 +225,18 @@ def plot_wrf_curtain(
                         colors="black", linewidths=0.4, alpha=0.5)
         ax.clabel(cs, cs.levels[::2], fontsize=6, fmt="%.0f")
 
+    # In-plane vectors only: along-transect + vertical. The component normal to
+    # the section is DISCARDED here, not folded in -- say so, because a vector
+    # field on a vertical plane reads as "the wind" unless told otherwise, and
+    # the flow crossing the plane can be the larger part of it.
     sz, sx = quiver_stride
     q = ax.quiver(dist2d[::sz, ::sx], zm[::sz, ::sx],
                   np.asarray(section.along2d, dtype=float)[::sz, ::sx],
                   np.asarray(section.w2d, dtype=float)[::sz, ::sx] * w_exaggeration,
                   color="black", width=0.0016, alpha=0.85, zorder=8)
+    # Key stays short -- it sits at the top right and a long one runs off the
+    # figure (the clipped-title failure, again).  What the vectors *mean* goes in
+    # the orientation stamp below the axes, where there is width for a sentence.
     ax.quiverkey(q, 0.86, 1.02, 10.0,
                  rf"10 m s$^{{-1}}$ along, $w\times${w_exaggeration:g}",
                  labelpos="E", coordinates="axes", fontproperties={"size": 7})
@@ -163,6 +256,13 @@ def plot_wrf_curtain(
     tkw = dict(color=_ACCENT, fontsize=11, fontweight="bold", transform=ax.transAxes)
     ax.text(0.0, -0.09, section.termini[0], ha="left", va="top", **tkw)
     ax.text(1.0, -0.09, section.termini[1], ha="right", va="top", **tkw)
+
+    if show_orientation:
+        note = (f"{orientation_note(section)}  |  vectors: in-plane only "
+                f"(along-transect + $w\\times${w_exaggeration:g}), "
+                "normal component not shown")
+        ax.text(0.5, -0.09, note, transform=ax.transAxes,
+                ha="center", va="top", fontsize=7, alpha=0.8)
 
     if waypoints:
         _draw_section_towns(ax, section, waypoints, waypoint_offset_km)

--- a/scripts/stage_green_river_600m.dtn.slurm
+++ b/scripts/stage_green_river_600m.dtn.slurm
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Gate A staging for green_river_600m -- HRRR atmosphere + GFS soil.
+#
+# EVENT: 21-22 NOVEMBER 2025, the Green River corridor as a nocturnal cold-air
+# reservoir. Tracked at ub-wx experiments/20251121-green-river-cold-reservoir/.
+# Gate A0 evidence lives there; do not restate it here. In one line: the corridor
+# network confirms a quiescent drainage night -- PC101 at 302 deg down-canyon,
+# Manila 310, Kings Point 288, Split Mountain 292, all at 0.5-3.3 m/s.
+#
+# INIT 12Z, NOT 18Z. The residual boundary layer that survives into the night is
+# that day's CBL top and is one of the layers the experiment measures; an 18Z init
+# is after the morning transition, so that layer would be HRRR's and would persist
+# all night. A 12Z init inherits HRRR's nocturnal layer instead, which the model's
+# own morning transition erases. 21Z is not viable at all -- non-synoptic HRRR
+# cycles stop at f18 and cannot reach the 16Z end of the window.
+#
+# WINDOW vs STAGING SPAN -- deliberately different, same reasoning as the siblings:
+#   wrf.exe integrates   12Z 21 Nov -> 16Z 22 Nov   (28 h, run_hours=28)
+#   staging + real.exe   12Z 21 Nov -> 22Z 22 Nov   (34 h, HRRR f00..f34)
+# real.exe builds wrfbdy_d01 across the FULL staged span, so a restart can run on
+# past 16Z WITHOUT re-running WPS or real.exe. The six extra leads cost ~5 GB.
+#
+# SINGLE CYCLE, NOT SPLICED ANALYSES. brc-docs/BRC-WRF-UINTA-COLD-POOL-WAVES.md:
+# "do not splice hourly analyses" -- an hourly analysis increment injected at the
+# LBC radiates inward as spurious gravity waves, which is worse than 28 h of
+# forecast drift. For this event the drift is small anyway: HRRR carries 700 hPa at
+# 1.3-2.7 m/s and 500 hPa at 2.4-3.3 m/s over the box through the whole window.
+#
+# TWO STREAMS IS NOT OPTIONAL. Public HRRR GRIB (nat+sfc) carries ZERO
+# soil-temperature messages and soil moisture only at degenerate 0 / 0.01 m layers,
+# so a single-stream metgrid yields num_metgrid_soil_levels=0 and real.exe cannot
+# initialise Noah. A property of the product, not of the date. Soil comes from
+# --source gfs_soil (Herbie/AWS): it takes the most recent cycle AT OR BEFORE init
+# and sets the lead to the gap, so the file is valid AT init -- here the 12Z 21 Nov
+# cycle at f000, 0 h staleness. Verified present on noaa-gfs-bdp-pds.
+#
+# LEADS ARE AN EXPLICIT LIST, not a count. The 37 m case lost two jobs to
+# `--max-fhours N` meaning f00..f(N-1) in a different tool; --leads is enumerated
+# precisely so that class of off-by-one cannot recur. f00..f34 = 35 valid times.
+#
+# Expected: 70 HRRR files (35 leads x nat+sfc, ~30 GB at the measured 0.85 GB/lead)
+# + 1 GFS soil file (~0.5 GB). Verified live on noaa-hrrr-bdp-pds: the 12Z 21 Nov
+# cycle carries wrfnat+wrfsfc f00-f24 plus f30/f36/f48 (12Z is a synoptic hour, so
+# the cycle is the extended one).
+#
+# Submit:  sbatch scripts/stage_green_river_600m.dtn.slurm
+
+#SBATCH --job-name=stage_greenriver600m
+#SBATCH --account=dtn
+#SBATCH --partition=notchpeak-dtn
+#SBATCH --qos=notchpeak-dtn
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --mem=32G
+#SBATCH --time=0-06:00:00
+#SBATCH --output=/scratch/general/vast/%u/stage_greenriver600m_%j.out
+#SBATCH --error=/scratch/general/vast/%u/stage_greenriver600m_%j.out
+
+set -euo pipefail
+
+PY="$HOME/software/pkg/miniforge3/envs/brc-tools-2026/bin/python"
+REPO="$HOME/gits/brc-tools"
+CASE=green_river_600m
+OUT="/scratch/general/vast/$USER/wrf_inputs"
+INIT="2025-11-21 12:00"
+LEADS="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"
+
+cd "$REPO"
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+# CHPC DTNs can hang on outbound IPv6 (job 13471949 wedged in SYN-SENT to an NCEI
+# IPv6 address); force IPv4 for every download.
+export BRC_TOOLS_HTTP_IPV4_ONLY=1
+export PYTHONPYCACHEPREFIX="/scratch/general/vast/$USER/pycache"
+# Herbie's per-GRIB lock defaults to node-local /tmp, so fanned-out jobs do NOT
+# serialise and one can delete a subset GRIB while another reads it.
+export BRC_TOOLS_LOCK_DIR="/scratch/general/vast/$USER/herbie_locks"
+mkdir -p "$BRC_TOOLS_LOCK_DIR"
+
+echo "=== green river 600m gate A staging start $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
+echo "    case=$CASE init=$INIT leads=f00..f34 products=nat,sfc"
+
+# A pre-existing directory means a previous attempt, and link_grib.csh would silently
+# link any stale GRIB sitting beside the new ones into ungrib. Refuse rather than mix.
+if [[ -d "$OUT/$CASE" ]] && compgen -G "$OUT/$CASE/hrrr/*.grib2" > /dev/null; then
+  echo "ERROR: $OUT/$CASE already holds HRRR GRIB. Move it aside or delete it before" >&2
+  echo "       re-staging -- a stale file beside the new set gets linked silently." >&2
+  exit 2
+fi
+
+# ---- plan first: list URLs and bytes, download nothing -----------------------
+# NOTE: --plan is NOT honoured on the --source hrrr path -- the tool now refuses it
+# outright (exit 2) because it used to fall through to a real download, which cost
+# 5.6 GB on a login node in job 14296762. No HRRR plan call here.
+echo "--- PLAN: GFS soil ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_soil --init-time "$INIT" \
+  --output-dir "$OUT" --plan
+
+# ---- stage ------------------------------------------------------------------
+# ORDER MATTERS: HRRR first, then soil. The soil run merges into the existing
+# manifest and contract, and metgrid reads fg_name in PRIORITY order -- the
+# atmosphere source must come first or the supplement wins fields it should not.
+echo "--- STAGE: HRRR nat+sfc f00..f34 from 2025-11-21 12Z (34 h span for restarts) ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source hrrr --init-time "2025-11-21 12Z" \
+  --leads "$LEADS" \
+  --products nat,sfc --interval-seconds 3600 \
+  --no-quicklook --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+echo "--- STAGE: GFS soil via Herbie/AWS, valid AT init (12Z 21 Nov cycle f000) ---"
+"$PY" -B -m brc_tools.nwp.wrf_staging \
+  --case "$CASE" --source gfs_soil --init-time "$INIT" \
+  --output-dir "$OUT" --herbie-save-dir "$OUT/.herbie_cache_$CASE"
+
+# ---- verify -----------------------------------------------------------------
+# NOTE: `set -o pipefail` + `| head` makes SIGPIPE fail the job even when staging
+# succeeded -- that is what marked job 14298037 FAILED with exit 32 after both
+# streams had landed correctly. Every reporting pipe below is guarded.
+set +o pipefail
+echo "=== staged set ==="
+du -sh "$OUT/$CASE"/* || true
+n_hrrr=$(ls "$OUT/$CASE"/hrrr/*.grib2 2>/dev/null | wc -l)
+n_soil=$(ls "$OUT/$CASE"/gfs_soil/*.grib2 2>/dev/null | wc -l)
+echo "hrrr files: $n_hrrr (expect 70 = 35 leads x nat+sfc)"
+echo "soil files: $n_soil (expect 1)"
+
+echo "--- MANIFEST VERIFY (existence + size + sha256 of every staged file) ---"
+for m in "$OUT/$CASE"/manifest_*.json; do
+    [[ -f "$m" ]] && "$PY" -B -m brc_tools.nwp.wrf_staging --verify-manifest "$m" || true
+done
+echo "--- CONTRACT (fg_name order is the two-stream contract) ---"
+for c in "$OUT/$CASE"/contract_*.json; do
+    [[ -f "$c" ]] && { echo "--- $c ---"; "$PY" -m json.tool "$c" | head -40 || true; }
+done
+rm -rf "$OUT/.herbie_cache_$CASE" || true
+
+# Gate A does not pass on "the job exited 0". These are the gate.
+[[ "$n_hrrr" -eq 70 ]] || echo "WARN: expected 70 HRRR files, found $n_hrrr -- gate A NOT passed"
+[[ "$n_soil" -eq 1 ]] || echo "WARN: expected 1 soil file, found $n_soil -- gate A NOT passed"
+
+echo "=== green river 600m gate A staging done $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo
+echo "NEXT: gate C two-stream metgrid over 35 valid times -> 70 met_em (2 domains x 35),"
+echo "      num_metgrid_levels 51, num_metgrid_soil_levels 4, ST spatial std > 2 K."

--- a/scripts/wrf_convective.py
+++ b/scripts/wrf_convective.py
@@ -47,7 +47,10 @@ from brc_tools.visualize.hodograph import plot_hodograph  # noqa: E402
 from brc_tools.visualize.nwp_maps import plot_nwp_surface_map  # noqa: E402
 from brc_tools.visualize.profile import plot_skewt, sounding_from_column  # noqa: E402
 from brc_tools.visualize.style import use_publication_style  # noqa: E402
-from brc_tools.visualize.wrf_curtain import plot_wrf_curtain  # noqa: E402
+from brc_tools.visualize.wrf_curtain import (  # noqa: E402
+    plot_wrf_curtain,
+    shade_style_key,
+)
 
 FAMILIES = ("surface", "aux", "section", "beam", "sounding", "verify", "track")
 
@@ -67,6 +70,9 @@ def _titles(cfg: dict, dom: dict, ds, valid: datetime, init: datetime):
     dx_km = float(ds.attrs["DX"]) / 1000.0
     lead = (valid - init).total_seconds() / 60.0
     stamp = f"{valid:%Y%m%d_%H%M}"
+    # Source-free on purpose: most figures here are model output, but the observed
+    # radar panel reuses `short` too.  Each render site prefixes its own source via
+    # we.compose_title, so a new family cannot inherit the wrong provenance.
     base = (f"{cfg['case']['label']} | {tag} {dx_km:g} km | "
             f"valid {valid:%Y-%m-%d %H:%MZ} (+{lead:.0f} min)")
     short = f"{tag} {dx_km:g} km | {valid:%H:%MZ} +{lead:.0f} min"
@@ -139,7 +145,7 @@ def render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, *, extra=None,
                 style=style, waypoints=wps,
                 barb_stride=int(dom.get("barb_stride", 8)),
                 extent=extent, overlays=overlays, annotation=annotation,
-                title=f"{base} | {style.label}", dpi=args.dpi,
+                title=we.compose_title(we.SOURCE_WRF, base, style.label), dpi=args.dpi,
             ),
             sources=sources, family="surface", domain=number, var=var,
         )
@@ -252,8 +258,8 @@ def render_sections(cfg, dom, plane, out_dir, ctx, args, ledger, *, sources=()) 
             plot_wrf_curtain(
                 section, path,
                 shade=shade,
-                style=we.style_for(cfg, spec.get("style", _shade_style(shade))),
-                title=f"{short} | {spec.get('label', key)}",
+                style=we.style_for(cfg, spec.get("style", shade_style_key(shade))),
+                title=we.compose_title(we.SOURCE_WRF, short, spec.get("label", key)),
                 annotation=annotation, waypoints=wps,
                 waypoint_offset_km=float(spec.get("offset_km", 10.0)),
                 y_top_m=float(spec.get("y_top_m", 12000.0)),
@@ -278,10 +284,6 @@ def render_sections(cfg, dom, plane, out_dir, ctx, args, ledger, *, sources=()) 
     return made
 
 
-def _shade_style(shade: str) -> str:
-    return {"refl": "refl", "w": "w", "theta": "theta", "speed": "wind_speed_10m"}.get(
-        shade, "refl"
-    )
 
 
 def _observed_elevations(spec: dict) -> set[float] | None:
@@ -356,7 +358,8 @@ def render_beams(cfg, dom, ds, plane, out_dir, ctx, args, ledger, *, sources=())
                     extent=extent, overlays=overlays, annotation=note,
                     # Short title: the full case label clips at this width, and it
                     # is already in the annotation.
-                    title=f"{_short} | {site.id} {float(elev):g} deg beam surface",
+                    title=we.compose_title(we.SOURCE_WRF, _short,
+                                           f"{site.id} {float(elev):g} deg beam surface"),
                     dpi=args.dpi,
                 )
 
@@ -416,7 +419,8 @@ def _render_observed(cfg, spec, site, extent, wps, overlays, ctx, out_dir, args,
                 f"{annotation} | IEM RIDGE {product} | observed {field.valid_time:%H:%MZ} "
                 f"({lag:+.0f} min vs model) | elevation 1 = {field.elevation_deg:g} deg"
             ),
-            title=f"OBSERVED {site.id} {product} {field.elevation_deg:g} deg | {short}",
+            title=we.compose_title(we.SOURCE_OBSERVED,
+                                   f"{site.id} {product} {field.elevation_deg:g} deg", short),
             dpi=args.dpi,
         )
 
@@ -475,7 +479,8 @@ def render_soundings(cfg, dom, ds, out_dir, ctx, args, ledger, *, sources=()) ->
                 lambda path, sounding=sounding, spec=spec, key=key,
                 parcel=parcel, note=note: plot_skewt(
                     sounding, path,
-                    title=f"{short} | {spec.get('label', key)} | {parcel} parcel",
+                    title=we.compose_title(we.SOURCE_WRF, short, spec.get("label", key),
+                                           f"{parcel} parcel"),
                     annotation=note, parcel=parcel, mark_levels=True, shade_cape=True,
                     p_top_hpa=float(spec.get("p_top_hpa", 150.0)),
                     t_range=tuple(spec.get("t_range", (-50.0, 30.0))),
@@ -597,13 +602,21 @@ def render_verify(cfg, out_dir, args, ledger) -> int:
             drawn = sorted({s for s in obs if any(
                 st.get("stid") == s for st in entry["stations"])})
             print(f"  verify {key}: observations for {drawn or 'NONE (model only)'}")
+            # Say in the title whether an observation is even present.  A panel
+            # with no obs station resolved is a model trace on its own, and
+            # "verify" in the filename is the only thing that used to suggest
+            # otherwise -- the legend was the sole place model and obs differed.
+            source = we.SOURCE_COMPARISON if drawn else we.SOURCE_WRF
+            window_txt = " to ".join(window) if window else ""
             made += ledger.emit(
                 out_dir / f"verify_{key}_{variable}.png",
-                lambda path, series=series, styles=styles, entry=entry,
-                key=key, variable=variable: plot_scalar_timeseries(
+                lambda path, series=series, styles=styles, entry=entry, key=key,
+                variable=variable, source=source, window_txt=window_txt:
+                plot_scalar_timeseries(
                     series, path,
                     ylabel=_ts_label(cfg, variable),
-                    title=f"{cfg['case']['label']} | {entry.get('label', key)}",
+                    title=we.compose_title(source, cfg["case"]["label"],
+                                           entry.get("label", key), window_txt),
                     run_styles=styles, figsize=(10.0, 5.0), dpi=args.dpi,
                 ),
                 # The .TS traces grow while a run integrates, so no mtime

--- a/scripts/wrf_winds.py
+++ b/scripts/wrf_winds.py
@@ -22,7 +22,6 @@ hourly output lags a fine nest on 5-minute output.
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 import traceback
 from datetime import datetime
@@ -30,18 +29,19 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-
 from brc_tools.nwp import wrf_engine as we  # noqa: E402
 from brc_tools.nwp import wrf_output as wo  # noqa: E402
 from brc_tools.nwp import wrf_section as ws  # noqa: E402
 from brc_tools.visualize import coldpool3d as cp3  # noqa: E402
 from brc_tools.visualize.nwp_maps import plot_nwp_surface_map  # noqa: E402
 from brc_tools.visualize.style import use_publication_style  # noqa: E402
-from brc_tools.visualize.wrf_curtain import plot_wrf_curtain  # noqa: E402
+from brc_tools.visualize.wrf_curtain import (  # noqa: E402
+    plot_wrf_curtain,
+    shade_style_key,
+)
 
 # Config, waypoints, colour scales and time selection are shared with the
 # convective engine so the two cannot drift; see brc_tools.nwp.wrf_engine.
-DEFAULT_OUTPUT_ROOT = we.DEFAULT_OUTPUT_ROOT
 _MAP_LAYERS = we.MAP_LAYERS
 _TIME_FMT = we.TIME_FMT
 
@@ -126,7 +126,8 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                     style=st, waypoints=map_wps,
                     barb_stride=int(dom.get("barb_stride", 6)),
                     extent=extent, overlays=overlays, annotation=an,
-                    title=f"{base} | {st.label}", dpi=args.dpi),
+                    title=we.compose_title(we.SOURCE_WRF, base, st.label),
+                    dpi=args.dpi),
                 sources=src, family="topdown", domain=d, var=var,
             )
 
@@ -148,17 +149,22 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                                 family="section", domain=d, var=key)
                     continue
                 sec_wps = waypoints(s.get("waypoint_group"))
+                shade = s.get("shade", "speed")
 
-                def _draw(path, s=s, key=key, sec_wps=sec_wps):
+                def _draw(path, s=s, key=key, sec_wps=sec_wps, shade=shade):
                     sec = ws.section_from_plane(
                         plane, tuple(s["a"]), tuple(s["b"]),
                         n_points=int(s.get("n_points", 240)),
                         termini=tuple(s.get("termini", ("A", "B"))))
                     plot_wrf_curtain(
                         sec, path,
-                        shade=s.get("shade", "speed"),
-                        style=style_for(cfg, "wind_speed_10m"),
-                        title=f"{sec_base} | {s.get('label', key)}",
+                        shade=shade,
+                        # Per SHADE, not a fixed wind scale: this used to pass
+                        # wind_speed_10m for every shade, so a theta curtain came
+                        # out on a 0-15 m/s ramp labelled "10 m wind".
+                        style=style_for(cfg, s.get("style", shade_style_key(shade))),
+                        title=we.compose_title(we.SOURCE_WRF, sec_base,
+                                               s.get("label", key)),
                         annotation=an, waypoints=sec_wps,
                         waypoint_offset_km=float(s.get("offset_km", 15.0)),
                         y_top_m=float(s.get("y_top_m", 3000.0)),
@@ -173,7 +179,7 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                         dpi=args.dpi)
 
                 made += ledger.emit(
-                    out_dir / f"xsection_{key}_{tag}_{stamp}.png",
+                    out_dir / f"xsection_{shade}_{key}_{tag}_{stamp}.png",
                     _draw, sources=src, family="section", domain=d, var=key,
                 )
             made += render_views3d(cfg, v3d, plane, tag, stamp, sec_base, an,
@@ -214,8 +220,9 @@ def render_views3d(cfg, keys, plane, tag, stamp, sec_base, an, out_dir, args,
                 cp3.plot_coldpool_3d(
                     lon, lat, terr, lid, path,
                     theta_iso=float(iso),
-                    title=(f"{sec_base} | {v.get('label', key)} | "
-                           rf"cold air below $\theta$ = {float(iso):g} K"),
+                    title=we.compose_title(
+                        we.SOURCE_WRF, sec_base, v.get("label", key),
+                        rf"cold air below $\theta$ = {float(iso):g} K"),
                     annotation=an,
                     stride=int(v.get("stride", 2)),
                     elev=float(v.get("elev", 22.0)),
@@ -278,9 +285,9 @@ def main() -> int:
     use_publication_style(dpi=args.dpi)
     times = select_times(run_dir, numbers, args)
     init = ws.init_time(run_dir, min(numbers))
-    out_root = (args.output_dir or Path(os.path.expandvars(cfg["case"]["output_dir"]))
-                if (args.output_dir or cfg["case"].get("output_dir"))
-                else DEFAULT_OUTPUT_ROOT / cfg["case"]["slug"])
+    # we.output_root, not an inlined copy: the shared resolver carries the guard
+    # that refuses an output path inside the brc-tools or case checkout.
+    out_root = we.output_root(cfg, args.output_dir, config_path=args.config)
 
     # --report reads what previous jobs recorded; it renders nothing.
     if args.report:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -119,3 +119,72 @@ class TestConvectiveStyles:
     def test_srh_covers_the_measured_maximum(self):
         # 0-3 km SRH reached 824 m2 s-2 at 02Z in the 23Z cycle.
         assert st.VAR_STYLES["srh_0to3km"].vmax >= 824.0
+
+
+# --------------------------------------------------------------------------- #
+# non-linear norms
+# --------------------------------------------------------------------------- #
+def test_linear_styles_pass_vmin_vmax_not_a_norm():
+    """The default path is unchanged: no gamma means no norm, so every existing
+    variable renders exactly as it did."""
+    s = st.get_style("theta")
+    assert s.gamma is None
+    assert st.build_norm(s) is None
+    assert st.norm_kwargs(s) == {"vmin": s.vmin, "vmax": s.vmax}
+
+
+def test_gamma_style_builds_a_power_norm_carrying_the_limits():
+    s = st.get_style("uphel_2to5km")
+    norm = st.build_norm(s)
+    assert norm is not None
+    assert norm.gamma == s.gamma
+    assert (norm.vmin, norm.vmax) == (s.vmin, s.vmax)
+
+
+def test_norm_kwargs_are_exclusive():
+    """matplotlib raises when handed both a norm and vmin/vmax, so the helper
+    must return one or the other -- never both."""
+    kw = st.norm_kwargs(st.get_style("uphel_2to5km"))
+    assert set(kw) == {"norm"}
+    assert "vmin" not in kw and "vmax" not in kw
+
+
+def test_gamma_below_one_favours_the_low_end():
+    """gamma < 1 is the point: a value a fifth of the way up the range must land
+    well above a fifth of the way through the colour map, or the weak-signal band
+    the scale exists for is still crushed."""
+    norm = st.build_norm(st.get_style("uphel_2to5km"))
+    lo, hi = norm.vmin, norm.vmax
+    fifth = lo + 0.2 * (hi - lo)
+    assert float(norm(fifth)) > 0.35
+
+
+def test_updraft_helicity_scale_starts_at_its_masking_floor():
+    """The colour floor and the masking floor are the same number on purpose:
+    otherwise 'masked' and 'weak' are two indistinguishable shades."""
+    from brc_tools.nwp.wrf_convective import MASK_AT_OR_BELOW
+
+    for key in ("uphel_2to5km", "uphel_0to3km"):
+        s = st.get_style(key)
+        assert s.vmin == MASK_AT_OR_BELOW[key] == 5.0
+        assert s.vmax == 50.0
+        assert s.extend == "max"
+
+
+def test_section_wind_component_styles_are_diverging():
+    """A signed component on a sequential ramp would draw flow into the page and
+    out of it in the same colour."""
+    for key in ("wind_normal", "wind_along"):
+        s = st.get_style(key)
+        assert s.diverging is True
+        assert s.vmin == -s.vmax
+
+
+def test_varstyle_still_accepts_levels_for_the_pelican_case_toml_path():
+    """`wrf_figures._varstyle_from_dict` passes `levels=` unconditionally, so the
+    field cannot be dropped however dead it looks -- removing it raises TypeError
+    on every pelican style override, and no test exercised that constructor."""
+    from brc_tools.nwp.wrf_figures import _varstyle_from_dict
+
+    assert _varstyle_from_dict({"cmap": "viridis"}).levels is None
+    assert _varstyle_from_dict({"cmap": "viridis", "levels": [1, 2, 3]}).levels == (1, 2, 3)

--- a/tests/test_visualize_crosssection.py
+++ b/tests/test_visualize_crosssection.py
@@ -96,3 +96,55 @@ def test_reflectivity_shade_is_refused_without_reflectivity(tmp_path, monkeypatc
     assert sec.refl2d is None
     with _pytest.raises(ValueError, match="carries no refl2d"):
         plot_wrf_curtain(sec, tmp_path / "x.png", shade="refl", title="t")
+
+
+# --------------------------------------------------------------------------- #
+# saying which wind, in which plane
+# --------------------------------------------------------------------------- #
+def test_every_shade_has_a_field_a_style_and_a_label():
+    """The three tables are keyed on the same names on purpose.  A shade with a
+    field but no style is how a theta curtain came out on a 0-15 m/s wind ramp:
+    the engine fell back to a fixed key rather than failing."""
+    from brc_tools.visualize import wrf_curtain as wc
+    from brc_tools.visualize.style import VAR_STYLES
+
+    assert set(wc.SHADE_FIELD) == set(wc.SHADE_STYLE) == set(wc.SHADE_LABEL)
+    for shade, key in wc.SHADE_STYLE.items():
+        assert key in VAR_STYLES, f"shade {shade!r} maps to unknown style {key!r}"
+
+
+def test_shade_style_keys_are_distinct_for_distinct_quantities():
+    """Wind speed, theta and reflectivity must not share a scale -- that shared
+    fallback is exactly what made a curtain lie about its own units."""
+    from brc_tools.visualize.wrf_curtain import shade_style_key
+
+    keys = {shade: shade_style_key(shade) for shade in ("speed", "theta", "refl", "w")}
+    assert len(set(keys.values())) == 4
+
+
+def test_wind_shade_labels_state_magnitude_or_component():
+    from brc_tools.visualize.wrf_curtain import SHADE_LABEL
+
+    assert "magnitude" in SHADE_LABEL["speed"]
+    assert "into page" in SHADE_LABEL["normal"]
+    assert "toward B" in SHADE_LABEL["along"]
+
+
+def test_orientation_note_names_the_bearing_and_the_into_page_direction():
+    """A signed fill is uninterpretable without knowing which way the viewer
+    faces, so the stamp must resolve 'into the page' to a compass direction."""
+    import types
+
+    import numpy as np
+
+    from brc_tools.visualize.wrf_curtain import orientation_note
+
+    west_to_east = types.SimpleNamespace(
+        lat_line=np.array([40.2, 40.2]), lon_line=np.array([-110.0, -109.5]))
+    note = orientation_note(west_to_east)
+    assert "090" in note
+    assert note.endswith("into page = N")
+
+    south_to_north = types.SimpleNamespace(
+        lat_line=np.array([40.0, 40.5]), lon_line=np.array([-110.0, -110.0]))
+    assert orientation_note(south_to_north).endswith("into page = W")

--- a/tests/test_wrf_engine.py
+++ b/tests/test_wrf_engine.py
@@ -469,3 +469,43 @@ class TestFigureLedger:
         (tmp_path / "manifest_bad.json").write_text("{not json")
         assert we.read_manifests(tmp_path) == []
         assert "unreadable manifest" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# figure provenance
+# --------------------------------------------------------------------------- #
+class TestComposeTitle:
+    """Whether a figure is model output or a measurement is not a detail of the
+    caption -- on a beam comparison it is the entire claim, and until now only
+    the observed panel said which it was."""
+
+    def test_source_leads_and_empty_parts_are_dropped(self):
+        got = we.compose_title(we.SOURCE_WRF, "d02 0.6 km", "", "valid 02:20Z")
+        assert got == "WRF | d02 0.6 km | valid 02:20Z"
+
+    def test_model_and_observed_titles_are_distinguishable_at_a_glance(self):
+        model = we.compose_title(we.SOURCE_WRF, "d02 0.6 km", "KGJX 0.5 deg beam")
+        obs = we.compose_title(we.SOURCE_OBSERVED, "KGJX N0B 0.5 deg", "d02 0.6 km")
+        assert model.startswith("WRF")
+        assert obs.startswith("OBSERVED")
+        assert not obs.startswith(we.SOURCE_WRF)
+
+    def test_a_comparison_names_both(self):
+        assert we.compose_title(we.SOURCE_COMPARISON, "x").startswith("WRF vs OBS")
+
+
+class TestStyleGammaOverride:
+    def test_a_case_can_retune_gamma(self):
+        cfg = {"style": {"overrides": {"uphel_2to5km": {"gamma": 1.0, "vmax": 80.0}}}}
+        got = we.style_for(cfg, "uphel_2to5km")
+        assert got.gamma == 1.0 and got.vmax == 80.0
+        assert got.vmin == 5.0  # untouched keys fall through to the shared table
+
+    def test_gamma_zero_means_linear_not_a_broken_norm(self):
+        """PowerNorm(0) is not a scale; an explicit falsy value has to read as
+        'make this linear again' or a case silently produces a blank panel."""
+        cfg = {"style": {"overrides": {"uphel_2to5km": {"gamma": 0.0}}}}
+        assert we.style_for(cfg, "uphel_2to5km").gamma is None
+
+    def test_untouched_variables_keep_a_linear_scale(self):
+        assert we.style_for({}, "theta").gamma is None

--- a/tests/test_wrf_section.py
+++ b/tests/test_wrf_section.py
@@ -133,3 +133,53 @@ class TestOffGridBlanking:
         )
         assert not sec.offgrid1d.any()
         assert np.isfinite(sec.speed2d).all()
+
+
+class TestSectionNormalComponent:
+    """The wind crossing the section, which the in-plane vectors discard.
+
+    Sign convention: ``+normal`` is INTO THE PAGE -- the left-hand normal of
+    A->B -- so on a west-to-east transect drawn with A at the left, northerly
+    flow is positive.  These pin that down, because a sign error here is
+    invisible in the figure and reverses the meaning of every curtain.
+    """
+
+    @staticmethod
+    def _uniform(plane, east, north):
+        """Replace the plane's wind with a uniform (east, north) field."""
+        plane.ue = np.full_like(plane.ue, float(east))
+        plane.ve = np.full_like(plane.ve, float(north))
+        return plane
+
+    def test_northerly_flow_is_positive_into_the_page_on_a_west_east_line(self, plane):
+        # A due-north wind (v = +10) across a west-to-east cut.
+        sec = ws.section_from_plane(self._uniform(plane, 0.0, 10.0),
+                                    (40.2, -109.9), (40.2, -109.6), n_points=20)
+        assert np.allclose(sec.normal2d, 10.0)
+        assert np.allclose(sec.along2d, 0.0)
+
+    def test_reversing_the_transect_reverses_the_sign(self, plane):
+        """A->B and B->A are the same ground seen from opposite sides, so the
+        viewer's 'into the page' flips.  If it did not, the convention would be
+        a property of the compass rather than of the figure."""
+        p = self._uniform(plane, 0.0, 10.0)
+        west_east = ws.section_from_plane(p, (40.2, -109.9), (40.2, -109.6), n_points=20)
+        east_west = ws.section_from_plane(p, (40.2, -109.6), (40.2, -109.9), n_points=20)
+        assert np.allclose(west_east.normal2d, -east_west.normal2d)
+
+    def test_along_and_normal_are_orthogonal_and_conserve_speed(self, plane):
+        """Whatever the line's bearing, the two components must decompose the
+        horizontal wind exactly -- no energy invented or lost by the rotation."""
+        sec = ws.section_from_plane(self._uniform(plane, 6.0, -8.0),
+                                    INSIDE_A, INSIDE_B, n_points=20)
+        assert np.allclose(np.hypot(sec.along2d, sec.normal2d), 10.0)
+        assert np.allclose(sec.speed2d, 10.0)
+
+    def test_offgrid_samples_are_blanked_in_the_normal_field_too(self, plane):
+        """The blanking must cover every data field; a component that escaped it
+        would redraw the edge-column artefact the sampler exists to prevent."""
+        sec = ws.section_from_plane(self._uniform(plane, 3.0, 4.0),
+                                    (40.2, -109.9), (40.2, -109.0), n_points=40)
+        assert sec.offgrid1d.any()
+        assert np.isnan(sec.normal2d[:, sec.offgrid1d]).all()
+        assert not np.isnan(sec.normal2d[:, ~sec.offgrid1d]).any()


### PR DESCRIPTION
Three figures in this suite could not be read correctly, and a fourth could not be drawn at all. All four are one defect: **the figure knows something the reader needs and does not print it.**

This is the shared layer both engines sit on — first of three. New families (convective mesoanalysis, winds surface set + profiles) and the skill/doc rewrite follow separately.

## The section fill was always magnitude, and never said so

`speed2d` is `hypot(u, v)`. A curtain shading it draws a 12 m/s along-valley jet and 12 m/s of cross-valley flow in **the same colour**, under a colourbar reading `10 m wind (m s⁻¹)` — a variable name, on a vertical plane, where the whole question is *which component*.

The component crossing the section could not be plotted because nothing computed it. `NWPSection` gains `normal2d`, positive **into the page** — the left-hand normal of A→B, so a west-to-east transect makes northerly flow positive on a diverging map. Both samplers fill it; the isobaric one already had the tangent sitting in a local variable.

That sign is deliberately **opposite** to `integrate_flux_transect`'s rightward normal. That one orients a boundary for a flux integral, this one orients a viewer standing at A. Both docstrings say so, because a silent disagreement between them would be unfindable.

Three tables in `wrf_curtain` — field, style, label — are keyed on the same shade names and tested for it. The label is the *definition* of what is drawn and overrides the style's own; an orientation stamp resolves "into the page" to a compass direction, without which a signed field names no direction at all.

```
A→B 090° (W→E)  |  into page = N  |  vectors: in-plane only (along-transect + w×8), normal component not shown
```

## A theta curtain came out on a wind scale

`wrf_winds.py:160` passed `style_for(cfg, "wind_speed_10m")` for **every** shade. `shade = "theta"` was drawn on a 0–15 m/s `YlGnBu` ramp, labelled "10 m wind", with theta clipped at 15 K. The convective engine had half a fix, and its fallback sent `theta_e` to a reflectivity scale. One shared table now, so a shade cannot exist without a scale that means something.

## Updraft helicity painted the whole domain

`MASK_AT_OR_BELOW` covered the reflectivity family and not UH — which is near zero over almost every cell of almost every frame. The panel was a domain-wide pale wash with the storm somewhere inside it. That is **error 5 in the SOP**, recurring in the one field nobody re-checked.

Floor 5, top 50, `gamma = 0.6`:

- **5** because that is where masking starts, so "masked" and "weak" are not two indistinguishable shades;
- **50** because the 600 m nest resolves cores an order of magnitude above the 19.5 m² s⁻² the 3 km gate-A0 table peaked at, and a scale ending near that peak saturates on every real updraft;
- **gamma 0.6** because a *linear* 5–50 scale spends its colour where a Basin storm rarely reaches and crushes the 5–20 band the mesocyclone signal actually lives in.

`VarStyle.gamma` is opt-in and `None` everywhere else, so every other variable renders unchanged.

`VarStyle.levels` looked equally dead and is **not** — `wrf_figures._varstyle_from_dict` passes it unconditionally from a study TOML, so removing it raises `TypeError` on any pelican style override. It stays, documented as accepted-and-read-by-nothing, with the test that would have caught it.

## Also

- **Every title leads with its source.** Only the observed radar panel said what it was; the model panel beside it, on the same colour scale, said nothing — and "compared on a matched beam surface" is the entire argument for that family. `verify` reads `WRF vs OBS`, or `WRF` when no observation resolved.
- `wrf_winds` now uses `we.output_root`, so it stops skipping the guard against writing figures into a checkout.
- The quiver key stays short and the plane statement moved below the axes: the long version ran off the figure, which is the clipped-title failure the SOP already records once.

## Testing

`532 passed, 6 skipped` (was 511 — 21 new). Sign conventions are pinned three ways: a due-north wind on a W→E cut is positive, reversing the transect reverses it, and along/normal decompose the wind exactly at any bearing.

**Pelican freeze respected, and checked rather than assumed:** the publication engine imports none of the changed renderers — it goes through `crosssection`/`surface`/`profile`/`domains` — and the only shared file is `style.py`, where no entry it reads was touched and `gamma=None` reproduces the existing linear path exactly.

Rendered and inspected: a `normal` curtain (diverging, correct sign, stamp legible), and a UH panel where clear air is unpainted and a 12 m² s⁻² boundary band stays separable from a 45 core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZcsFNUN2u67hwzazHeDxw
