### PR TITLE
feat(nwp,visualize): mesoanalysis, profiles, and family selection on both engines

### DIFF
--- a/brc_tools/nwp/wrf_convective.py
+++ b/brc_tools/nwp/wrf_convective.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import numpy as np
 
 from brc_tools.nwp import wrf_output as wo
-from brc_tools.nwp.wrf_section import _parse_stamp, _lon180
+from brc_tools.nwp.wrf_section import _lon180, _parse_stamp
 
 #: Fields whose accumulation window is reset by the **history** write, not by the
 #: write of the stream they appear in.
@@ -268,6 +268,105 @@ def vertical_vorticity(ds, *, earth_relative: bool = True) -> np.ndarray:
     dv_dx = np.gradient(ve, dx, axis=2)
     du_dy = np.gradient(ue, dy, axis=1)
     return dv_dx - du_dy
+
+
+#: Style key -> the ``wrfout`` fields it needs.  A run missing any of them gets
+#: the panel named-skipped rather than a crash, the same contract as
+#: :data:`SURFACE_FIELDS`.
+MESO_REQUIRES: dict[str, tuple[str, ...]] = {
+    "dewpoint_2m": ("PSFC", "Q2"),
+    "dewpoint_depression_2m": ("PSFC", "Q2", "T2"),
+    "theta_e_2m": ("PSFC", "Q2", "T2"),
+    "theta_e_grad_2m": ("PSFC", "Q2", "T2"),
+    "conv_10m": ("U10", "V10"),
+    "mfc_10m": ("U10", "V10", "Q2"),
+}
+
+
+def horizontal_divergence(ds, u, v, *, earth_relative: bool = True) -> np.ndarray:
+    """Horizontal divergence of a 2-D vector field on the mass grid (per second).
+
+    A thin name over :func:`brc_tools.nwp.wrf_output.horizontal_flux_divergence`,
+    whose docstring says "W m-2" because it was written for the cold-pool heat
+    flux.  The operator is unit-agnostic -- the result carries the input's units
+    per metre -- and reusing it means surface convergence gets the same
+    map-factor form as the deficit transport instead of a second, subtly
+    different differencing.
+
+    Note this *does* apply the map factor while :func:`vertical_vorticity`
+    deliberately does not.  The asymmetry is inherited, not chosen: vorticity
+    argues the correction is far below the truncation error at 600 m, which is
+    true, and the flux operator was written to be exact for an integral over a
+    large domain.  Both are defensible; the point is that neither is silently
+    guessing, and a convergence line diagnosed here is directly comparable with a
+    deficit-flux convergence computed by the same operator.
+    """
+    return wo.horizontal_flux_divergence(ds, u, v, earth_relative=earth_relative)
+
+
+def surface_dewpoint_c(ds) -> np.ndarray:
+    """2 m dewpoint (deg C) from ``PSFC`` and ``Q2``, Magnus form.
+
+    WRF writes no 2 m dewpoint.  ``Q2`` is a mixing ratio and ``PSFC`` is the
+    surface pressure, which is what the column routine already reduces; this is
+    the same function applied to one level.
+    """
+    return wo._dewpoint_c(wo.surface_field(ds, "PSFC"), wo.surface_field(ds, "Q2"))
+
+
+def surface_theta_e(ds) -> np.ndarray:
+    """2 m equivalent potential temperature (K), Bolton (1980) Eq. 43.
+
+    The mesoanalysis field for a boundary: theta-e sees the moisture a
+    temperature map misses, so an outflow edge that is only two degrees cooler
+    but markedly drier reads as a sharp gradient here and as nothing on T2.
+    """
+    from brc_tools.nwp.derived import theta_e
+
+    temp_k = wo.surface_field(ds, "T2")
+    dew_k = surface_dewpoint_c(ds) + 273.15
+    pres_hpa = wo.surface_field(ds, "PSFC") / 100.0
+    return np.asarray(theta_e(temp_k, dew_k, pres_hpa), dtype=float)
+
+
+def meso_field(ds, key: str) -> np.ndarray:
+    """One derived surface-mesoanalysis field by style key.
+
+    Signs are chosen so that **positive means the thing you are looking for**:
+    ``conv_10m`` and ``mfc_10m`` are *convergence*, i.e. the negative of the
+    divergence, because a mesoanalyst hunting a boundary wants the line to be a
+    positive maximum rather than a negative one.
+    """
+    from brc_tools.nwp.derived import horizontal_gradient_magnitude
+
+    if key not in MESO_REQUIRES:
+        raise KeyError(f"unknown mesoanalysis field {key!r}; "
+                       f"known: {sorted(MESO_REQUIRES)}")
+    missing = [v for v in MESO_REQUIRES[key] if v not in ds]
+    if missing:
+        raise KeyError(f"{key} needs {', '.join(missing)}, absent from this run")
+
+    if key == "dewpoint_2m":
+        return surface_dewpoint_c(ds)
+    if key == "dewpoint_depression_2m":
+        return (wo.surface_field(ds, "T2") - 273.15) - surface_dewpoint_c(ds)
+    if key == "theta_e_2m":
+        return surface_theta_e(ds)
+    if key == "theta_e_grad_2m":
+        # dx from the FILE, not the 3 km HRRR default the helper carries: on a
+        # 600 m nest that default understates every gradient five-fold.
+        dx, _dy = wo.dx_dy(ds)
+        return np.asarray(
+            horizontal_gradient_magnitude(surface_theta_e(ds), dx_m=dx)) * 1000.0
+
+    u10, v10 = wo.surface_field(ds, "U10"), wo.surface_field(ds, "V10")
+    if key == "conv_10m":
+        # 10^-3 s^-1, matching the style's label.
+        return -horizontal_divergence(ds, u10, v10, earth_relative=False) * 1000.0
+    # Moisture flux convergence: -div(q * V).  Units g/kg per hour.
+    q = wo.surface_field(ds, "Q2")
+    flux = -horizontal_divergence(ds, q * u10, q * v10, earth_relative=False)
+    return flux * 1000.0 * 3600.0
 
 
 def echo_top_height(ds, *, threshold_dbz: float = 40.0, refl3d=None) -> np.ndarray:

--- a/brc_tools/nwp/wrf_engine.py
+++ b/brc_tools/nwp/wrf_engine.py
@@ -35,7 +35,13 @@ DEFAULT_OUTPUT_ROOT = Path(
 )
 
 #: Natural-Earth overlay layers a case TOML may switch on under ``[map]``.
-MAP_LAYERS = ("states", "counties", "roads", "rivers", "lakes")
+#: ``[map]`` switches a case TOML may set.  ``cities`` draws population-ranked
+#: Natural-Earth place labels and was implemented in ``basemap.draw_cities`` but
+#: missing from this tuple, so no case could reach it -- the engines build their
+#: overlay dict by iterating exactly this list.  Complements the curated
+#: ``[waypoints]`` in ``lookups.toml``: those are the places a Basin study names
+#: deliberately, these are whatever else is big enough to orient a reader.
+MAP_LAYERS = ("states", "counties", "roads", "rivers", "lakes", "cities")
 
 #: ``--valid`` / display format.
 TIME_FMT = "%Y-%m-%d_%H:%M"

