### PR TITLE
fix(cron): make the wrapper bootstrap survive a real cron shell

### DIFF
--- a/scripts/cron/run_hrrr_kvel_crosswind_push.sh
+++ b/scripts/cron/run_hrrr_kvel_crosswind_push.sh
@@ -7,7 +7,7 @@
 # is merged and released, (2) the website ships the matching MAJOR
 # DATA_MANIFEST bump + aviation.js label fix. Then install on notchpeak1:
 #   55 * * * * ~/gits/brc-tools/scripts/cron/run_hrrr_kvel_crosswind_push.sh
-set -euo pipefail
+set -eo pipefail
 
 CONDA_ENV="${CONDA_ENV:-brc-tools-2026}"
 REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
@@ -19,9 +19,16 @@ MAX_FXX="${MAX_FXX:-6}"
 
 mkdir -p "${LOG_DIR}"
 
-# shellcheck disable=SC1090
-source "${HOME}/.bashrc"
+# Bootstrap the cron environment. Do NOT source ~/.bashrc here: it bails
+# in non-interactive shells, and /etc/bashrc trips `set -u` (unbound
+# BASHRCSOURCED). Mirror the proven obs-cron line instead: the
+# cron-specific env file (exports DATA_UPLOAD_API_KEY) plus the conda
+# hook, with -u deferred until the sourcing is done.
+# shellcheck disable=SC1090,SC1091
+source "${HOME}/.bashrc_basinwx"
+source "${HOME}/software/pkg/miniforge3/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENV}"
+set -u
 
 cd "${REPO_DIR}"
 

--- a/scripts/cron/run_hrrr_surface_push.sh
+++ b/scripts/cron/run_hrrr_surface_push.sh
@@ -8,7 +8,7 @@
 #
 # Install on notchpeak1:
 #   45 0,6,12,18 * * * ~/gits/brc-tools/scripts/cron/run_hrrr_surface_push.sh
-set -euo pipefail
+set -eo pipefail
 
 CONDA_ENV="${CONDA_ENV:-brc-tools-2026}"
 REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
@@ -17,10 +17,16 @@ LOG_FILE="${LOG_FILE:-${LOG_DIR}/hrrr_surface.log}"
 
 mkdir -p "${LOG_DIR}"
 
-# Ensure DATA_UPLOAD_API_KEY is exported by the user's shell profile.
-# shellcheck disable=SC1090
-source "${HOME}/.bashrc"
+# Bootstrap the cron environment. Do NOT source ~/.bashrc here: it bails
+# in non-interactive shells, and /etc/bashrc trips `set -u` (unbound
+# BASHRCSOURCED). Mirror the proven obs-cron line instead: the
+# cron-specific env file (exports DATA_UPLOAD_API_KEY) plus the conda
+# hook, with -u deferred until the sourcing is done.
+# shellcheck disable=SC1090,SC1091
+source "${HOME}/.bashrc_basinwx"
+source "${HOME}/software/pkg/miniforge3/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENV}"
+set -u
 
 cd "${REPO_DIR}"
 

--- a/scripts/cron/run_hrrr_waypoint_push.sh
+++ b/scripts/cron/run_hrrr_waypoint_push.sh
@@ -7,7 +7,7 @@
 #
 # Install on notchpeak1:
 #   50 * * * * ~/gits/brc-tools/scripts/cron/run_hrrr_waypoint_push.sh
-set -euo pipefail
+set -eo pipefail
 
 CONDA_ENV="${CONDA_ENV:-brc-tools-2026}"
 REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
@@ -17,9 +17,16 @@ GROUP="${GROUP:-us40_dense}"
 
 mkdir -p "${LOG_DIR}"
 
-# shellcheck disable=SC1090
-source "${HOME}/.bashrc"
+# Bootstrap the cron environment. Do NOT source ~/.bashrc here: it bails
+# in non-interactive shells, and /etc/bashrc trips `set -u` (unbound
+# BASHRCSOURCED). Mirror the proven obs-cron line instead: the
+# cron-specific env file (exports DATA_UPLOAD_API_KEY) plus the conda
+# hook, with -u deferred until the sourcing is done.
+# shellcheck disable=SC1090,SC1091
+source "${HOME}/.bashrc_basinwx"
+source "${HOME}/software/pkg/miniforge3/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENV}"
+set -u
 
 cd "${REPO_DIR}"
 

--- a/scripts/cron/run_road_forecast_push.sh
+++ b/scripts/cron/run_road_forecast_push.sh
@@ -13,7 +13,7 @@
 #
 # Install on notchpeak1:
 #   20 * * * * ~/gits/brc-tools/scripts/cron/run_road_forecast_push.sh
-set -euo pipefail
+set -eo pipefail
 
 CONDA_ENV="${CONDA_ENV:-brc-tools-2026}"
 REPO_DIR="${REPO_DIR:-$HOME/gits/brc-tools}"
@@ -22,10 +22,16 @@ LOG_FILE="${LOG_FILE:-${LOG_DIR}/road_forecast.log}"
 
 mkdir -p "${LOG_DIR}"
 
-# Ensure DATA_UPLOAD_API_KEY is exported by the user's shell profile.
-# shellcheck disable=SC1090
-source "${HOME}/.bashrc"
+# Bootstrap the cron environment. Do NOT source ~/.bashrc here: it bails
+# in non-interactive shells, and /etc/bashrc trips `set -u` (unbound
+# BASHRCSOURCED). Mirror the proven obs-cron line instead: the
+# cron-specific env file (exports DATA_UPLOAD_API_KEY) plus the conda
+# hook, with -u deferred until the sourcing is done.
+# shellcheck disable=SC1090,SC1091
+source "${HOME}/.bashrc_basinwx"
+source "${HOME}/software/pkg/miniforge3/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENV}"
+set -u
 
 cd "${REPO_DIR}"
 


### PR DESCRIPTION
Found by the pre-install smoke run required by the cron-operations SOP: every wrapper aborted on line one under a real cron shell (`set -u` + `/etc/bashrc`'s unbound `BASHRCSOURCED`), and `~/.bashrc` bails in non-interactive shells anyway, so `DATA_UPLOAD_API_KEY` and `conda` would never have loaded.

Fix mirrors the proven obs-cron bootstrap: `source ~/.bashrc_basinwx` + the miniforge `conda.sh` hook, with `set -u` deferred until after sourcing. Verified by a live smoke run of `run_road_forecast_push.sh` on notchpeak1 (log: `~/logs/road_forecast.log`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)