### PR TITLE
fix(outlooks): fan out push_outlook uploads to every configured site

### DIFF
--- a/brc_tools/download/push_data.py
+++ b/brc_tools/download/push_data.py
@@ -2,6 +2,7 @@
 
 John Lawson, July 2025
 """
+import mimetypes
 import socket
 import os
 import re
@@ -35,7 +36,11 @@ def save_json(df, fpath, orient='records'):
 
 
 def _post_json_to_url(server_address, fpath, file_data, api_key, *, role="PRIMARY"):
-    """Upload one JSON file to one server. Return True on HTTP 200."""
+    """Upload one file to one server. Return True on HTTP 200.
+
+    Named for its original JSON-only life; it now also carries the outlook
+    .md files, so the MIME type follows the file extension.
+    """
     endpoint = f"{server_address}/api/upload/{file_data}"
     hostname = socket.getfqdn()
     headers = {'x-api-key': api_key, 'x-client-hostname': hostname}
@@ -50,8 +55,9 @@ def _post_json_to_url(server_address, fpath, file_data, api_key, *, role="PRIMAR
 
     print(f"{prefix} uploading {os.path.basename(fpath)} to {endpoint}")
     try:
+        mime = mimetypes.guess_type(str(fpath))[0] or 'application/octet-stream'
         with open(fpath, 'rb') as f:
-            files = {'file': (os.path.basename(fpath), f, 'application/json')}
+            files = {'file': (os.path.basename(fpath), f, mime)}
             response = requests.post(endpoint, files=files, headers=headers, timeout=30)
         if response.status_code == 200:
             print(f"{prefix} ✅ uploaded {os.path.basename(fpath)}")

--- a/brc_tools/download/push_outlook.py
+++ b/brc_tools/download/push_outlook.py
@@ -8,20 +8,17 @@ Usage:
 
 Requires:
     - DATA_UPLOAD_API_KEY environment variable
-    - ~/.config/ubair-website/website_url file with server URL
+    - upload URLs from BASINWX_API_URLS or ~/.config/ubair-website/website_urls
+      (first URL is the primary; the rest are best-effort mirrors)
 
 John Lawson, December 2025
 """
 import argparse
-import os
 import re
-import socket
 import sys
 from pathlib import Path
 
-import requests
-
-from .push_data import load_config
+from .push_data import load_config_urls, send_json_to_all
 
 
 def validate_outlook_filename(filepath: Path) -> bool:
@@ -50,52 +47,6 @@ def validate_outlook_content(filepath: Path) -> bool:
         return True
     except Exception as e:
         print(f"WARNING: Could not validate content: {e}")
-        return False
-
-
-def send_markdown_to_server(server_url: str, fpath: Path, api_key: str) -> bool:
-    """Upload markdown file to /api/upload/outlooks endpoint."""
-    endpoint = f"{server_url}/api/upload/outlooks"
-    hostname = socket.getfqdn()
-
-    headers = {
-        'x-api-key': api_key,
-        'x-client-hostname': hostname
-    }
-
-    # Health check first
-    try:
-        health_response = requests.get(f"{server_url}/api/health", timeout=10)
-        if health_response.status_code != 200:
-            print(f"WARNING: Health check returned {health_response.status_code}")
-    except requests.exceptions.RequestException as e:
-        print(f"WARNING: Health check failed: {e}")
-        # Continue anyway - health endpoint might not exist
-
-    # Upload file
-    print(f"Uploading {fpath.name} to {endpoint}...")
-    try:
-        with open(fpath, 'rb') as f:
-            files = {'file': (fpath.name, f, 'text/markdown')}
-            response = requests.post(
-                endpoint,
-                files=files,
-                headers=headers,
-                timeout=30,
-            )
-
-        if response.status_code == 200:
-            print(f"Successfully uploaded {fpath.name}")
-            print(f"Outlook should appear at: {server_url}/forecast_outlooks")
-            return True
-        else:
-            print(f"Upload failed ({response.status_code}): {response.text}")
-            return False
-    except requests.exceptions.Timeout:
-        print(f"Upload timed out after 30 seconds")
-        return False
-    except requests.exceptions.RequestException as e:
-        print(f"Upload error: {e}")
         return False
 
 
@@ -134,17 +85,23 @@ def main():
 
     # Load config
     try:
-        api_key, server_url = load_config()
+        api_key, server_urls = load_config_urls()
     except (ValueError, FileNotFoundError) as e:
         print(f"ERROR: Configuration error: {e}")
         print("\nSetup required:")
         print("  1. Set DATA_UPLOAD_API_KEY environment variable")
-        print("  2. Create ~/.config/ubair-website/website_url with server URL")
+        print("  2. Set BASINWX_API_URLS or create "
+              "~/.config/ubair-website/website_urls with the upload URL(s)")
         sys.exit(1)
 
-    # Upload
-    success = send_markdown_to_server(server_url, fpath, api_key)
-    sys.exit(0 if success else 1)
+    # Upload: primary must succeed; mirrors are best-effort.
+    try:
+        send_json_to_all(server_urls, str(fpath), "outlooks", api_key)
+    except RuntimeError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+    print(f"Outlook should appear at: {server_urls[0]}/forecast_outlooks")
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/docs/WEBSITE-INTEGRATION.md
+++ b/docs/WEBSITE-INTEGRATION.md
@@ -164,7 +164,7 @@ This page is the **contract reference**, folded from the 2026-04-27 and
 Hard rules: temperatures in °C (not Kelvin); never invent dataTypes without a
 website-side PR; don't regress the observations channel.
 
-Known gap: `push_outlook.py` uses `load_config()`, which returns only the first
-URL, so outlooks reach `.com` alone. `clyfar/export/to_basinwx.py` reads the
-singular `BASINWX_API_URL` at four sites with the same effect. Both should move
-to `load_config_urls()`; neither is urgent while Clyfar is out of season.
+Known gap: `clyfar/export/to_basinwx.py` reads the singular `BASINWX_API_URL`
+at four sites, so forecasts/images/llm_outlooks reach `.com` alone — the clyfar
+fan-out PR must land **before ozone season (~Nov)**. (`push_outlook.py` was
+fixed 2026-08-13: it now fans out via `load_config_urls()`.)


### PR DESCRIPTION
Half of the fan-out gap named in `WEBSITE-BRCTOOLS-HANDOFF-aug13.md` §Priority 2 (the brc-tools half; the clyfar half is a separate PR in that repo).

- `push_outlook.py`: `load_config()` → `load_config_urls()` + `send_json_to_all()` — primary failure fails the job, mirror failures WARN. Private `send_markdown_to_server` deleted (no external callers; grepped brc-tools + clyfar).
- `push_data._post_json_to_url`: MIME now follows the file extension (it carries `.md` too now).
- `load_config()` itself is untouched — clyfar's import contract stands.

17/17 push_data tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)