--- a/brc_tools/nwp/wrf_section.py
+++ b/brc_tools/nwp/wrf_section.py
@@ -125,9 +125,15 @@ def plan_dataset(ds, *, extra: dict | None = None):
     Field names are :mod:`brc_tools.visualize.style` keys, because
     :func:`~brc_tools.visualize.nwp_maps.plot_nwp_surface_map` looks the colour
     scale up by variable name: ``wind_speed_10m``, ``wind_u_10m``,
-    ``wind_v_10m``, ``theta_2m``, ``temp_2m``, ``pblh``, plus ``terrain_height``
-    and 2-D ``latitude``/``longitude``.  ``pblh`` is omitted when the run did not
-    write ``PBLH``.  ``extra`` adds ``{name: 2-D array}`` pairs verbatim.
+    ``wind_v_10m``, ``theta_2m``, ``temp_2m``, plus ``terrain_height`` and 2-D
+    ``latitude``/``longitude``.
+
+    Present only when the run wrote what they need, and named-skipped by the
+    engines otherwise: ``pblh`` (``PBLH``), ``tsk_minus_t2`` (``TSK``),
+    ``snow_depth`` (``SNOWH``), ``conv_10m`` (``U10``/``V10``).
+
+    ``extra`` adds ``{name: 2-D array}`` pairs verbatim, and wins over anything
+    built here -- that is how the convective engine injects its own diagnostics.
     """
     import xarray as xr
 
@@ -142,6 +148,24 @@ def plan_dataset(ds, *, extra: dict | None = None):
     }
     if "PBLH" in ds:
         fields["pblh"] = wo.surface_field(ds, "PBLH")
+    # Cold-pool context that the run already writes and nothing could plot.
+    # TSK-T2 is the surface decoupling: strongly negative is a surface radiating
+    # under a decoupled layer, which is the pool forming, and it says so hours
+    # before the theta field looks unusual.  Snow is the albedo/emissivity
+    # control on that whole process.
+    if "TSK" in ds:
+        fields["tsk_minus_t2"] = wo.surface_field(ds, "TSK") - wo.surface_field(ds, "T2")
+    if "SNOWH" in ds:
+        fields["snow_depth"] = wo.surface_field(ds, "SNOWH")
+    # Surface convergence, from the same map-factor operator the convective
+    # mesoanalysis and the deficit transport use -- one implementation, so a
+    # convergence line means the same thing in all three.
+    if "U10" in ds and "V10" in ds:
+        from brc_tools.nwp.wrf_convective import horizontal_divergence
+
+        fields["conv_10m"] = -horizontal_divergence(
+            ds, wo.surface_field(ds, "U10"), wo.surface_field(ds, "V10"),
+            earth_relative=False) * 1000.0
     fields.update(extra or {})
     return xr.Dataset(
         {k: (("y", "x"), np.asarray(a, dtype=float)) for k, a in fields.items()},

--- a/brc_tools/visualize/profile.py
+++ b/brc_tools/visualize/profile.py
@@ -422,16 +422,79 @@ def _stability_bands(z, theta, z_top, *, min_thick=80.0, merge_gap=120.0):
     return [b for b in raw if b[1] - b[0] >= min_thick]
 
 
-def _profile_barbs(ax, x, z, u, v, z_top, color):
+def _barb_levels(z, z_top, *, interval_m=None, n=14):
+    """Indices of the levels to draw barbs at, paced in HEIGHT not level index.
+
+    Eta levels are stretched -- tens of metres apart near the ground and hundreds
+    aloft -- so every-nth-level would crowd the surface and leave the free
+    atmosphere bare.  ``interval_m`` gives a fixed metre spacing (comparable
+    across figures and cases); the default keeps the historical behaviour of ``n``
+    barbs spread over whatever depth is visible.
+    """
+    z = np.asarray(z, float)
+    if z.size == 0:
+        return np.empty(0, dtype=int)
+    top = min(float(z.max()), float(z_top))
+    if interval_m:
+        targets = np.arange(float(z.min()), top + 0.5 * interval_m, float(interval_m))
+    else:
+        targets = np.linspace(float(z.min()), float(z.max()), n)
+    return np.unique([int(np.abs(z - t).argmin()) for t in targets])
+
+
+def _profile_barbs(ax, x, z, u, v, z_top, color, *, interval_m=None):
     z, u, v = np.asarray(z, float), np.asarray(u, float), np.asarray(v, float)
     m = np.isfinite(z) & np.isfinite(u) & np.isfinite(v) & (z <= z_top)
     z, u, v = z[m], u[m], v[m]
     if z.size == 0:
         return
-    targets = np.linspace(z.min(), z.max(), 14)
-    idx = np.unique([int(np.abs(z - t).argmin()) for t in targets])
+    idx = _barb_levels(z, z_top, interval_m=interval_m)
     ax.barbs(np.full(idx.size, x), z[idx], u[idx], v[idx],
              length=6, color=color, linewidth=0.7, zorder=5)
+
+
+def _profile_speed_bars(ax, z, u, v, z_top, color, *, interval_m=None,
+                        barbs: bool = True):
+    """Wind speed as minimal horizontal bars against height, barbs at the tips.
+
+    An alternative to a column of barbs: the bar carries the magnitude at every
+    model level -- so a nocturnal jet reads as a bulge rather than as two barbs
+    that happen to have an extra flag -- and a barb at the tip of every nth bar
+    carries the direction without the clutter of one per level.
+    """
+    z, u, v = np.asarray(z, float), np.asarray(u, float), np.asarray(v, float)
+    m = np.isfinite(z) & np.isfinite(u) & np.isfinite(v) & (z <= z_top)
+    z, u, v = z[m], u[m], v[m]
+    if z.size == 0:
+        return
+    spd = np.hypot(u, v)
+    ax.barh(z, spd, height=np.gradient(z) * 0.72, color=color, alpha=0.30,
+            linewidth=0, zorder=2)
+    ax.plot(spd, z, color=color, lw=1.0, zorder=3)
+    if barbs:
+        idx = _barb_levels(z, z_top, interval_m=interval_m)
+        ax.barbs(spd[idx], z[idx], u[idx], v[idx], length=5.5, color=color,
+                 linewidth=0.7, zorder=5)
+
+
+def _humidity_trace(snd, kind: str):
+    """``(values, axis_label)`` for the humidity overlay: RH (%) or q (g/kg)."""
+    from brc_tools.nwp.derived import (
+        mixing_ratio,
+        relative_humidity,
+        saturation_vapor_pressure,
+    )
+
+    temp_k = np.asarray(snd.temperature_c, float) + 273.15
+    dew_k = np.asarray(snd.dewpoint_c, float) + 273.15
+    if kind == "rh":
+        # derived.relative_humidity already returns percent, not a fraction.
+        return np.asarray(relative_humidity(temp_k, dew_k), float), "RH (%)"
+    if kind == "q":
+        pres_pa = np.asarray(snd.pressure_hpa, float) * 100.0
+        q = mixing_ratio(saturation_vapor_pressure(dew_k), pres_pa)
+        return np.asarray(q, float) * 1000.0, r"mixing ratio $q$ (g kg$^{-1}$)"
+    raise ValueError(f"humidity must be 'rh' or 'q', got {kind!r}")
 
 
 def plot_theta_wind_profile(
@@ -443,6 +506,9 @@ def plot_theta_wind_profile(
     crest_m: float | None = None,
     y_top_m: float = 5500.0,
     annotation: str | None = None,
+    humidity: str | None = None,
+    wind_bars: bool = False,
+    barb_interval_m: float | None = None,
     figsize: tuple[float, float] = (8.2, 8.0),
     dpi: int = 300,
 ) -> Path:
@@ -456,6 +522,21 @@ def plot_theta_wind_profile(
 
     The first model in ``models`` is the reference for the stability shading and the
     change-shading (filled between the first and last model curve).
+
+    Three options are **off by default**, so the pelican ``thetaz`` family renders
+    exactly as it always has:
+
+    ``humidity``
+        ``"rh"`` or ``"q"`` adds a humidity trace on a twin axis.  θ alone cannot
+        distinguish a dry residual layer from a moist one at the same
+        temperature, and which it is decides whether the layer will mix out.
+    ``wind_bars``
+        Draw wind *speed* as horizontal bars at every level with barbs at the
+        bar tips, instead of a column of barbs at a nominal x.  A low-level jet
+        is then a visible bulge rather than something inferred from flag counts.
+    ``barb_interval_m``
+        Pace barbs every N metres rather than spreading a fixed count over the
+        visible depth, so two figures with different tops stay comparable.
     """
     import matplotlib
 
