### PR TITLE
feat(aviation): KVEL runway 16/34 -> 17/35 per FAA redesignation

### DIFF
--- a/brc_tools/nwp/lookups.toml
+++ b/brc_tools/nwp/lookups.toml
@@ -604,7 +604,11 @@ name = "Vernal Regional Airport"
 lat = 40.4408
 lon = -109.5104
 elevation_m = 1609
-runway_headings_deg = [160, 340]  # true, not magnetic
+# FAA redesignated 16/34 -> 17/35 (~2022). Magnetic 169/349, var 10E
+# (AirNav/SkyVector, checked 2026-08-13). True headings drive the
+# cross/headwind math against HRRR's true-north winds; the Rwy labels
+# floor(heading/10) to 17/35.
+runway_headings_deg = [179, 359]  # true, not magnetic
 
 # ── Aliases: surface / near-surface ─────────────────────────────────────────
 

--- a/docs/WEBSITE-INTEGRATION.md
+++ b/docs/WEBSITE-INTEGRATION.md
@@ -69,13 +69,13 @@ output on 2026-08-13.
 { "product": "aviation_crosswind",   // literal; else the <h2> falls back to "hrrr"
   "model": "hrrr_subh",              // shown in the header when product matches
   "init_time": "Z",                  // rendered verbatim as a string
-  "runway_headings_deg": [160, 340], // TOP-LEVEL, degrees true; drives every column pair
+  "runway_headings_deg": [179, 359], // TOP-LEVEL, degrees true; drives every column pair
   "valid_times": ["Z", ...],         // drives row count
   "series": {
     "wind_speed_kt": [..], "wind_dir_deg": [..],
     // key = "crosswind_kt_" + String(heading).padStart(3, '0')
-    "headwind_kt_160": [..], "crosswind_kt_160": [..],
-    "headwind_kt_340": [..], "crosswind_kt_340": [..] } }
+    "headwind_kt_179": [..], "crosswind_kt_179": [..],
+    "headwind_kt_359": [..], "crosswind_kt_359": [..] } }
 ```
 > ⚠️ Earlier revisions of this page (inherited from the 2026-04-27 handoff)
 > specified `crosswind_kt_rwy16` and `metadata.runway_headings_deg_true`. Both are
@@ -84,8 +84,16 @@ output on 2026-08-13.
 
 **Every `series` array must be index-aligned with `valid_times`.** Short or
 missing arrays render as `—` rather than erroring, so a misalignment looks like
-partial data, not a failure. Column headers derive as `Rwy` + `round(heading/10)`,
-so `160` → `Rwy16`.
+partial data, not a failure.
+
+> ⚠️ **Runway redesignation (2026-08-13).** FAA renamed KVEL 16/34 → 17/35
+> (magnetic 169/349, var 10E → true 179/359). The producer now emits
+> `runway_headings_deg: [179, 359]` and `*_kt_179`/`*_kt_359` keys. The website
+> derives series keys dynamically, but its column headers use
+> `Rwy + round(heading/10)`, which mislabels `179` as `Rwy18` — the coordinated
+> website release must switch to `Math.floor(heading/10)` (`179` → `Rwy17`,
+> `359` → `Rwy35`) alongside a **MAJOR `DATA_MANIFEST.json` bump**. Do not
+> install the kvel cron until both sides have shipped; brc-tools releases first.
 
 **`forecast_hrrr_surface_layers_*`** — `POST /api/upload/forecasts`,
 filename `forecast_hrrr_surface_layers_<YYYYMMDD_HHMMZ>.json`. **Schema already

--- a/tests/test_aviation_wind.py
+++ b/tests/test_aviation_wind.py
@@ -57,15 +57,16 @@ class TestCrosswindMath:
         assert hw == pytest.approx(10.0 * KT_PER_MS, rel=1e-6)
         assert cw == pytest.approx(0.0, abs=1e-9)
 
-    def test_kvel_runway_16_quartering(self):
-        # KVEL runway 16 heading = 160° true. 45° right of heading = 205°.
-        # Wind FROM 205° at 10 m/s (u, v from wind_components):
-        #   u = -10 sin(205°), v = -10 cos(205°).
+    def test_kvel_runway_17_quartering(self):
+        # KVEL runway 17 heading = 179° true (FAA redesignation 16/34 ->
+        # 17/35). 45° right of heading = 224°.
+        # Wind FROM 224° at 10 m/s (u, v from wind_components):
+        #   u = -10 sin(224°), v = -10 cos(224°).
         from brc_tools.nwp.derived import wind_components
 
-        u, v = wind_components(10.0, 205.0)
-        hw = headwind_kt(u, v, 160)
-        cw = crosswind_kt(u, v, 160)
+        u, v = wind_components(10.0, 224.0)
+        hw = headwind_kt(u, v, 179)
+        cw = crosswind_kt(u, v, 179)
         # 45° quartering headwind from the right: hw = cw = 10/sqrt(2).
         expected = 10.0 / np.sqrt(2.0) * KT_PER_MS
         assert hw == pytest.approx(expected, rel=1e-6)
@@ -121,28 +122,30 @@ class TestAviationPayload:
         )
         assert payload["model"] == "hrrr_subh"
         assert payload["airport"] == "KVEL"
-        assert payload["runway_headings_deg"] == [160, 340]
+        assert payload["runway_headings_deg"] == [179, 359]
         assert payload["forecast_minutes"] == [0, 15, 30]
         assert len(payload["valid_times"]) == 3
         for key in ("wind_speed_kt", "wind_dir_deg", "gust_kt",
-                    "crosswind_kt_160", "crosswind_kt_340",
-                    "headwind_kt_160", "headwind_kt_340"):
+                    "crosswind_kt_179", "crosswind_kt_359",
+                    "headwind_kt_179", "headwind_kt_359"):
             assert key in payload["variables"]
             assert key in payload["series"]
             assert len(payload["series"][key]) == 3
 
     def test_payload_values_southerly_wind(self, kvel_dataset):
         # u=0, v=+10: wind blows toward north, FROM south (180°).
-        # Runway 160 (SSE heading) faces the wind -> positive headwind;
-        # runway 340 (NNW heading) has wind from behind -> negative headwind.
+        # Runway 17 (heading 179°, nearly due south) faces the wind ->
+        # positive headwind; runway 35 (heading 359°) has wind from
+        # behind -> negative headwind. 359 - 179 = 180 exactly, so the
+        # two headwinds are antisymmetric.
         init = dt.datetime(2026, 4, 24, 12, 0)
         payload = build_airport_crosswind_payload(
             kvel_dataset, airport="KVEL", init_time=init
         )
         wind_speed = payload["series"]["wind_speed_kt"][0]
         assert wind_speed == pytest.approx(10.0 * KT_PER_MS, rel=1e-2)
-        hw_340 = payload["series"]["headwind_kt_340"][0]
-        hw_160 = payload["series"]["headwind_kt_160"][0]
-        assert hw_160 > 0
-        assert hw_340 < 0
-        assert hw_340 == pytest.approx(-hw_160, rel=1e-6)
+        hw_359 = payload["series"]["headwind_kt_359"][0]
+        hw_179 = payload["series"]["headwind_kt_179"][0]
+        assert hw_179 > 0
+        assert hw_359 < 0
+        assert hw_359 == pytest.approx(-hw_179, rel=1e-6)


### PR DESCRIPTION
FAA redesignated KVEL's runway 16/34 → 17/35 (~2022). Current magnetic headings 169/349, var 10E → **true [179, 359]** (AirNav + SkyVector, 2026-08-13). The producer's `[160, 340]` and `crosswind_kt_160`-style keys are stale.

- `lookups.toml` is the only data change — `aviation.py` derives keys and labels from it (`crosswind_kt_179`/`_359`, floor-labels `Rwy 17`/`Rwy 35`).
- Tests updated (10/10 pass); 359−179 = 180° exactly, so the headwind antisymmetry assertions hold.
- `docs/WEBSITE-INTEGRATION.md` example updated, with the cross-repo sequencing spelled out.

**Sequencing** (per 2026-08-13 handoff): merge + release this first (v0.1.1) → website MAJOR `DATA_MANIFEST.json` bump + `aviation.js` label derivation round→floor (round(179/10)=18 would mislabel Rwy18) → only then install `run_hrrr_kvel_crosswind_push.sh`. The merge is inert on CHPC: no kvel cron exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)