### PR TITLE
docs(skills): stop a skill claiming a region it does not have, and a variable it cannot set

### DIFF
--- a/.claude/skills/wrf-basin-winds/SKILL.md
+++ b/.claude/skills/wrf-basin-winds/SKILL.md
@@ -100,9 +100,11 @@ run directory alone. Ask, then say back what you chose.
    against a still-writing run.
 
 9. **Promote the keepers and write the finding.** Copy the few worth keeping to
-   `$UB_WX_FIGS_KEEP` / group6, from the job or a DTN, not the login node. **No
-   figure images in git.** Put the finding, with its caveats, in the case's
-   `notes.md`.
+   persistent group storage, from the job or a DTN, not the login node — the
+   brc-tools default is `$BRC_TOOLS_OUTPUT_DIR` (`lawson-group6/jrlawson/brc-tools-output`);
+   a ub-wx case has its own `$UB_WX_FIGS_KEEP`, which is **unset outside that
+   repo**, so do not reach for it by default. **No figure images in git.** Put the
+   finding, with its caveats, in the case's `notes.md`.
 
 ## Reading a cross-section
 

--- a/.claude/skills/wrf-convective/SKILL.md
+++ b/.claude/skills/wrf-convective/SKILL.md
@@ -90,8 +90,11 @@ what the job costs and what it can claim. Ask, then say back what you chose.
    safe against a still-writing run.
 
 9. **Promote the keepers and write the finding.** Copy the few worth keeping to
-   `$UB_WX_FIGS_KEEP`, from the job or a DTN. **No figure images in git.** Put the
-   finding and its caveats in the case's `notes.md`.
+   persistent group storage, from the job or a DTN — the brc-tools default is
+   `$BRC_TOOLS_OUTPUT_DIR` (`lawson-group6/jrlawson/brc-tools-output`); a ub-wx case
+   has its own `$UB_WX_FIGS_KEEP`, which is **unset outside that repo**, so do not
+   reach for it by default. **No figure images in git.** Put the finding and its
+   caveats in the case's `notes.md`.
 
 ## Notes — what goes wrong first
 

--- a/.claude/skills/wrf-full-figures/SKILL.md
+++ b/.claude/skills/wrf-full-figures/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrf-full-figures
-description: Generate publication "full-figures" (300-DPI versions of the WRF quicklooks) for a Uinta Basin WRF case on CHPC SLURM, choosing a specific case/run. Use when asked to make full-figures / publication figures for a WRF run.
+description: Generate publication "full-figures" (300-DPI versions of the WRF quicklooks) on CHPC SLURM from whichever case TOML you name — the pelican2013 study is the default example, not the scope. Use when asked to make full-figures / publication figures for a WRF run.
 ---
 
 # WRF full-figures on SLURM
