### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brc-tools"
-version = "0.1.0"
+version = "0.1.1"
 description = "Bingham Research Center Python Tools for atmospheric data operations"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Real version bump (PR #60 accidentally merged empty — its branch had already landed via #58; see commit 7c0ea47). v0.1.1 marks the KVEL runway rename (#59) + wrapper bootstrap fix (#58) release for the website's coordinated aviation work to pin against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)