@@ -509,21 +590,55 @@ def plot_theta_wind_profile(
         ax.axhline(crest_m, color="k", lw=0.7, ls="--", zorder=1)
         ax.text(ax.get_xlim()[1], crest_m, " crest", fontsize=7, va="bottom", ha="right")
 
+    axh = None
+    if humidity:
+        # Twin axis, dashed and desaturated: it must read as a second quantity
+        # sharing the height axis, never as another theta curve.
+        axh = ax.twiny()
+        for i, lab in enumerate(labels):
+            vals, hlabel = _humidity_trace(models[lab], humidity)
+            axh.plot(vals, m_z[lab], color="#1b7837", lw=1.3, zorder=3,
+                     ls="-" if i == 0 else "--",
+                     alpha=1.0 if i == 0 else 0.55,
+                     label=f"{hlabel.split()[0]} {lab}")
+        axh.set_xlabel(hlabel, fontsize=9, color="#1b7837")
+        axh.tick_params(axis="x", colors="#1b7837", labelsize=8)
+        if humidity == "rh":
+            axh.set_xlim(0.0, 100.0)
+        else:
+            axh.set_xlim(left=0.0)
+
     # wind panel: model columns then obs, evenly spaced
     profs = [(lab, models[lab], DEFAULT_RUN_STYLES.get(i, {}).get("color", "black"))
              for i, lab in enumerate(labels)]
     if obs is not None:
         profs.append(("obs", obs, "k"))
-    xs = np.linspace(0.28, 0.82, len(profs))
-    for x, (lab, snd, color) in zip(xs, profs):
-        _profile_barbs(axw, x, _heights(snd, z0), snd.u_kt, snd.v_kt, y_top_m, color)
-    axw.set_xlim(0.15, 0.95)
-    axw.set_xticks(list(xs))
-    axw.set_xticklabels([lab for lab, _s, _c in profs], fontsize=8)
-    axw.set_title("wind (kt)", fontsize=9)
-    axw.tick_params(left=False)
-    for s in ("top", "right", "left"):
-        axw.spines[s].set_visible(False)
+    if wind_bars:
+        # The panel's x-axis becomes a real speed axis rather than a set of
+        # nominal slots, so the bars are readable as magnitudes.
+        for _lab, snd, color in profs:
+            if snd.u_kt is None or snd.v_kt is None:
+                continue
+            _profile_speed_bars(axw, _heights(snd, z0), snd.u_kt, snd.v_kt, y_top_m,
+                                color, interval_m=barb_interval_m)
+        axw.set_xlim(left=0.0)
+        axw.set_xlabel("kt", fontsize=8)
+        axw.set_title("wind speed + direction", fontsize=9)
+        axw.grid(True, axis="x", alpha=0.25)
+        for s in ("top", "right"):
+            axw.spines[s].set_visible(False)
+    else:
+        xs = np.linspace(0.28, 0.82, len(profs))
+        for x, (lab, snd, color) in zip(xs, profs):
+            _profile_barbs(axw, x, _heights(snd, z0), snd.u_kt, snd.v_kt, y_top_m,
+                           color, interval_m=barb_interval_m)
+        axw.set_xlim(0.15, 0.95)
+        axw.set_xticks(list(xs))
+        axw.set_xticklabels([lab for lab, _s, _c in profs], fontsize=8)
+        axw.set_title("wind (kt)", fontsize=9)
+        axw.tick_params(left=False)
+        for s in ("top", "right", "left"):
+            axw.spines[s].set_visible(False)
 
     ax.set_ylim(z0 - 50.0, y_top_m)
     vis = [m_th[lab][m_z[lab] <= y_top_m] for lab in labels]
@@ -533,10 +648,14 @@ def plot_theta_wind_profile(
     ax.set_xlim(float(np.nanmin(vis)) - 1.5, float(np.nanmax(vis)) + 2.5)
     ax.set_xlabel(r"potential temperature  $\theta$  (K)")
     ax.set_ylabel("height (m MSL)")
-    ax.set_title(title, fontsize=10)
+    # The humidity twin puts its own ticks and label along the top, so the title
+    # needs room or it lands on them.
+    ax.set_title(title, fontsize=10, pad=30 if axh is not None else None)
     ax.grid(True, axis="y", alpha=0.25)
 
     handles, _ = ax.get_legend_handles_labels()
+    if axh is not None:
+        handles += axh.get_legend_handles_labels()[0]
     handles += [Patch(fc=band_c["inversion"], alpha=0.25, label="inversion (very stable)"),
                 Patch(fc=band_c["unstable"], alpha=0.25, label="unstable (dθ/dz<0)")]
     ax.legend(handles=handles, loc="lower right", fontsize=7.5, framealpha=0.9)

--- a/brc_tools/visualize/style.py
+++ b/brc_tools/visualize/style.py
@@ -174,6 +174,33 @@ VAR_STYLES: dict[str, VarStyle] = {
     # winter wind_speed_10m style uses.
     "wspd10max":      VarStyle("YlOrRd", r"max 10 m wind (m s$^{-1}$)",
                                 0.0, 35.0, extend="max"),
+    # --- Surface mesoanalysis --------------------------------------------------
+    # The fields a forecaster reads to find a boundary, which WRF does not write
+    # and the suite therefore could not show.  Signs are set so that POSITIVE is
+    # the feature being hunted: both convergence fields are the negative of the
+    # divergence, so a convergence line is a positive maximum.
+    #
+    # Diverging maps for both, because the sign is the whole content -- a
+    # sequential ramp would draw convergence and divergence the same colour and
+    # lose the boundary in the difference field around it.
+    "conv_10m":       VarStyle("RdBu_r",
+                                r"10 m convergence $-\nabla\!\cdot V$ ($10^{-3}$ s$^{-1}$)",
+                                -5.0, 5.0, diverging=True),
+    "mfc_10m":        VarStyle("BrBG",
+                                r"moisture flux conv. $-\nabla\!\cdot(qV)$ "
+                                r"(g kg$^{-1}$ h$^{-1}$)",
+                                -10.0, 10.0, diverging=True),
+    # Theta-e sees the moisture a temperature map misses: an outflow edge two
+    # kelvin cooler but markedly drier is a sharp gradient here and nothing on T2.
+    "theta_e_2m":     VarStyle("RdYlBu_r", r"$\theta_{e,2\,\mathrm{m}}$ (K)", 315.0, 345.0),
+    "theta_e_grad_2m": VarStyle("magma", r"$|\nabla\theta_e|$ (K km$^{-1}$)",
+                                 0.0, 10.0, extend="max"),
+    "dewpoint_2m":    VarStyle("YlGn", r"$T_{d,2\,\mathrm{m}}$ ($^{\circ}$C)",
+                                -10.0, 20.0),
+    # Dark = dry: a large depression is the deep sub-cloud layer that turns a
+    # modest core into a downburst, so it must not read as "nothing here".
+    "dewpoint_depression_2m": VarStyle("YlOrBr", r"$T-T_d$ at 2 m (K)",
+                                        0.0, 30.0, extend="max"),
     "hail_max":       VarStyle("PuBu", r"max hail diameter (mm)", 0.0, 50.0, extend="max"),
     "tornado_mask":   VarStyle("Greys", "AFWA tornado mask", 0.0, 1.0, extend="neither"),
     "llws":           VarStyle("YlGnBu", r"0-2 km low-level wind shear (m s$^{-1}$)",

--- a/scripts/wrf_convective.py
+++ b/scripts/wrf_convective.py
@@ -6,6 +6,8 @@ switched on per nest in the case TOML:
 
 ``surface``   plan views from the history stream -- composite reflectivity,
               gust swath, updraft helicity, echo top, vertical vorticity.
+``meso``      surface mesoanalysis -- theta-e, dewpoint, 10 m convergence and
+              moisture-flux convergence: what the storm is running into.
 ``aux``       the same kind of plan view from a high-cadence auxiliary stream,
               which is the only way to see a feature the history stream aliases.
 ``section``   reflectivity / vertical-velocity / theta curtains along A->B lines.
@@ -52,7 +54,8 @@ from brc_tools.visualize.wrf_curtain import (  # noqa: E402
     shade_style_key,
 )
 
-FAMILIES = ("surface", "aux", "section", "beam", "sounding", "verify", "track")
+FAMILIES = ("surface", "meso", "aux", "section", "beam", "sounding", "verify",
+            "track")
 
 #: Field -> style tables live in the package (with tests), not here, so other
 #: callers get them too and the REFD_COM/REFD_MAX distinction is enforced in one
@@ -117,27 +120,38 @@ def _plan_extra(ds, dom: dict) -> dict:
 # --------------------------------------------------------------------------- #
 # families
 # --------------------------------------------------------------------------- #
-def render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, *, extra=None,
-                   sources=()) -> int:
-    """Plan views of whatever 2-D convective fields the run wrote."""
+def _plan_views(cfg, dom, ds, pds, out_dir, ctx, args, ledger, *, variables, family,
+                prefix, sources=()) -> int:
+    """Render a list of style keys from one plan dataset, through the ledger.
+
+    ``ds`` is the raw ``wrfout`` -- ``plan_extent`` reads ``XLAT``/``XLONG``,
+    which the plan dataset renames.
+    """
     tag, stamp, base, _short, annotation = ctx
     number = int(dom["domain"])
-    pds = ws.plan_dataset(ds, extra=extra if extra is not None else _plan_extra(ds, dom))
     extent = tuple(dom["extent"]) if dom.get("extent") else ws.plan_extent(
         ds, pad_deg=float(dom.get("pad_deg", 0.0))
     )
     wps = we.waypoints(dom.get("waypoint_group"))
     overlays = we.overlays_from(cfg)
     made = 0
-    for var in dom.get("surface_vars", ["refl_comp"]):
+    for var in variables:
         if var not in pds:
             print(f"[SKIP] {tag} {var}: not written by this run")
             ledger.note(we.ABSENT, "not written by this run",
-                        family="surface", domain=number, var=var)
+                        family=family, domain=number, var=var)
             continue
-        style = we.style_for(cfg, var)
+        try:
+            style = we.style_for(cfg, var)
+        except KeyError:
+            # Was outside the emit closure and uncaught, so one unknown style key
+            # in one case TOML killed the whole sweep instead of one panel.
+            print(f"[SKIP] {tag} {var}: no entry in VAR_STYLES")
+            ledger.note(we.ERROR, "no entry in VAR_STYLES",
+                        family=family, domain=number, var=var)
+            continue
         made += ledger.emit(
-            out_dir / f"plan_{var}_{tag}_{stamp}.png",
+            out_dir / f"{prefix}_{var}_{tag}_{stamp}.png",
             # var/style bound as defaults: this is a loop, and a late-binding
             # closure would render the last variable once per iteration.
             lambda path, var=var, style=style: plot_nwp_surface_map(
@@ -147,9 +161,45 @@ def render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, *, extra=None,
                 extent=extent, overlays=overlays, annotation=annotation,
                 title=we.compose_title(we.SOURCE_WRF, base, style.label), dpi=args.dpi,
             ),
-            sources=sources, family="surface", domain=number, var=var,
+            sources=sources, family=family, domain=number, var=var,
         )
     return made
+
+
+def render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, *, extra=None,
+                   sources=()) -> int:
+    """Plan views of whatever 2-D convective fields the run wrote."""
+    pds = ws.plan_dataset(ds, extra=extra if extra is not None else _plan_extra(ds, dom))
+    return _plan_views(cfg, dom, ds, pds, out_dir, ctx, args, ledger,
+                       variables=dom.get("surface_vars", ["refl_comp"]),
+                       family="surface", prefix="plan", sources=sources)
+
+
+def render_meso(cfg, dom, ds, out_dir, ctx, args, ledger, *, sources=()) -> int:
+    """Surface mesoanalysis: the fields that locate a boundary.
+
+    Its own family rather than more ``surface_vars`` because it answers a
+    different question and is swept separately -- reflectivity tells you where
+    the storm *is*, these tell you what it is running into, and on a long sweep
+    you usually want one or the other.
+
+    Every field here is derived (WRF writes none of them), so a run missing an
+    input gets that panel named-skipped, not the whole family.
+    """
+    tag = str(dom.get("tag") or f"d{int(dom['domain']):02d}")
+    extra: dict[str, np.ndarray] = {}
+    for key in dom.get("meso_vars", []):
+        try:
+            extra[key] = wc.meso_field(ds, key)
+        except KeyError as exc:
+            print(f"[SKIP] {tag} {key}: {exc}")
+            ledger.note(we.ABSENT, str(exc), family="meso",
+                        domain=int(dom["domain"]), var=key)
+    if not extra:
+        return 0
+    return _plan_views(cfg, dom, ds, ws.plan_dataset(ds, extra=extra), out_dir,
+                       ctx, args, ledger, variables=list(extra), family="meso",
+                       prefix="meso", sources=sources)
 
 
 def render_aux(cfg, dom, valid, init, out_dir, args, ledger) -> int:
@@ -778,6 +828,8 @@ def render_domain(cfg, dom, valid, init, out_root, families, args, ledger) -> in
         made = 0
         if "surface" in families:
             made += render_surface(cfg, dom, ds, out_dir, ctx, args, ledger, sources=src)
+        if "meso" in families:
+            made += render_meso(cfg, dom, ds, out_dir, ctx, args, ledger, sources=src)
         if "aux" in families:
             made += render_aux(cfg, dom, valid, init, out_root / ctx[1], args, ledger)
         if "sounding" in families:

--- a/scripts/wrf_winds.py
+++ b/scripts/wrf_winds.py
@@ -34,11 +34,23 @@ from brc_tools.nwp import wrf_output as wo  # noqa: E402
 from brc_tools.nwp import wrf_section as ws  # noqa: E402
 from brc_tools.visualize import coldpool3d as cp3  # noqa: E402
 from brc_tools.visualize.nwp_maps import plot_nwp_surface_map  # noqa: E402
+from brc_tools.visualize.profile import (  # noqa: E402
+    plot_theta_wind_profile,
+    sounding_from_column,
+)
 from brc_tools.visualize.style import use_publication_style  # noqa: E402
 from brc_tools.visualize.wrf_curtain import (  # noqa: E402
     plot_wrf_curtain,
     shade_style_key,
 )
+
+#: Selectable with ``--figure`` (repeatable); default is all of them.
+#:
+#: ``topdown``  surface plan views -- wind, theta, PBLH, convergence, snow.
+#: ``section``  terrain-filled curtains on native eta levels along A->B lines.
+#: ``profile``  theta + humidity profiles with a wind panel at named points.
+#: ``view3d``   3-D isentrope lid over hillshaded terrain.
+FAMILIES = ("topdown", "section", "profile", "view3d")
 
 # Config, waypoints, colour scales and time selection are shared with the
 # convective engine so the two cannot drift; see brc_tools.nwp.wrf_engine.
@@ -50,8 +62,8 @@ _TIME_FMT = we.TIME_FMT
 # config
 # --------------------------------------------------------------------------- #
 def load_config(path: Path) -> dict:
-    """Case TOML, with ``[[sections]]``/``[[views3d]]`` indexed by key."""
-    return we.load_config(path, index=("sections", "views3d"))
+    """Case TOML, with ``[[sections]]``/``[[views3d]]``/``[[profiles]]`` indexed."""
+    return we.load_config(path, index=("sections", "views3d", "profiles"))
 
 
 def waypoints(group: str | None) -> dict:
@@ -73,6 +85,7 @@ def select_times(run_dir: Path, domains: list[int], args) -> list[datetime]:
         run_dir, domains,
         valid=args.valid, lead=args.lead, hourly=args.hourly,
         every=args.every, all_times=args.all_times,
+        start=args.start, end=args.end,
     )
 
 