@@ -71,12 +71,20 @@ brc-tools. (The older `wrf-nudge-ozone-air2026` repo is frozen/read-only — do 
 - The slurm wrapper sets the `brc-tools-2026` python, `PYTHONPATH=~/gits/brc-tools`, and
   `MPLCONFIGDIR` on scratch; figures route out of every repo by default.
 - Redirect output with `--output-dir <path>` (nests `<case>/<family>/`).
-- Families: `domains, section, upperair, surface, difference, profile, skewt, thetaz, heatdeficit, heatdeficit_map, deficitflux_map, deficitflux_div, deficitflux_transect, all`.
+- Families: `domains, section, upperair, surface, difference, profile, skewt, thetaz,
+  heatdeficit, heatdeficit_map, deficitflux_map, deficitflux_div, deficitflux_transect,
+  deficitbulk_map, deficit_budget, all`.
   `heatdeficit_map` renders the spatial cold-pool heat-deficit field (per case) + a diff map
   per `[[differences]]` pair; nest via `heatdeficit_domain` (pelican2013 = `d02`).
   The `deficitflux_*` trio renders cold-pool **advection**: flux quivers over the deficit
   (`deficitflux_map`), advective dH/dt (`deficitflux_div`), and canyon-gate export Φ(t)
   through `[[transects]]` lines (`deficitflux_transect`); nest via `deficitflux_domain`.
+  `deficitbulk_map` adds a three-panel **exploratory** diagnostic — active-layer depth,
+  deficit-weighted speed `|F|/H`, and a reduced-gravity bulk Froude proxy; **the Froude
+  panel is not a hydraulic-control diagnosis** and may not be captioned as one.
+  `deficit_budget` closes the books: area-mean `H`, interval storage, horizontal
+  convergence and the **unresolved remainder**, with a CSV of the exact interval values —
+  the remainder is the honest part, so quote it whenever you quote the budget.
 - The `upperair` family renders **two** maps per time: the crest-level θ/wind/T-adv map on
   the inner nest plus a synoptic **T-advection map on a pressure surface**
   (`upper_pressure_hpa`, default 600 hPa, computed on `upper_adv_domain` — the coarse

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -58,6 +58,38 @@ def test_skill_teaches_the_flags_that_keep_a_sweep_honest(skill):
         assert flag in text, f"{skill} never mentions {flag}"
 
 
+def test_full_figures_names_every_family_its_engine_has():
+    """The one WRF skill the checks above do not cover, and it had drifted.
+
+    `/wrf-full-figures` is deliberately outside `DRIVEN_BY`: that set also asserts
+    `--dry-run`, `--report`, `--allow-errors` and three `(ask the user)` prompts,
+    none of which the publication engine has -- it predates the `FigureLedger`
+    workflow the two sweep engines share. Family coverage is the part that does
+    apply, and by the time this was written `deficitbulk_map` and `deficit_budget`
+    were in `FAMILIES` and named nowhere in the skill, so an agent following it
+    could not reach them.
+    """
+    from brc_tools.nwp.wrf_figures import FAMILIES
+
+    text = _skill("wrf-full-figures")
+    missing = [f for f in FAMILIES if f"`{f}`" not in text and f not in text]
+    assert not missing, f"wrf-full-figures does not name: {missing}"
+
+
+@pytest.mark.parametrize("skill", ["wrf-basin-winds", "wrf-convective"])
+def test_the_promote_target_is_not_only_a_ub_wx_variable(skill):
+    """`$UB_WX_FIGS_KEEP` is set by a sibling repo's `.env`.
+
+    Both skills named it as *the* place keepers go, so an agent working a case
+    that is not a ub-wx one -- a study in `latex-jrl-mjd-mdpiair-2026`, say -- was
+    told to copy figures to an unset variable. brc-tools has its own answer and
+    the skills must name it: the output root these engines already default to.
+    """
+    text = _skill(skill)
+    assert "BRC_TOOLS_OUTPUT_DIR" in text, \
+        "name the brc-tools output root, not only the ub-wx variable"
+
+
 @pytest.mark.parametrize("skill", DRIVEN_BY)
 def test_skill_says_to_read_the_err_not_just_the_out(skill):
     """Any failure exits non-zero and the `[tally]` line is printed last -- but


### PR DESCRIPTION
Three couplings, each of which sends an agent somewhere wrong. Found while auditing whether any brc-tools skill is really a Uinta Basin skill that belongs in `ub-wx`. **None is** — all four front region-agnostic engines. What was actually wrong is wording, one stale list, and a variable a brc-tools skill cannot set.

## 1. A skill claiming a region it does not have

`/wrf-full-figures` advertised itself as *"for a Uinta Basin WRF case"*. It is not — it drives whatever case TOML it is handed, and pelican2013 (the default example) is a **study**, living in `latex-jrl-mjd-mdpiair-2026`, not a region. The `description` is the only thing an agent sees before choosing a skill, so a wrong one is a routing error rather than a typo. Moving the skill to `ub-wx` on the strength of that sentence would have pointed it at the wrong repo.

## 2. The same skill had drifted from its engine

`deficitbulk_map` and `deficit_budget` are in `brc_tools.nwp.wrf_figures.FAMILIES` and were named nowhere in the skill — an agent following it could not reach two of fifteen families. Both are now named **with the caveat each carries**:

- `deficitbulk_map`'s Froude panel is a proxy, **not a hydraulic-control diagnosis**, and may not be captioned as one;
- `deficit_budget`'s **unresolved remainder** is the honest part of the budget, so it gets quoted whenever the budget is.

## 3. A variable a brc-tools skill cannot set

`/wrf-basin-winds` and `/wrf-convective` both told the reader to promote keepers to `$UB_WX_FIGS_KEEP` — set by a sibling repo's `.env`. Working any case that is not a ub-wx one, that is a copy to an unset variable. Both now name the brc-tools output root (`$BRC_TOOLS_OUTPUT_DIR` → `lawson-group6/jrlawson/brc-tools-output`) first, with `$UB_WX_FIGS_KEEP` as the ub-wx variant and a note that it is unset outside that repo.

## Guarded

This is exactly the drift `tests/test_skill_docs.py` was written to catch, and `/wrf-full-figures` was the one WRF skill it did not cover — which is why it is the one that drifted. It stays **outside** `DRIVEN_BY` deliberately: that set also asserts `--dry-run`, `--report`, `--allow-errors` and three `(ask the user)` prompts, none of which the publication engine has (it predates the `FigureLedger` workflow the two sweep engines share). So it gets the family-coverage check alone, plus a promote-target check on the two sweep skills.

All three new assertions were run against the unmodified skills first and fail there:

```
AssertionError: wrf-full-figures does not name: ['deficitbulk_map', 'deficit_budget']
AssertionError: name the brc-tools output root, not only the ub-wx variable   (x2)
3 failed, 14 passed
```

and pass after: `18 passed` across `test_skill_docs.py` + `test_wrf_doc_freshness.py`.

The SOP's own copy of the promote step is fixed in #51, which already rewrites that hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)