@@ -80,7 +93,7 @@ def select_times(run_dir: Path, domains: list[int], args) -> list[datetime]:
 # rendering
 # --------------------------------------------------------------------------- #
 def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
-                  out_root: Path, args, ledger) -> int:
+                  out_root: Path, args, ledger, families=FAMILIES) -> int:
     run_dir = cfg["case"]["run_dir"]
     d = int(dom["domain"])
     path = ws.wrfout_path(run_dir, d, valid)
@@ -112,7 +125,8 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
         extent = tuple(dom["extent"]) if dom.get("extent") else ws.plan_extent(ds, pad_deg=pad)
         pds = ws.plan_dataset(ds)
         map_wps = waypoints(dom.get("waypoint_group"))
-        for var in dom.get("surface_vars", ["wind_speed_10m"]):
+        for var in (dom.get("surface_vars", ["wind_speed_10m"])
+                    if "topdown" in families else []):
             if var not in pds:
                 print(f"[SKIP] {tag} {var}: not written by this run")
                 ledger.note(we.ABSENT, "not written by this run",
@@ -132,8 +146,8 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
             )
 
         # -- cross-sections + 3-D cold-pool views ----------------------------
-        keys = dom.get("sections", [])
-        v3d = dom.get("views3d", [])
+        keys = dom.get("sections", []) if "section" in families else []
+        v3d = dom.get("views3d", []) if "view3d" in families else []
         if keys or v3d:
             plane = ws.load_plane(ds)   # the expensive read; shared by both families
             loc = dict(lon2d=plane.lon2d, lat2d=plane.lat2d, terrain2d=plane.terrain)
@@ -184,10 +198,59 @@ def render_domain(cfg: dict, dom: dict, valid: datetime, init: datetime,
                 )
             made += render_views3d(cfg, v3d, plane, tag, stamp, sec_base, an,
                                    out_dir, args, ledger, domain=d, sources=src)
+
+        if "profile" in families:
+            made += render_profiles(cfg, dom, ds, tag, stamp, sec_base, an, out_dir,
+                                    args, ledger, domain=d, sources=src)
         print(f"  {tag}: {made} figures -> {out_dir}")
         return made
     finally:
         ds.close()
+
+
+def render_profiles(cfg, dom, ds, tag, stamp, sec_base, an, out_dir, args, ledger,
+                    *, domain=None, sources=()) -> int:
+    """theta + humidity profiles with a wind panel, at named waypoints.
+
+    Deliberately not a skew-T.  A skew-T is built to read a deep convective
+    parcel path; a basin study is asking how deep the stable layer is and whether
+    the air above it is dry enough to mix down, and theta-versus-height answers
+    that directly -- inversion depth is a slope you can see, not a curve you
+    interpret against a background of adiabats.  The convective engine keeps the
+    skew-T, because there the parcel path *is* the question.
+    """
+    made = 0
+    for key in dom.get("profiles", []):
+        spec = cfg["_profiles"].get(key)
+        if spec is None:
+            print(f"[SKIP] {tag} profile {key!r}: not in [[profiles]]")
+            ledger.note(we.ABSENT, "not in [[profiles]]", family="profile",
+                        domain=domain, var=key)
+            continue
+        wp = we.waypoint(spec["waypoint"])
+
+        def _draw(path, spec=spec, key=key, wp=wp):
+            col = wo.extract_column(ds, float(wp["lat"]), float(wp["lon"]))
+            snd = sounding_from_column(
+                col, source=f"WRF {tag}", station=spec.get("label", key))
+            plot_theta_wind_profile(
+                {f"{sec_base.split('|')[-1].strip()}": snd}, path,
+                title=we.compose_title(we.SOURCE_WRF, sec_base,
+                                       spec.get("label", key)),
+                annotation=an,
+                crest_m=spec.get("crest_m"),
+                y_top_m=float(spec.get("y_top_m", 5500.0)),
+                humidity=spec.get("humidity", "rh"),
+                wind_bars=bool(spec.get("wind_bars", True)),
+                barb_interval_m=float(spec.get("barb_interval_m", 250.0)),
+                dpi=args.dpi,
+            )
+
+        made += ledger.emit(
+            out_dir / f"profile_{key}_{tag}_{stamp}.png",
+            _draw, sources=sources, family="profile", domain=domain, var=key,
+        )
+    return made
 
 
 def render_views3d(cfg, keys, plane, tag, stamp, sec_base, an, out_dir, args,
@@ -244,17 +307,14 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--config", required=True, type=Path, help="case TOML")
     ap.add_argument("--run-dir", type=Path, help="override the TOML run directory")
-    ap.add_argument("--valid", help=f"exact valid time, {_TIME_FMT.replace('%', '%%')}")
-    ap.add_argument("--lead", type=int, help="minutes after init")
-    ap.add_argument("--hourly", action="store_true",
-                    help="sweep every whole-hour valid time written so far "
-                         "(shorthand for --every 60)")
-    ap.add_argument("--every", type=int, metavar="MIN",
-                    help="sweep every valid time on a MIN-minute cadence (e.g. 15). "
-                         "A domain that lacks a given time is skipped for it")
-    ap.add_argument("--all", dest="all_times", action="store_true",
-                    help="sweep every valid time at the run's native output "
-                         "interval (a 5-minute nest makes this a lot of figures)")
+    # The shared set, so --start/--end exist here too.  They did not, which made
+    # docs/VISUAL-SUITE-SOP.md's "bound the window" step an argparse error on one
+    # of the two engines it is written for.
+    we.add_time_arguments(ap)
+    ap.add_argument(
+        "--figure", action="append", metavar="FAMILY",
+        help=f"restrict to a family ({'|'.join(FAMILIES)}); repeatable",
+    )
     ap.add_argument("--theta-iso", type=float, action="append", metavar="K",
                     help="override the [[views3d]] isentrope(s) for the 3-D "
                          "cold-pool panels (repeatable)")
@@ -275,6 +335,11 @@ def main() -> int:
     run_dir = cfg["case"]["run_dir"]
     if not run_dir.is_dir():
         raise SystemExit(f"run directory not found: {run_dir}")
+
+    families = tuple(args.figure) if args.figure else FAMILIES
+    unknown = [f for f in families if f not in FAMILIES]
+    if unknown:
+        raise SystemExit(f"unknown --figure {unknown}; choose from {list(FAMILIES)}")
 
     doms = [d for d in cfg.get("domains", [])
             if not args.domain or int(d["domain"]) in args.domain]
@@ -313,7 +378,8 @@ def main() -> int:
             # One bad time (a wrfout caught half-written by the running job, say)
             # must not take the rest of the sweep down with it.
             try:
-                total += render_domain(cfg, dom, valid, init, out_root, args, ledger)
+                total += render_domain(cfg, dom, valid, init, out_root, args,
+                                       ledger, families=families)
             except Exception as exc:
                 print(f"[ERR] {dom.get('tag', dom['domain'])} {valid:{_TIME_FMT}}: {exc}")
                 traceback.print_exc()

--- a/tests/_wrf_synthetic.py
+++ b/tests/_wrf_synthetic.py
@@ -91,6 +91,11 @@ def make_synthetic_wrf(
             "COSALPHA": (sfc, _t(np.ones((ny, nx)))),
             "SINALPHA": (sfc, _t(np.zeros((ny, nx)))),
             "PSFC": (sfc, _t(np.full((ny, nx), 90000.0))),
+            # 2 m mixing ratio, with a west-east gradient on purpose: T2 and PSFC
+            # are uniform, so a constant Q2 would make every moisture diagnostic
+            # (theta-e, its gradient, moisture-flux convergence) identically zero
+            # and the tests over them vacuous.
+            "Q2": (sfc, _t(0.002 + 0.001 * (ii / max(nx - 1, 1)))),
             "T2": (sfc, _t(np.full((ny, nx), 270.0))),
             "TH2": (sfc, _t(np.full((ny, nx), 275.0))),
             "U10": (sfc, _t(np.full((ny, nx), 3.0))),

--- a/tests/test_engine_families.py
+++ b/tests/test_engine_families.py
@@ -1,0 +1,88 @@
+"""The two sweep engines' family registries and CLI surface.
+
+Both engines are scripts, so they are imported by path.  What is tested here is
+the contract the skills and `docs/VISUAL-SUITE-SOP.md` promise: that `--figure`
+selects families, that the family list an operator is told about is the family
+list the engine has, and that the shared time flags exist on *both* engines --
+the SOP presented `--start`/`--end` as engine-agnostic when only one engine had
+them, so following it against the other was an argparse error.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(f"_eng_{name}", SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def winds():
+    return _load("wrf_winds")
+
+
+@pytest.fixture(scope="module")
+def convective():
+    return _load("wrf_convective")
+
+
+def _parser_flags(mod) -> set[str]:
+    """The engine's option strings, without running it."""
+    import argparse
+
+    seen: set[str] = set()
+    real_add = argparse.ArgumentParser.add_argument
+
+    def spy(self, *args, **kwargs):
+        seen.update(a for a in args if isinstance(a, str) and a.startswith("-"))
+        return real_add(self, *args, **kwargs)
+
+    argparse.ArgumentParser.add_argument = spy
+    try:
+        with pytest.raises(SystemExit):
+            mod.main.__globals__["sys"].argv = ["x", "--help"]
+            mod.main()
+    finally:
+        argparse.ArgumentParser.add_argument = real_add
+    return seen
+
+
+class TestSharedFlags:
+    """Both engines, same flags -- the SOP is written once for both."""
+
+    @pytest.mark.parametrize("engine", ["wrf_winds", "wrf_convective"])
+    def test_time_and_output_flags_exist(self, engine):
+        flags = _parser_flags(_load(engine))
+        for flag in ("--valid", "--lead", "--every", "--hourly", "--all",
+                     "--start", "--end", "--figure", "--domain",
+                     "--dry-run", "--skip-existing", "--report", "--allow-errors"):
+            assert flag in flags, f"{engine} is missing {flag}"
+
+
+class TestFamilies:
+    def test_winds_families(self, winds):
+        assert winds.FAMILIES == ("topdown", "section", "profile", "view3d")
+
+    def test_convective_families_include_meso(self, convective):
+        assert "meso" in convective.FAMILIES
+        assert convective.FAMILIES[0] == "surface"
+
+    @pytest.mark.parametrize("engine", ["wrf_winds", "wrf_convective"])
+    def test_every_family_is_named_in_the_module_docstring_or_registry(self, engine):
+        """An operator picks families from what the engine advertises.  The
+        convective skill named three of seven, so the other four were reachable
+        only by reading the source."""
+        mod = _load(engine)
+        assert len(set(mod.FAMILIES)) == len(mod.FAMILIES), "duplicate family"
+        assert all(f.islower() and f.isidentifier() for f in mod.FAMILIES)

--- a/tests/test_visualize_profile.py
+++ b/tests/test_visualize_profile.py
@@ -157,3 +157,87 @@ class TestSkewTConvectiveAdditions:
         out = tmp_path / "tiny.png"
         assert plot_skewt(tiny, out, title="t", parcel="ml", mark_levels=True) == out
         assert out.stat().st_size > 0
+
+
+# --------------------------------------------------------------------------- #
+# opt-in profile options (PR-B) -- all default off so `thetaz` is unchanged
+# --------------------------------------------------------------------------- #
+def _demo_sounding():
+    from brc_tools.visualize.profile import Sounding
+
+    z = np.linspace(1500.0, 5000.0, 40)
+    p = 1013.25 * (1.0 - 2.25577e-5 * z) ** 5.25588
+    t = 20.0 - 6.5e-3 * (z - 1500.0)
+    return Sounding(
+        pressure_hpa=p, temperature_c=t, dewpoint_c=t - 8.0,
+        u_kt=np.linspace(2.0, 40.0, z.size), v_kt=np.full(z.size, 5.0),
+        source="WRF", station="demo", height_m=z,
+    )
+
+
+def test_barb_levels_are_paced_in_height_not_level_index():
+    """Eta levels are stretched, so every-nth-level crowds the surface.  A fixed
+    metre interval must give near-uniform height spacing whatever the grid."""
+    from brc_tools.visualize.profile import _barb_levels
+
+    # deliberately stretched: dense low down, sparse aloft
+    z = 1500.0 + np.cumsum(np.linspace(10.0, 400.0, 60))
+    idx = _barb_levels(z, z_top=z.max(), interval_m=500.0)
+    gaps = np.diff(z[idx])
+    assert gaps.min() > 250.0        # nothing crowded together
+    assert gaps.max() < 900.0        # nothing left bare
+
+
+def test_barb_levels_default_keeps_the_historical_count():
+    from brc_tools.visualize.profile import _barb_levels
+
+    z = np.linspace(1500.0, 5000.0, 80)
+    assert _barb_levels(z, z_top=5000.0).size == 14
+
+
+def test_humidity_trace_rh_is_percent_not_a_fraction():
+    """derived.relative_humidity already returns 0-100; scaling it again would
+    put every value off the axis."""
+    from brc_tools.visualize.profile import _humidity_trace
+
+    vals, label = _humidity_trace(_demo_sounding(), "rh")
+    assert "%" in label
+    assert 10.0 < float(np.nanmax(vals)) <= 100.0
+
+
+def test_humidity_trace_q_is_positive_and_in_g_per_kg():
+    from brc_tools.visualize.profile import _humidity_trace
+
+    vals, label = _humidity_trace(_demo_sounding(), "q")
+    assert "q" in label
+    assert 0.0 < float(np.nanmax(vals)) < 40.0
+
+
+def test_humidity_kind_is_validated():
+    from brc_tools.visualize.profile import _humidity_trace
+
+    with pytest.raises(ValueError, match="rh"):
+        _humidity_trace(_demo_sounding(), "specific")
+
+
+def test_profile_options_default_off_so_thetaz_is_unchanged():
+    """The pelican `thetaz` family calls this renderer.  Every option added for
+    the winds engine must be opt-in or that frozen figure set moves."""
+    import inspect
+
+    from brc_tools.visualize.profile import plot_theta_wind_profile
+
+    sig = inspect.signature(plot_theta_wind_profile).parameters
+    assert sig["humidity"].default is None
+    assert sig["wind_bars"].default is False
+    assert sig["barb_interval_m"].default is None
+
+
+def test_theta_wind_profile_renders_with_every_option_on(tmp_path):
+    from brc_tools.visualize.profile import plot_theta_wind_profile
+
+    out = plot_theta_wind_profile(
+        {"02Z": _demo_sounding()}, tmp_path / "p.png", title="WRF | demo",
+        humidity="rh", wind_bars=True, barb_interval_m=400.0, dpi=60,
+    )
+    assert out.exists() and out.stat().st_size > 0

--- a/tests/test_wrf_engine.py
+++ b/tests/test_wrf_engine.py
@@ -509,3 +509,27 @@ class TestStyleGammaOverride:
 
     def test_untouched_variables_keep_a_linear_scale(self):
         assert we.style_for({}, "theta").gamma is None
+
+
+class TestMapLayers:
+    def test_cities_is_reachable_from_a_case_toml(self):
+        """basemap.draw_cities existed but MAP_LAYERS omitted it, and the engines
+        build their overlay dict by iterating exactly that tuple -- so no case
+        could switch it on."""
+        assert "cities" in we.MAP_LAYERS
+        assert we.overlays_from({"map": {"cities": True}})["cities"] is True
+
+    def test_layers_default_off(self):
+        overlays = we.overlays_from({})
+        assert set(overlays) == set(we.MAP_LAYERS)
+        assert not any(overlays.values())
+
+    def test_every_layer_is_one_add_reference_overlays_accepts(self):
+        """A layer name that the renderer does not take is a silent no-op."""
+        import inspect
+
+        from brc_tools.visualize.basemap import add_reference_overlays
+
+        accepted = inspect.signature(add_reference_overlays).parameters
+        for layer in we.MAP_LAYERS:
+            assert layer in accepted, f"{layer} is not a add_reference_overlays kwarg"

--- a/tests/test_wrf_meso.py
+++ b/tests/test_wrf_meso.py
@@ -1,0 +1,111 @@
+"""Surface-mesoanalysis diagnostics -- the fields WRF does not write.
+
+The signs are the whole point and are the easy thing to get backwards: every
+field here is defined so that **positive means the feature being hunted**, so a
+convergence line is a positive maximum rather than a negative one.  A sign error
+would be invisible in the figure and would invert the diagnosis.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from _wrf_synthetic import make_synthetic_wrf
+
+from brc_tools.nwp import wrf_convective as wc
+
+
+@pytest.fixture
+def ds():
+    return make_synthetic_wrf(convective=True)
+
+
+class TestConvergenceSign:
+    @staticmethod
+    def _with_wind(ds, u, v):
+        """Replace U10/V10 with 2-D fields, keeping the leading Time dimension."""
+        ds = ds.copy()
+        ds["U10"] = (ds["U10"].dims, np.asarray(u, dtype=float)[None, ...])
+        ds["V10"] = (ds["V10"].dims, np.asarray(v, dtype=float)[None, ...])
+        return ds
+
+    @staticmethod
+    def _shape(ds):
+        return ds["U10"].shape[-2:]
+
+    def test_confluent_flow_is_positive_convergence(self, ds):
+        """u decreasing eastward is air piling up: du/dx < 0, so -div > 0."""
+        ny, nx = self._shape(ds)
+        u = np.tile(np.linspace(5.0, -5.0, nx), (ny, 1))
+        conv = wc.meso_field(self._with_wind(ds, u, np.zeros_like(u)), "conv_10m")
+        assert np.nanmean(conv) > 0
+
+    def test_diffluent_flow_is_negative(self, ds):
+        ny, nx = self._shape(ds)
+        u = np.tile(np.linspace(-5.0, 5.0, nx), (ny, 1))
+        conv = wc.meso_field(self._with_wind(ds, u, np.zeros_like(u)), "conv_10m")
+        assert np.nanmean(conv) < 0
+
+    def test_uniform_flow_has_no_convergence(self, ds):
+        u = np.full(self._shape(ds), 7.0)
+        conv = wc.meso_field(self._with_wind(ds, u, u * 0.5), "conv_10m")
+        assert np.allclose(conv, 0.0, atol=1e-9)
+
+
+class TestGridSpacing:
+    def test_gradient_uses_the_files_own_dx_not_the_3km_default(self, ds):
+        """derived.horizontal_gradient_magnitude defaults to HRRR's 3 km.  Left
+        alone, a 600 m nest would report every gradient five times too small."""
+        from brc_tools.nwp import wrf_output as wo
+        from brc_tools.nwp.derived import horizontal_gradient_magnitude
+
+        dx, _dy = wo.dx_dy(ds)
+        theta_e = wc.surface_theta_e(ds)
+        got = wc.meso_field(ds, "theta_e_grad_2m")
+        expected = np.asarray(horizontal_gradient_magnitude(theta_e, dx_m=dx)) * 1000.0
+        assert np.allclose(got, expected)
+        # and it must NOT match the default, or the test proves nothing
+        wrong = np.asarray(horizontal_gradient_magnitude(theta_e, dx_m=3000.0)) * 1000.0
+        assert not np.allclose(got, wrong)
+
+
+class TestMoisture:
+    def test_dewpoint_never_exceeds_temperature(self, ds):
+        from brc_tools.nwp import wrf_output as wo
+
+        td = wc.meso_field(ds, "dewpoint_2m")
+        t = wo.surface_field(ds, "T2") - 273.15
+        assert np.all(td <= t + 1e-6)
+
+    def test_depression_is_temperature_minus_dewpoint(self, ds):
+        dep = wc.meso_field(ds, "dewpoint_depression_2m")
+        assert np.all(dep >= -1e-6)
+
+    def test_theta_e_exceeds_theta(self, ds):
+        """Latent heat is added, never removed -- theta_e < theta means the
+        moisture term went in with the wrong sign."""
+        from brc_tools.nwp import wrf_output as wo
+
+        assert np.all(wc.surface_theta_e(ds) >= wo.theta_2m(ds) - 1e-6)
+
+
+class TestMissingInputs:
+    def test_a_field_whose_inputs_are_absent_raises_a_named_error(self):
+        """The engine turns this into one named-skipped panel, so the message has
+        to say which variable is missing rather than failing anonymously."""
+        ds = make_synthetic_wrf(convective=True, drop_vars=("Q2",))
+        with pytest.raises(KeyError, match="Q2"):
+            wc.meso_field(ds, "theta_e_2m")
+
+    def test_an_unknown_key_lists_the_known_ones(self, ds):
+        with pytest.raises(KeyError, match="dewpoint_2m"):
+            wc.meso_field(ds, "not_a_field")
+
+
+def test_every_meso_field_has_a_style():
+    """A field the engine can build but cannot colour is a job-killing KeyError
+    at render time, not a missing panel."""
+    from brc_tools.visualize.style import VAR_STYLES
+
+    for key in wc.MESO_REQUIRES:
+        assert key in VAR_STYLES, f"{key} has no VAR_STYLES entry"


### PR DESCRIPTION
Three families of thing the suite could not show, and one flag it could not take. Second of three — the shared layer landed in #47; skills and docs follow.

## What the storm is running into

A **`meso`** family: θₑ, dewpoint, dewpoint depression, 10 m convergence, moisture-flux convergence, θₑ gradient. WRF writes **none** of them, so the convective engine could show where the storm *was* and nothing about the air ahead of it.

Its own family rather than more `surface_vars`, because it answers a different question and gets swept separately — on a long run you usually want one or the other, and `--figure meso` is how you say so.

Signs are chosen so **positive is the feature being hunted**: both convergence fields are the negative of the divergence, so a boundary is a positive maximum on a diverging map, not a negative one on a scale that also has to render the divergence around it.

Two traps handled rather than inherited:

- **`horizontal_gradient_magnitude` defaults `dx_m = 3000`** — HRRR's. Left alone, a 600 m nest reports every gradient at a fifth of its true size. `dx` now comes from the file, with a test that fails if the default creeps back.
- **`horizontal_flux_divergence` says "W m⁻²"** because it was written for the cold-pool heat flux. It is unit-agnostic, so `horizontal_divergence` is a *name over it* rather than a second differencing — a convergence line here and a deficit-flux convergence are now literally the same operator, and the map-factor asymmetry with `vertical_vorticity` is documented where both live instead of being a discrepancy someone finds later.

## Profiles from the winds engine, which had none

`plot_theta_wind_profile` already drew θ(z) with a wind panel and stability bands. The winds engine simply never imported it. It does now, as a `profile` family over a `[[profiles]]` table.

Three options, all **default-off** so the pelican `thetaz` family is untouched:

| option | why |
|---|---|
| `humidity` (`"rh"`/`"q"`) | θ alone cannot tell a dry residual layer from a moist one at the same temperature, and which it is decides whether the layer mixes out |
| `wind_bars` | speed as bars at every level with barbs at the tips, so a drainage jet is a visible bulge rather than two barbs with an extra flag |
| `barb_interval_m` | eta levels are stretched, so a fixed *count* spread over the visible depth crowds the surface and leaves the free atmosphere bare — and two figures with different tops stop being comparable |

**Not a skew-T, deliberately.** A skew-T is built to read a parcel path; a basin study is asking how deep the stable layer is, and θ-versus-height answers that directly. The convective engine keeps its skew-T, where the parcel path *is* the question.

## Cold-pool context that was already in the file

`plan_dataset` now exposes `TSK−T2`, snow depth and 10 m convergence. The first two had colour scales in the shared table and **no way to reach them**; TSK−T2 is the surface decoupling, which says a pool is forming hours before the θ field looks unusual.

`MAP_LAYERS` gains `cities`. `basemap.draw_cities` worked, but the engines build their overlay dict by iterating that tuple, so no case TOML could switch it on.

## Family selection on the winds engine

It had no `--figure` and no `--start`/`--end`, and never called `add_time_arguments` — so `docs/VISUAL-SUITE-SOP.md`, which presents both as engine-agnostic, **was an argparse error against one of the two engines it is written for**. Both now take the shared set, and a test asserts the two engines expose the same flags.

Also: `style_for` moved inside the per-figure guard. It sat outside the emit closure and uncaught, so one unknown style key in one case TOML raised a bare `KeyError` and killed an entire sweep instead of skipping one panel.

## Testing

`558 passed, 6 skipped` (was 532). `Q2` added to the synthetic fixture *with a gradient* — T2 and PSFC are uniform there, so a constant would have made every moisture test vacuous.

**Pelican freeze verified by rendering, not by inspection:** `plot_theta_wind_profile` with fixed inputs hashes to the same SHA-256 on this branch and on `main`.

Rendered and inspected: a nocturnal basin profile — inversion shaded, RH showing a moist inversion under a dry residual layer, and the drainage jet as a bulge in the speed bars with barbs at the tips every 250 m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZcsFNUN2u67hwzazHeDxw
